### PR TITLE
Problems with review assignments based on authorship?

### DIFF
--- a/shared/agent/src/git/gitService.ts
+++ b/shared/agent/src/git/gitService.ts
@@ -821,39 +821,53 @@ export class GitService implements IGitService, Disposable {
 		}
 	}
 
+	async isCommitsExclusiveOnBranch(repoPath: string, branch: string): Promise<boolean> {
+		const commits = await this.getCommitsExclusiveToBranch(repoPath, branch);
+
+		return !(commits === undefined || commits.size === 0);
+	}
+
+	async getCommitsExclusiveToBranch(
+		repoPath: string,
+		branch: string
+	): Promise<Map<string, GitCommit> | undefined> {
+		// commits for a specific branch
+		// https://stackoverflow.com/questions/14848274/git-log-to-get-commits-only-for-a-specific-branch
+		// git log [BRANCHNAME] --not $(git for-each-ref --format='%(refname)' refs/heads/ | grep -v "refs/heads/[BRANCHNAME]")
+
+		let data: string | undefined;
+		try {
+			data = await git({ cwd: repoPath }, "branch", "--");
+		} catch {}
+		if (!data) return;
+		const otherBranches = data
+			.trim()
+			.split("\n")
+			.filter(b => !b.startsWith("*"))
+			.map(b => "refs/heads/" + b.trim());
+		// .join(" ");
+
+		const data2 = await git(
+			{ cwd: repoPath },
+			"log",
+			branch,
+			`--format='${GitLogParser.defaultFormat}`,
+			"--not",
+			...otherBranches,
+			"--"
+		);
+
+		return GitLogParser.parse(data2.trim(), repoPath);
+	}
+
 	async getCommitsOnBranch(
 		repoPath: string,
 		branch: string,
 		prevEndCommit?: string
 	): Promise<{ sha: string; info: {}; localOnly: boolean }[] | undefined> {
 		try {
-			// commits for a specific branch
-			// https://stackoverflow.com/questions/14848274/git-log-to-get-commits-only-for-a-specific-branch
-			// git log [BRANCHNAME] --not $(git for-each-ref --format='%(refname)' refs/heads/ | grep -v "refs/heads/[BRANCHNAME]")
+			let commits = await this.getCommitsExclusiveToBranch(repoPath, branch);
 
-			let data: string | undefined;
-			try {
-				data = await git({ cwd: repoPath }, "branch", "--");
-			} catch {}
-			if (!data) return;
-			const otherBranches = data
-				.trim()
-				.split("\n")
-				.filter(b => !b.startsWith("*"))
-				.map(b => "refs/heads/" + b.trim());
-			// .join(" ");
-
-			const data2 = await git(
-				{ cwd: repoPath },
-				"log",
-				branch,
-				`--format='${GitLogParser.defaultFormat}`,
-				"--not",
-				...otherBranches,
-				"--"
-			);
-
-			let commits = GitLogParser.parse(data2.trim(), repoPath);
 			let hasCommitsExclusiveToThisBranch = true;
 			if (commits === undefined || commits.size === 0) {
 				hasCommitsExclusiveToThisBranch = false;

--- a/shared/agent/src/git/models/author.ts
+++ b/shared/agent/src/git/models/author.ts
@@ -3,4 +3,5 @@ export interface GitAuthor {
 	readonly date: Date;
 	readonly email: string;
 	readonly lines: number;
+	readonly hunks?: number;
 }

--- a/shared/agent/src/git/parsers/authorParser.ts
+++ b/shared/agent/src/git/parsers/authorParser.ts
@@ -8,6 +8,7 @@ export interface AuthorEntry {
 	date: Date;
 	email: string;
 	lines: number;
+	hunks: number;
 }
 
 export class GitAuthorParser {
@@ -34,8 +35,10 @@ export class GitAuthorParser {
 						const key = `${author.name}|${author.email}`;
 						const a = authors.get(key);
 						if (a !== undefined) {
+							a.hunks++;
 							a.lines += author.lines;
 						} else {
+							author.hunks = 1;
 							authors.set(key, author);
 						}
 					}

--- a/shared/agent/src/managers/scmManager.ts
+++ b/shared/agent/src/managers/scmManager.ts
@@ -325,8 +325,12 @@ export class ScmManager {
 						file = file.substr(1);
 					}
 
+					let hasCommitsExclusiveToBranch = false;
 					branch = await git.getCurrentBranch(uri.fsPath);
-					if (branch) commits = await git.getCommitsOnBranch(repoPath, branch);
+					if (branch) {
+						commits = await git.getCommitsOnBranch(repoPath, branch);
+						hasCommitsExclusiveToBranch = await git.isCommitsExclusiveOnBranch(repoPath, branch);
+					}
 
 					const repo = await git.getRepositoryByFilePath(repoPath);
 					repoId = repo && repo.id;
@@ -359,7 +363,7 @@ export class ScmManager {
 						startCommit = latestPushed?.sha;
 					}
 
-					if (commits) {
+					if (commits && hasCommitsExclusiveToBranch) {
 						commits.forEach(commit => {
 							// @ts-ignore
 							const email = commit.info.email;

--- a/shared/agent/src/managers/scmManager.ts
+++ b/shared/agent/src/managers/scmManager.ts
@@ -436,7 +436,7 @@ export class ScmManager {
 						.map(authorList =>
 							authorList.forEach(author => {
 								if (!authorMap[author.email]) authorMap[author.email] = { stomped: 0, commits: 0 };
-								authorMap[author.email].stomped = 1 + authorMap[author.email].stomped;
+								authorMap[author.email].stomped = author.hunks + authorMap[author.email].stomped;
 							})
 						);
 				}


### PR DESCRIPTION
Now author sorted by "weigh 1 commits on the branch 10x as much as 1 line of codes stomped on"
So when we work on separate checkouted branch(from main branch, in our case `develop`) this logic works fine. 

But in scenario: we adding changes into main branch(or create a new branch and add a first changes without committing), requesting a review - we getting 100 last commits from `develop` branch relies on which we slect default review assigneres. 
In fact in this case if you add small changes(so hunks have no weight in front of commits), agent will suggest, as default assigners, authors who have added the most commits in the last 100 commits.
Solution for this scenario - not to take into account previous commits, but only code stomped on.



[Changes reviewed on CodeStream](https://api.codestream.com/r/W75JY6zGmBhgt48D/P4HyvnfiStuKfJ_rF-vJog?src=GitHub) by pez on Aug 17, 2020