### PR TITLE
change repoInfo to repoMetadata 

### DIFF
--- a/shared/agent/src/managers/reviewsManager.ts
+++ b/shared/agent/src/managers/reviewsManager.ts
@@ -586,7 +586,7 @@ export class ReviewsManager extends CachedEntityManagerBase<CSReview> {
 					if (remotePaths && remotePaths.length) {
 						// just need any url here...
 						remoteUrl = "https://example.com/" + remotePaths[0];
-						const providerRepoInfo = await providerRegistry.getRepoInfo({
+						const providerRepoInfo = await providerRegistry.getRepoMetadata({
 							providerId: providerId,
 							remote: remoteUrl
 						});
@@ -693,7 +693,7 @@ export class ReviewsManager extends CachedEntityManagerBase<CSReview> {
 
 			if (providerRepo?.provider) {
 				remoteUrl = "https://example.com/" + providerRepo.remotePaths[0];
-				const providerRepoInfo = await providerRegistry.getRepoInfo({
+				const providerRepoInfo = await providerRegistry.getRepoMetadata({
 					providerId: providerRepo.providerId,
 					remote: remoteUrl
 				});

--- a/shared/agent/src/providers/bitbucket.ts
+++ b/shared/agent/src/providers/bitbucket.ts
@@ -483,7 +483,11 @@ export class BitbucketProvider extends ThirdPartyIssueProviderBase<CSBitbucketPr
 					repoResponse.body.mainbranch.type === "branch"
 						? repoResponse.body.mainbranch.name
 						: undefined,
-				pullRequests: pullRequests
+				pullRequests: pullRequests,
+				metadata: {
+					method: "getRepoMetadata",
+					providerDisplayName: this.displayName
+				}
 			};
 		} catch (ex) {
 			Logger.error(ex, `${this.displayName}: getRepoMetadata`, {

--- a/shared/agent/src/providers/bitbucket.ts
+++ b/shared/agent/src/providers/bitbucket.ts
@@ -414,7 +414,7 @@ export class BitbucketProvider extends ThirdPartyIssueProviderBase<CSBitbucketPr
 		void (await this.ensureConnected());
 
 		try {
-			const repoInfo = await this.getRepoInfo({ remote: request.remote });
+			const repoInfo = await this.getRepoMetadata({ remote: request.remote });
 			if (repoInfo && repoInfo.error) {
 				return {
 					error: repoInfo.error
@@ -456,7 +456,7 @@ export class BitbucketProvider extends ThirdPartyIssueProviderBase<CSBitbucketPr
 		}
 	}
 
-	async getRepoInfo(request: { remote: string }): Promise<any> {
+	async getRepoMetadata(request: { remote: string }): Promise<any> {
 		try {
 			const { owner, name } = this.getOwnerFromRemote(request.remote);
 			const repoResponse = await this.get<BitBucketRepo>(`/repositories/${owner}/${name}`);
@@ -486,7 +486,7 @@ export class BitbucketProvider extends ThirdPartyIssueProviderBase<CSBitbucketPr
 				pullRequests: pullRequests
 			};
 		} catch (ex) {
-			Logger.error(ex, `${this.displayName}: getRepoInfo`, {
+			Logger.error(ex, `${this.displayName}: getRepoMetadata`, {
 				remote: request.remote
 			});
 			return {

--- a/shared/agent/src/providers/bitbucketServer.ts
+++ b/shared/agent/src/providers/bitbucketServer.ts
@@ -352,7 +352,11 @@ export class BitbucketServerProvider extends ThirdPartyIssueProviderBase<CSBitbu
 					key: repoResponse.body.project.key
 				},
 				defaultBranch: defaultBranchName,
-				pullRequests: pullRequests
+				pullRequests: pullRequests,
+				metadata: {
+					method: "getRepoMetadata",
+					providerDisplayName: this.displayName
+				}
 			};
 		} catch (ex) {
 			Logger.error(ex, `${this.displayName}: getRepoMetadata`, {

--- a/shared/agent/src/providers/bitbucketServer.ts
+++ b/shared/agent/src/providers/bitbucketServer.ts
@@ -262,7 +262,7 @@ export class BitbucketServerProvider extends ThirdPartyIssueProviderBase<CSBitbu
 		void (await this.ensureConnected());
 
 		try {
-			const repoInfo = await this.getRepoInfo({ remote: request.remote });
+			const repoInfo = await this.getRepoMetadata({ remote: request.remote });
 			if (repoInfo && repoInfo.error) {
 				return {
 					error: repoInfo.error
@@ -320,7 +320,7 @@ export class BitbucketServerProvider extends ThirdPartyIssueProviderBase<CSBitbu
 		}
 	}
 
-	async getRepoInfo(request: { remote: string }): Promise<any> {
+	async getRepoMetadata(request: { remote: string }): Promise<any> {
 		try {
 			const { owner, name } = this.getOwnerFromRemote(request.remote);
 			const repoResponse = await this.get<BitbucketServerRepo>(`/projects/${owner}/repos/${name}`);
@@ -355,7 +355,7 @@ export class BitbucketServerProvider extends ThirdPartyIssueProviderBase<CSBitbu
 				pullRequests: pullRequests
 			};
 		} catch (ex) {
-			Logger.error(ex, `${this.displayName}: getRepoInfo`, {
+			Logger.error(ex, `${this.displayName}: getRepoMetadata`, {
 				remote: request.remote
 			});
 			return {

--- a/shared/agent/src/providers/github.ts
+++ b/shared/agent/src/providers/github.ts
@@ -785,7 +785,11 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 			return {
 				id: response.repository.id,
 				defaultBranch: response.repository.defaultBranchRef.name,
-				pullRequests: response.repository.pullRequests.nodes
+				pullRequests: response.repository.pullRequests.nodes,
+				metadata: {
+					method: "getRepoMetadata",
+					providerDisplayName: this.displayName
+				}
 			};
 		} catch (ex) {
 			Logger.error(ex, "GitHub: getRepoMetadataq", {

--- a/shared/agent/src/providers/github.ts
+++ b/shared/agent/src/providers/github.ts
@@ -693,7 +693,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 				};
 			}
 
-			const repoInfo = await this.getRepoInfo({ remote: request.remote });
+			const repoInfo = await this.getRepoMetadata({ remote: request.remote });
 			if (repoInfo && repoInfo.error) {
 				return {
 					error: repoInfo.error
@@ -745,7 +745,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		}
 	}
 
-	async getRepoInfo(request: { remote: string }): Promise<ProviderGetRepoInfoResponse> {
+	async getRepoMetadata(request: { remote: string }): Promise<ProviderGetRepoInfoResponse> {
 		try {
 			const { owner, name } = this.getOwnerFromRemote(request.remote);
 
@@ -788,7 +788,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 				pullRequests: response.repository.pullRequests.nodes
 			};
 		} catch (ex) {
-			Logger.error(ex, "GitHub: getRepoInfo", {
+			Logger.error(ex, "GitHub: getRepoMetadataq", {
 				remote: request.remote
 			});
 			let errorMessage =
@@ -878,7 +878,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 				forks
 			};
 		} catch (ex) {
-			Logger.error(ex, "GitHub: getRepoInfo", {
+			Logger.error(ex, "GitHub: getRepoMetadata", {
 				remote: request.remote
 			});
 			let errorMessage =

--- a/shared/agent/src/providers/githubEnterprise.ts
+++ b/shared/agent/src/providers/githubEnterprise.ts
@@ -104,7 +104,7 @@ export class GitHubEnterpriseProvider extends GitHubProvider {
 		if (!(await this.isPRApiCompatible())) return undefined;
 
 		try {
-			const repoInfo = await this.getRepoInfo({ remote: request.remote });
+			const repoInfo = await this.getRepoMetadata({ remote: request.remote });
 			if (repoInfo && repoInfo.error) {
 				return {
 					error: repoInfo.error
@@ -143,7 +143,7 @@ export class GitHubEnterpriseProvider extends GitHubProvider {
 		}
 	}
 
-	async getRepoInfo(request: { remote: string }): Promise<ProviderGetRepoInfoResponse> {
+	async getRepoMetadata(request: { remote: string }): Promise<ProviderGetRepoInfoResponse> {
 		try {
 			const { owner, name } = this.getOwnerFromRemote(request.remote);
 			const repoResponse = await this.get<GitHubEnterpriseRepo>(`/repos/${owner}/${name}`);
@@ -167,7 +167,7 @@ export class GitHubEnterpriseProvider extends GitHubProvider {
 				pullRequests: pullRequests
 			};
 		} catch (ex) {
-			Logger.error(ex, `${this.displayName}: getRepoInfo`, {
+			Logger.error(ex, `${this.displayName}: getRepoMetadata`, {
 				remote: request.remote
 			});
 			return {

--- a/shared/agent/src/providers/gitlab.ts
+++ b/shared/agent/src/providers/gitlab.ts
@@ -374,10 +374,12 @@ export class GitLabProvider extends ThirdPartyIssueProviderBase<CSGitLabProvider
 		try {
 			const { owner, name } = this.getOwnerFromRemote(request.remote);
 
+			// TODO better logging here for failed requests
 			const projectResponse = await this.get<GitLabProjectInfoResponse>(
 				`/projects/${encodeURIComponent(`${owner}/${name}`)}`
 			);
 
+			// TODO better logging here for failed requests
 			const mergeRequestsResponse = await this.get<GitLabMergeRequestInfoResponse[]>(
 				`/projects/${encodeURIComponent(`${owner}/${name}`)}/merge_requests?state=opened`
 			);
@@ -390,7 +392,11 @@ export class GitLabProvider extends ThirdPartyIssueProviderBase<CSGitLabProvider
 						id: _.iid.toString(),
 						url: _.web_url,
 						baseRefName: _.target_branch,
-						headRefName: _.source_branch
+						headRefName: _.source_branch,
+						metadata: {
+							method: "getRepoMetadata",
+							providerDisplayName: this.displayName
+						}
 					};
 				})
 			};

--- a/shared/agent/src/providers/gitlab.ts
+++ b/shared/agent/src/providers/gitlab.ts
@@ -325,7 +325,7 @@ export class GitLabProvider extends ThirdPartyIssueProviderBase<CSGitLabProvider
 			}
 			const { owner, name } = this.getOwnerFromRemote(request.remote);
 
-			const repoInfo = await this.getRepoInfo({ remote: request.remote });
+			const repoInfo = await this.getRepoMetadata({ remote: request.remote });
 			if (repoInfo && repoInfo.error) {
 				return {
 					error: repoInfo.error
@@ -370,7 +370,7 @@ export class GitLabProvider extends ThirdPartyIssueProviderBase<CSGitLabProvider
 		}
 	}
 
-	async getRepoInfo(request: { remote: string }): Promise<ProviderGetRepoInfoResponse> {
+	async getRepoMetadata(request: { remote: string }): Promise<ProviderGetRepoInfoResponse> {
 		try {
 			const { owner, name } = this.getOwnerFromRemote(request.remote);
 
@@ -395,7 +395,7 @@ export class GitLabProvider extends ThirdPartyIssueProviderBase<CSGitLabProvider
 				})
 			};
 		} catch (ex) {
-			Logger.error(ex, `${this.displayName}: getRepoInfo`, {
+			Logger.error(ex, `${this.displayName}: getRepoMetadata`, {
 				remote: request.remote
 			});
 

--- a/shared/agent/src/providers/provider.ts
+++ b/shared/agent/src/providers/provider.ts
@@ -95,7 +95,7 @@ export interface ThirdPartyProviderSupportsPullRequests {
 	createPullRequest(
 		request: ProviderCreatePullRequestRequest
 	): Promise<ProviderCreatePullRequestResponse | undefined>;
-	getRepoInfo(request: ProviderGetRepoInfoRequest): Promise<ProviderGetRepoInfoResponse>;
+	getRepoMetadata(request: ProviderGetRepoInfoRequest): Promise<ProviderGetRepoInfoResponse>;
 	getIsMatchingRemotePredicate(): (remoteLike: GitRemoteLike) => boolean;
 	getRemotePaths(repo: GitRepository, _projectsByRemotePath: any): any;
 

--- a/shared/agent/src/providers/provider.ts
+++ b/shared/agent/src/providers/provider.ts
@@ -935,6 +935,7 @@ export interface ProviderGetRepoInfoResponse {
 	id?: string;
 	defaultBranch?: string;
 	pullRequests?: ProviderPullRequestInfo[];
+	metadata?: any;
 	error?: { message?: string; type: string };
 }
 

--- a/shared/agent/src/providers/registry.ts
+++ b/shared/agent/src/providers/registry.ts
@@ -467,7 +467,7 @@ export class ThirdPartyProviderRegistry {
 		return response;
 	}
 
-	async getRepoInfo(request: ProviderGetRepoInfoRequest) {
+	async getRepoMetadata(request: ProviderGetRepoInfoRequest) {
 		const provider = getProvider(request.providerId);
 		if (provider === undefined) {
 			throw new Error(`No registered provider for '${request.providerId}'`);
@@ -484,7 +484,7 @@ export class ThirdPartyProviderRegistry {
 
 		// TODO clean it up remote here
 
-		const response = await pullRequestProvider.getRepoInfo(request);
+		const response = await pullRequestProvider.getRepoMetadata(request);
 		return response;
 	}
 


### PR DESCRIPTION
Ensure these *provider methods use the new naming convention

<!-- testing this out --> foo bar
<!-- testing this out --> foo bar