### PR TITLE
Field 'repository' doesn't accept argument 'after'

### DIFF
--- a/shared/agent/src/providers/github.ts
+++ b/shared/agent/src/providers/github.ts
@@ -3505,9 +3505,11 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 
 		// TODO: Need to page if there are more than 100 review threads
 		try {
-			const query = `query pr($owner:String!, $repo:String!) {
-				repository(name: $repo, owner: $owner${cursor ? `, after: $cursor` : ""}) {
-					pullRequests(states: [OPEN, MERGED], first: 100, orderBy: { field: UPDATED_AT, direction: DESC }) {
+			const query = `query pr($owner:String!, $repo:String!${cursor ? `, $cursor:String` : ""}) {
+				repository(name: $repo, owner: $owner) {
+					pullRequests(states: [OPEN, MERGED], first: 100, orderBy: { field: UPDATED_AT, direction: DESC }${
+						cursor ? `, after: $cursor` : ""
+					}) {
 						totalCount
 						pageInfo {
 							startCursor


### PR DESCRIPTION
This is a fix that allows pagination for PR comments. Previously, the `after` statement was not setup on the correct object (needs to be on the PR, not the repo), and the cursor variable was not passed in

https://trello.com/c/gU49XxkP/5181-field-repository-doesnt-accept-argument-after