### PR TITLE
prune, compactify, and debounce updating modifiedRepos

### DIFF
--- a/shared/agent/src/api/apiProvider.ts
+++ b/shared/agent/src/api/apiProvider.ts
@@ -130,7 +130,6 @@ import {
 	SetCodemarkStatusRequest,
 	SetCodemarkStatusResponse,
 	SetModifiedReposRequest,
-	SetModifiedReposResponse,
 	SetStreamPurposeRequest,
 	SetStreamPurposeResponse,
 	ThirdPartyProviderSetTokenRequest,
@@ -334,7 +333,7 @@ export interface ApiProvider {
 	updatePreferences(request: UpdatePreferencesRequest): Promise<UpdatePreferencesResponse>;
 	updateInvisible(request: UpdateInvisibleRequest): Promise<UpdateInvisibleResponse>;
 	updateStatus(request: UpdateStatusRequest): Promise<UpdateStatusResponse>;
-	setModifiedRepos(request: SetModifiedReposRequest): Promise<SetModifiedReposResponse>;
+	setModifiedRepos(request: SetModifiedReposRequest): Promise<void>;
 	getPreferences(): Promise<GetPreferencesResponse>;
 	updatePresence(request: UpdatePresenceRequest): Promise<UpdatePresenceResponse>;
 	getTelemetryKey(): Promise<string>;

--- a/shared/agent/src/api/codestream/codestreamApi.ts
+++ b/shared/agent/src/api/codestream/codestreamApi.ts
@@ -4,7 +4,7 @@ import AbortController from "abort-controller";
 import { Agent as HttpAgent } from "http";
 import { Agent as HttpsAgent } from "https";
 import HttpsProxyAgent from "https-proxy-agent";
-import { isEqual } from "lodash-es";
+import { debounce, isEqual } from "lodash-es";
 import fetch, { Headers, RequestInit, Response } from "node-fetch";
 import * as qs from "querystring";
 import { URLSearchParams } from "url";
@@ -24,6 +24,7 @@ import {
 	DeleteMarkerResponse,
 	DidChangeDataNotificationType,
 	ReportingMessageType,
+	RepoScmStatus,
 	UpdateInvisibleRequest
 } from "../../protocol/agent.protocol";
 import {
@@ -34,7 +35,6 @@ import {
 	ArchiveStreamRequest,
 	Capabilities,
 	CloseStreamRequest,
-	CodeStreamEnvironment,
 	CreateChannelStreamRequest,
 	CreateCodemarkPermalinkRequest,
 	CreateCodemarkRequest,
@@ -293,6 +293,7 @@ export class CodeStreamApiProvider implements ApiProvider {
 	private _preferences: CodeStreamPreferences | undefined;
 	private _features: CSApiFeatures | undefined;
 	private _runTimeEnvironment: string | undefined;
+	private _debouncedSetModifiedReposUpdate: (request: SetModifiedReposRequest) => {};
 
 	readonly capabilities: Capabilities = {
 		channelMute: true,
@@ -308,7 +309,11 @@ export class CodeStreamApiProvider implements ApiProvider {
 		private readonly _version: VersionInfo,
 		private readonly _httpsAgent: HttpsAgent | HttpsProxyAgent | HttpAgent | undefined,
 		private readonly _strictSSL: boolean
-	) {}
+	) {
+		this._debouncedSetModifiedReposUpdate = debounce(request => {
+			return this.setModifiedReposDebounced(request);
+		}, 10000, { leading: true });
+	}
 
 	get teamId(): string {
 		return this._teamId!;
@@ -605,7 +610,6 @@ export class CodeStreamApiProvider implements ApiProvider {
 		if (this._subscribedMessageTypes !== undefined && !this._subscribedMessageTypes.has(e.type)) {
 			return;
 		}
-
 		// Resolve any directives in the message data
 		switch (e.type) {
 			case MessageType.Codemarks:
@@ -722,6 +726,7 @@ export class CodeStreamApiProvider implements ApiProvider {
 				};
 
 				const userPreferencesBefore = JSON.stringify(me.preferences);
+	
 				e.data = await SessionContainer.instance().users.resolve(e, {
 					onlyIfNeeded: true
 				});
@@ -853,17 +858,30 @@ export class CodeStreamApiProvider implements ApiProvider {
 	}
 
 	@log()
-	async setModifiedRepos(request: SetModifiedReposRequest) {
-		const update = await this.put<{ [key: string]: any }, any>(
+	async setModifiedReposDebounced(request: SetModifiedReposRequest) {
+		// eventually, when support for compactified modifiedRepos is full (both cloud and on-prem),
+		// we'll eliminate this completely and go only with compactified, below
+		const prunedModifiedRepos = SessionContainer.instance().users.pruneModifiedRepos(request.modifiedRepos);
+		this.put<{ [key: string]: any }, any>(
 			"/users/me",
-			{ modifiedRepos: { [request.teamId]: request.modifiedRepos } },
+			{ modifiedRepos: { [request.teamId]: prunedModifiedRepos } },
 			this._token
 		);
-		const [user] = (await SessionContainer.instance().users.resolve({
-			type: MessageType.Users,
-			data: [update.user]
-		})) as CSMe[];
-		return { user };
+
+		const capabilities = SessionContainer.instance().session.apiCapabilities;
+		if (capabilities.compactModifiedRepos) {
+			const compactModifiedRepos = SessionContainer.instance().users.compactifyModifiedRepos(request.modifiedRepos);
+			this.put<{ [key: string]: any }, any>(
+				"/users/me",
+				{ compactModifiedRepos: { [request.teamId]: compactModifiedRepos } },
+				this._token
+			);
+		}
+	}
+
+	@log()
+	async setModifiedRepos(request: SetModifiedReposRequest) {
+		this._debouncedSetModifiedReposUpdate(request);
 	}
 
 	@log()

--- a/shared/agent/src/api/codestream/codestreamApi.ts
+++ b/shared/agent/src/api/codestream/codestreamApi.ts
@@ -312,7 +312,7 @@ export class CodeStreamApiProvider implements ApiProvider {
 	) {
 		this._debouncedSetModifiedReposUpdate = debounce(request => {
 			return this.setModifiedReposDebounced(request);
-		}, 10000, { leading: true });
+		}, 60000, { leading: true });
 	}
 
 	get teamId(): string {

--- a/shared/agent/src/protocol/agent.protocol.users.ts
+++ b/shared/agent/src/protocol/agent.protocol.users.ts
@@ -168,13 +168,9 @@ export interface SetModifiedReposRequest {
 	teamId: string;
 }
 
-export interface SetModifiedReposResponse {
-	user: CSUser;
-}
-
 export const SetModifiedReposRequestType = new RequestType<
 	SetModifiedReposRequest,
-	SetModifiedReposResponse,
+	void,
 	void,
 	void
 >("codestream/user/setModifiedRepos");
@@ -209,3 +205,13 @@ export interface GetPreferencesResponse {
 export const GetPreferencesRequestType = new RequestType<void, GetPreferencesResponse, void, void>(
 	"codestream/users/me/preferences"
 );
+
+export interface CompactModifiedRepo {
+	repoId: string;
+	repoPath: string;
+	branch: string;
+	localCommits: string[];
+	modifiedFiles: string[];
+	startCommit: string;
+	stompingAuthors: string[];
+}

--- a/shared/agent/src/protocol/api.protocol.models.ts
+++ b/shared/agent/src/protocol/api.protocol.models.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import { ParsedDiff } from "diff";
-import { RepoScmStatus, ThirdPartyProviders } from "./agent.protocol";
+import { CompactModifiedRepo, RepoScmStatus, ThirdPartyProviders } from "./agent.protocol";
 import { CSReviewCheckpoint } from "./api.protocol";
 
 export interface CSEntity {
@@ -589,6 +589,7 @@ export interface CSUser extends CSEntity {
 	// all of the local changes on disk (i.e. not pushed)
 	modifiedRepos?: { [teamId: string]: RepoScmStatus[] };
 	modifiedReposModifiedAt?: number;
+	compactModifiedRepos?: { [teamId: string]: CompactModifiedRepo[] };
 	status?: CSMeStatus;
 
 	avatar?: {

--- a/shared/ui/store/users/actions.ts
+++ b/shared/ui/store/users/actions.ts
@@ -61,11 +61,8 @@ const _updateModifiedRepos = (modifiedRepos: RepoScmStatus[], teamId: string) =>
 	dispatch,
 	getState: () => CodeStreamState
 ) => {
-	const response = await HostApi.instance.send(SetModifiedReposRequestType, {
+	return HostApi.instance.send(SetModifiedReposRequestType, {
 		modifiedRepos,
 		teamId
 	});
-	if (response && response.user) {
-		dispatch(updateUser(response.user));
-	}
 };


### PR DESCRIPTION
Note that until we can ensure that all users have this update, as well as the API server updated needed to support it, we have to store _both_ the modifiedRepos structure, and the compactified version. I have worked to "prune" the modifiedRepos structure, which results in some improvement to the size, but compactified is much better.

**This PR Addresses:**  
[Investigate large modifiedRepos objects and what to do about them](https://trello.com/c/So7GKCT8/4881-investigate-large-modifiedrepos-objects-and-what-to-do-about-them)  
