### PR TITLE
BUG: List of repos under start-work/new PR/request review doesn't pick up newly added ones w/o a reload

### DIFF
--- a/shared/agent/src/git/gitService.ts
+++ b/shared/agent/src/git/gitService.ts
@@ -2,7 +2,7 @@
 import { createPatch, ParsedDiff, parsePatch } from "diff";
 import * as fs from "fs";
 import * as path from "path";
-import { CommitsChangedData } from "protocol/agent.protocol";
+import { CommitsChangedData, WorkspaceChangedData } from "protocol/agent.protocol";
 import { Disposable, Event } from "vscode-languageserver";
 import { URI } from "vscode-uri";
 import { Logger } from "../logger";
@@ -114,6 +114,13 @@ export class GitService implements IGitService, Disposable {
 	 */
 	get onRepositoryChanged(): Event<CommitsChangedData> {
 		return this._repositories.onGitChanged;
+	}
+
+	/**
+	 * Fires when a workspace has changed (folders added or removed, though not on first initialization)
+	 */
+	get onGitWorkspaceChanged(): Event<WorkspaceChangedData> {
+		return this._repositories.onWorkspaceDidChange;
 	}
 
 	async getFileAuthors(uri: URI, options?: BlameOptions): Promise<GitAuthor[]>;

--- a/shared/agent/src/protocol/agent.protocol.notifications.ts
+++ b/shared/agent/src/protocol/agent.protocol.notifications.ts
@@ -58,7 +58,8 @@ export enum ChangeDataType {
 	Unreads = "unreads",
 	Users = "users",
 	Providers = "providers",
-	ApiCapabilities = "apiCapabilities"
+	ApiCapabilities = "apiCapabilities",
+	Workspace = "workspace"
 }
 
 export interface CodemarksChangedNotification {
@@ -153,15 +154,22 @@ export interface CommitsChangedData {
 	type: string;
 	path: string;
 	repo: {
-		id: string | undefined
-		path: string
-		normalizedPath: string
+		id: string | undefined;
+		path: string;
+		normalizedPath: string;
 	};
 }
+
+export interface WorkspaceChangedData {}
 
 export interface CommitsChangedNotification {
 	type: ChangeDataType.Commits;
 	data: CommitsChangedData;
+}
+
+export interface WorkspaceChangedNotification {
+	type: ChangeDataType.Workspace;
+	data: WorkspaceChangedData;
 }
 
 export type DidChangeDataNotification =
@@ -180,7 +188,8 @@ export type DidChangeDataNotification =
 	| ProvidersChangedNotification
 	| ApiCapabilitiesChangedNotification
 	| DocumentsChangedNotification
-	| CommitsChangedNotification;
+	| CommitsChangedNotification
+	| WorkspaceChangedNotification;
 
 export const DidChangeDataNotificationType = new NotificationType<DidChangeDataNotification, void>(
 	"codestream/didChangeData"

--- a/shared/agent/src/session.ts
+++ b/shared/agent/src/session.ts
@@ -836,6 +836,13 @@ export class CodeStreamSession {
 			});
 		});
 
+		SessionContainer.instance().git.onGitWorkspaceChanged(data => {
+			SessionContainer.instance().session.agent.sendNotification(DidChangeDataNotificationType, {
+				type: ChangeDataType.Workspace,
+				data: data
+			});
+		});
+
 		// Initialize tracking
 		this.initializeTelemetry(response.user, currentTeam, response.companies);
 

--- a/shared/ui/Stream/StatusPanel.tsx
+++ b/shared/ui/Stream/StatusPanel.tsx
@@ -18,7 +18,9 @@ import {
 	MoveThirdPartyCardRequestType,
 	GetReposScmRequestType,
 	ReposScm,
-	UpdateThirdPartyStatusRequestType
+	UpdateThirdPartyStatusRequestType,
+	DidChangeDataNotificationType,
+	ChangeDataType
 } from "@codestream/protocols/agent";
 import IssueDropdown, { Row } from "./CrossPostIssueControls/IssueDropdown";
 import { ConfigureBranchNames } from "./ConfigureBranchNames";
@@ -617,6 +619,15 @@ export const StatusPanel = () => {
 		});
 		if (derivedState.webviewFocused)
 			HostApi.instance.track("Page Viewed", { "Page Name": "Status Tab" });
+
+		const disposable = HostApi.instance.on(DidChangeDataNotificationType, async (e: any) => {
+			if (e.type === ChangeDataType.Workspace) {
+				await getBranches();
+			}
+		});
+		return () => {
+			disposable && disposable.dispose();
+		};
 	});
 
 	const showMoveCardCheckbox = React.useMemo(() => {


### PR DESCRIPTION
https://trello.com/c/2jdllhJK/4137-bug-list-of-repos-under-start-work-new-pr-request-review-doesnt-pick-up-newly-added-ones-w-o-a-reload
https://trello.com/c/CBrD26T1/4138-bug-added-removed-repos-require-reload-to-be-reflected-in-wip-pull-requests

**This PR Addresses:**  
[BUG: Added/removed repos require reload to be reflected in WIP & Pull Requests](https://trello.com/c/CBrD26T1/4138-bug-added-removed-repos-require-reload-to-be-reflected-in-wip-pull-requests)  


this addresses 2 issues:
1) race condition between looking up repos and the promise for actually finding them. I've added another awaiter for the process that finds newly added (or remove) repos from a workspace.
2) i've added the react code to watch for changes from repos
