### PR TITLE
Feature/gh points

### DIFF
--- a/shared/agent/src/providers/github.ts
+++ b/shared/agent/src/providers/github.ts
@@ -1529,6 +1529,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 				}
 			  }`;
 
+		// TODO
 		const response = await this.mutate<any>(query, {
 			assignableId: request.pullRequestId,
 			assigneeIds: request.assigneeId
@@ -1552,6 +1553,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 	}
 
 	async setAssigneeOnIssue(request: { issueId: string; assigneeId: string; onOff: boolean }) {
+		// does not require return directives
 		const method = request.onOff ? "addAssigneesToAssignable" : "removeAssigneesFromAssignable";
 		const Method = request.onOff ? "AddAssigneesFromAssignable" : "RemoveAssigneesFromAssignable";
 		const query = `mutation ${Method}($assignableId: ID!,$assigneeIds:[ID!]!) {
@@ -2829,6 +2831,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 	}
 
 	async addComment(request: { subjectId: string; text: string }) {
+		// does not require return directives
 		const response = await this.mutate<any>(
 			`mutation AddComment($subjectId:ID!,$body:String!) {
 				addComment(input: {subjectId:$subjectId, body:$body}) {

--- a/shared/agent/src/providers/github.ts
+++ b/shared/agent/src/providers/github.ts
@@ -1495,6 +1495,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 						  nodes {
 							... on AssignedEvent {
 							  __typename
+							  id
 							  actor {
 								login
 								avatarUrl
@@ -1510,6 +1511,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 							}
 							... on UnassignedEvent {
 							  __typename
+							  id
 							  actor {
 								login
 								avatarUrl
@@ -1530,7 +1532,6 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 				}
 			  }`;
 
-		// TODO
 		const response = await this.mutate<any>(query, {
 			assignableId: request.pullRequestId,
 			assigneeIds: request.assigneeId
@@ -1538,16 +1539,12 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		return {
 			directives: [
 				{
-					type: "replace",
-					// source: "assignable.assigness",
-					target: "assignees.nodes",
-					data: response[method]?.assignable?.assignees.nodes
+					type: "updatePullRequest",
+					data: { assignees: response[method].assignable.assignees }
 				},
 				{
-					type: "add",
-					// source: "assignable.assigness",
-					target: "timelineItems.nodes",
-					data: response[method]?.assignable?.timelineItems?.nodes[0]
+					type: "addNode",
+					data: response[method].assignable.timelineItems.nodes[0]
 				}
 			]
 		};
@@ -3344,6 +3341,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 			//   }`,
 			`... on AssignedEvent {
 			__typename
+			id
 			actor {
 			  login
 			  avatarUrl
@@ -3795,6 +3793,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 			//   }`,
 			`... on UnassignedEvent {
 			__typename
+			id
 			actor {
 			  login
 			  avatarUrl

--- a/shared/agent/src/providers/github.ts
+++ b/shared/agent/src/providers/github.ts
@@ -72,6 +72,26 @@ enum GitHubExceptionType {
 	Connection = "CONNECTION"
 };
 
+interface Directives {
+	directives: {
+		type:
+			| "addNode"
+			| "addNodes"
+			| "addReaction"
+			| "removeNode"
+			| "removeReaction"
+			| "resolveReviewThread"
+			| "unresolveReviewThread"
+			| "updateNode"
+			| "updatePullRequest"
+			| "updatePullRequestReview"
+			| "updatePullRequestReviewers"
+			| "updatePullRequestReviewComment"
+			| "updatePullRequestReviewCommentNode";
+		data: any;
+	}[];
+}
+
 const diffHunkRegex = /^@@ -([\d]+)(?:,([\d]+))? \+([\d]+)(?:,([\d]+))? @@/;
 
 @lspProvider("github")
@@ -1365,7 +1385,10 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		return query.repository.collaborators.nodes;
 	}
 
-	async markPullRequestReadyForReview(request: { pullRequestId: string; isReady: boolean }) {
+	async markPullRequestReadyForReview(request: {
+		pullRequestId: string;
+		isReady: boolean;
+	}): Promise<Directives | undefined> {
 		if (request.isReady) {
 			const query = `mutation MarkPullRequestReadyForReview($pullRequestId:ID!) {
 				markPullRequestReadyForReview(input: {pullRequestId: $pullRequestId}) {
@@ -1401,7 +1424,11 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		}
 	}
 
-	async setLabelOnPullRequest(request: { pullRequestId: string; labelId: string; onOff: boolean }) {
+	async setLabelOnPullRequest(request: {
+		pullRequestId: string;
+		labelId: string;
+		onOff: boolean;
+	}): Promise<Directives> {
 		const method = request.onOff ? "addLabelsToLabelable" : "removeLabelsFromLabelable";
 		const Method = request.onOff ? "AddLabelsToLabelable" : "RemoveLabelsFromLabelable";
 		const query = `mutation ${Method}($labelableId: ID!,$labelIds:[ID!]!) {
@@ -1473,7 +1500,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		pullRequestId: string;
 		assigneeId: string;
 		onOff: boolean;
-	}) {
+	}): Promise<Directives> {
 		const method = request.onOff ? "addAssigneesToAssignable" : "removeAssigneesFromAssignable";
 		const Method = request.onOff ? "AddAssigneesFromAssignable" : "RemoveAssigneesFromAssignable";
 		const query = `mutation ${Method}($assignableId:ID!, $assigneeIds:[ID!]!) {
@@ -1567,7 +1594,11 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		return response;
 	}
 
-	async toggleReaction(request: { subjectId: string; content: string; onOff: boolean }) {
+	async toggleReaction(request: {
+		subjectId: string;
+		content: string;
+		onOff: boolean;
+	}): Promise<Directives> {
 		const method = request.onOff ? "addReaction" : "removeReaction";
 		const Method = request.onOff ? "AddReaction" : "RemoveReaction";
 		const query = `mutation ${Method}($subjectId: ID!, $content:ReactionContent!) {
@@ -1627,7 +1658,10 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		};
 	}
 
-	async updatePullRequestSubscription(request: { pullRequestId: string; onOff: boolean }) {
+	async updatePullRequestSubscription(request: {
+		pullRequestId: string;
+		onOff: boolean;
+	}): Promise<Directives> {
 		const query = `mutation UpdateSubscription($subscribableId:ID!, $state:SubscriptionState!) {
 			updateSubscription(input: {subscribableId: $subscribableId, state:$state}) {
 				  clientMutationId
@@ -1651,7 +1685,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		};
 	}
 
-	async updateIssueComment(request: { id: string; body: string }) {
+	async updateIssueComment(request: { id: string; body: string }): Promise<Directives> {
 		const query = `mutation UpdateComment($id:ID!, $body:String!) {
 			updateIssueComment(input: {id: $id, body:$body}) {
 				clientMutationId
@@ -1680,7 +1714,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		};
 	}
 
-	async updateReviewComment(request: { id: string; body: string }) {
+	async updateReviewComment(request: { id: string; body: string }): Promise<Directives> {
 		const query = `mutation UpdateComment($pullRequestReviewCommentId: ID!, $body: String!) {
 			updatePullRequestReviewComment(input: {pullRequestReviewCommentId: $pullRequestReviewCommentId, body: $body}) {
 			  clientMutationId
@@ -1716,17 +1750,17 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		};
 	}
 
-	async updateReview(request: { id: string; body: string }) {
+	async updateReview(request: { id: string; body: string }): Promise<Directives> {
 		const query = `mutation UpdateComment($pullRequestReviewId:ID!, $body:String!) {
 			updatePullRequestReview(input: {pullRequestReviewId: $pullRequestReviewId, body:$body}) {
 				  clientMutationId
 				     pullRequestReview {
-      bodyText
-      bodyHTML
-      body
-      includesCreatedEdit
-      id
-    }
+						bodyText
+						bodyHTML
+						body
+						includesCreatedEdit
+						id
+					}
 				}
 			  }`;
 
@@ -1744,7 +1778,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		};
 	}
 
-	async updatePullRequestBody(request: { id: string; body: string }) {
+	async updatePullRequestBody(request: { id: string; body: string }): Promise<Directives> {
 		const query = `mutation UpdateComment($pullRequestId:ID!, $body:String!) {
 			updatePullRequest(input: {pullRequestId: $pullRequestId, body:$body}) {
 				  clientMutationId
@@ -1776,6 +1810,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 			};
 		};
 	}> {
+		// TODO add directives
 		const query = `
 		mutation AddPullRequestReview($pullRequestId:ID!) {
 		addPullRequestReview(input: {pullRequestId: $pullRequestId}) {
@@ -1943,6 +1978,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		// used with old servers
 		pullRequestReviewId?: string;
 	}) {
+		// TODO add directives
 		if (!request.eventType) {
 			request.eventType = "COMMENT";
 		}
@@ -2304,7 +2340,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		pullRequestId: string;
 		milestoneId: string;
 		onOff: boolean;
-	}) {
+	}): Promise<Directives> {
 		const query = `mutation UpdatePullRequest($pullRequestId:ID!, $milestoneId: ID) {
 			updatePullRequest(input: {pullRequestId: $pullRequestId, milestoneId: $milestoneId}) {
 				  clientMutationId
@@ -2369,7 +2405,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		pullRequestId: string;
 		projectId: string;
 		onOff: boolean;
-	}) {
+	}): Promise<Directives> {
 		const metadata = await this.getPullRequestMetadata(request.pullRequestId);
 		const projectIds = new Set(metadata.projectCards.map(_ => _.project.id));
 		const query = `mutation UpdatePullRequest($pullRequestId:ID!, $projectIds: [ID!]) {
@@ -2410,7 +2446,10 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		};
 	}
 
-	async updatePullRequestTitle(request: { pullRequestId: string; title: string }) {
+	async updatePullRequestTitle(request: {
+		pullRequestId: string;
+		title: string;
+	}): Promise<Directives> {
 		const query = `mutation UpdatePullRequest($pullRequestId:ID!, $title: String) {
 			updatePullRequest(input: {pullRequestId: $pullRequestId, title: $title}) {
 				  clientMutationId
@@ -2435,7 +2474,10 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		};
 	}
 
-	async mergePullRequest(request: { pullRequestId: string; mergeMethod: MergeMethod }) {
+	async mergePullRequest(request: {
+		pullRequestId: string;
+		mergeMethod: MergeMethod;
+	}): Promise<Directives> {
 		if (!request.mergeMethod) throw new Error("InvalidMergeMethod");
 		const mergeMethods = new Set(["MERGE", "REBASE", "SQUASH"]);
 		if (!mergeMethods.has(request.mergeMethod)) throw new Error("InvalidMergeMethod");
@@ -2531,7 +2573,10 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		};
 	}
 
-	async lockPullRequest(request: { pullRequestId: string; lockReason: string }) {
+	async lockPullRequest(request: {
+		pullRequestId: string;
+		lockReason: string;
+	}): Promise<Directives> {
 		// OFF_TOPIC, TOO_HEATED, SPAM
 		const response = await this.mutate<any>(
 			`mutation LockPullRequest($lockableId:ID!, $lockReason:LockReason) {
@@ -2561,7 +2606,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		};
 	}
 
-	async unlockPullRequest(request: { pullRequestId: string }) {
+	async unlockPullRequest(request: { pullRequestId: string }): Promise<Directives> {
 		const response = await this.mutate<any>(
 			`mutation UnlockPullRequest($pullRequestId:ID!) {
 				unlockLockable(input: {lockableId: $pullRequestId}) {
@@ -2630,7 +2675,10 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		);
 	}
 
-	async addReviewerToPullRequest(request: { pullRequestId: string; userId: string }) {
+	async addReviewerToPullRequest(request: {
+		pullRequestId: string;
+		userId: string;
+	}): Promise<Directives> {
 		const currentReviewers = await this.getReviewersForPullRequest(request);
 		const response = await this.mutate<any>(
 			`mutation RequestReviews($pullRequestId:ID!, $userIds:[ID!]!) {
@@ -2697,7 +2745,10 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		};
 	}
 
-	async removeReviewerFromPullRequest(request: { pullRequestId: string; userId: string }) {
+	async removeReviewerFromPullRequest(request: {
+		pullRequestId: string;
+		userId: string;
+	}): Promise<Directives> {
 		const currentReviewers = await this.getReviewersForPullRequest(request);
 		const response = await this.mutate<any>(
 			`mutation RequestReviews($pullRequestId:ID!, $userIds:[ID!]!) {
@@ -2739,7 +2790,10 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		};
 	}
 
-	async createPullRequestCommentAndClose(request: { pullRequestId: string; text: string }) {
+	async createPullRequestCommentAndClose(request: {
+		pullRequestId: string;
+		text: string;
+	}): Promise<Directives> {
 		const directives: any = [];
 		const response = { directives: directives };
 		if (request.text) {
@@ -2842,7 +2896,10 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		return response;
 	}
 
-	async createPullRequestCommentAndReopen(request: { pullRequestId: string; text: string }) {
+	async createPullRequestCommentAndReopen(request: {
+		pullRequestId: string;
+		text: string;
+	}): Promise<Directives> {
 		const directives: any = [];
 		const response = { directives: directives };
 		if (request.text) {
@@ -2944,7 +3001,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		return response;
 	}
 
-	async resolveReviewThread(request: { threadId: string }) {
+	async resolveReviewThread(request: { threadId: string }): Promise<Directives> {
 		const response = await this.mutate<any>(
 			`mutation ResolveReviewThread($threadId:ID!) {
 				resolveReviewThread(input: {threadId:$threadId}) {
@@ -2977,7 +3034,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		};
 	}
 
-	async unresolveReviewThread(request: { threadId: string }) {
+	async unresolveReviewThread(request: { threadId: string }): Promise<Directives> {
 		const response = await this.mutate<any>(
 			`mutation UnresolveReviewThread($threadId:ID!) {
 				unresolveReviewThread(input: {threadId:$threadId}) {
@@ -3112,7 +3169,10 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		return data.body;
 	}
 
-	async createPullRequestComment(request: { pullRequestId: string; text: string }) {
+	async createPullRequestComment(request: {
+		pullRequestId: string;
+		text: string;
+	}): Promise<Directives> {
 		// TODO move all that added code into a shared location
 		const query = `mutation AddCommentToPullRequest($subjectId:ID!, $body:String!) {
 				addComment(input: {subjectId: $subjectId, body:$body}) {
@@ -3158,8 +3218,12 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		});
 
 		return {
-			directives: "addNode",
-			data: response.addComment.timelineEdge.node
+			directives: [
+				{
+					type: "addNode",
+					data: response.addComment.timelineEdge.node
+				}
+			]
 		};
 	}
 
@@ -3203,7 +3267,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		id: string;
 		pullRequestId: string;
 		type: "ISSUE_COMMENT" | "REVIEW_COMMENT";
-	}) {
+	}): Promise<Directives | undefined> {
 		const method =
 			request.type === "ISSUE_COMMENT" ? "deleteIssueComment" : "deletePullRequestReviewComment";
 

--- a/shared/agent/src/providers/github.ts
+++ b/shared/agent/src/providers/github.ts
@@ -2317,8 +2317,20 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 					  description
 					  number
 					}
-					timelineItems(last: 1, itemTypes: MILESTONED_EVENT) {
+					timelineItems(last: 1, itemTypes: [MILESTONED_EVENT,DEMILESTONED_EVENT]) {
 					  nodes {
+						  ... on MilestonedEvent {
+							__typename
+							id
+							actor {
+								login
+								avatarUrl
+								resourcePath
+								url
+							}
+							createdAt
+							milestoneTitle
+						}
 						... on DemilestonedEvent {
 						  __typename
 						  id
@@ -3366,6 +3378,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 			//   }`,
 			`... on BaseRefForcePushedEvent {
 			__typename
+			id
 			actor {
 			  login
 			  avatarUrl
@@ -3402,6 +3415,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 			//   }`,
 			this._transform(`[... on ConvertToDraftEvent {
 				__typename
+				id
 				actor {
 				  login
 				  avatarUrl
@@ -3445,6 +3459,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 			//   }`,
 			`... on HeadRefDeletedEvent {
 			__typename
+			id
 			actor {
 			  login
 			  avatarUrl
@@ -3452,6 +3467,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		  }`,
 			`... on HeadRefForcePushedEvent {
 			__typename
+			id
 			actor {
 			  login
 			  avatarUrl
@@ -3500,6 +3516,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		}`,
 			`... on LabeledEvent {
 			__typename
+			id
 			label {
 			  name
 			  description
@@ -3513,6 +3530,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		  }`,
 			`... on LockedEvent {
 			__typename
+			id
 			actor {
 			  login
 			  avatarUrl
@@ -3522,9 +3540,11 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		  }`,
 			`... on MarkedAsDuplicateEvent {
 			__typename
+			id
 		  }`,
 			`... on MentionedEvent {
 			__typename
+			id
 			actor {
 			  login
 			  avatarUrl
@@ -3533,6 +3553,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		  }`,
 			`... on MergedEvent {
 			__typename
+			id
 			actor {
 			  login
 			  avatarUrl
@@ -3545,6 +3566,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		  }`,
 			`... on MilestonedEvent {
 			__typename
+			id
 			actor {
 			  login
 			  avatarUrl
@@ -3704,6 +3726,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 			//   }`,
 			`... on ReferencedEvent {
 			__typename
+			id
 			actor {
 			  login
 			  avatarUrl
@@ -3737,6 +3760,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 			//   }`,
 			`... on RenamedTitleEvent {
 			__typename
+			id
 			actor {
 			  login
 			  avatarUrl
@@ -3746,8 +3770,8 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 			createdAt
 		  }`,
 			`... on ReopenedEvent {
-			id
 			__typename
+			id
 			actor {
 			  login
 			  avatarUrl
@@ -3756,6 +3780,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		  }`,
 			`... on ReviewDismissedEvent {
 			__typename
+			id
 			actor {
 				login
 				avatarUrl
@@ -3772,6 +3797,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 			//   }`,
 			`... on ReviewRequestedEvent {
 			__typename
+			id
 			actor {
 			  login
 			  avatarUrl
@@ -3809,6 +3835,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		  }`,
 			`... on UnlabeledEvent {
 			__typename
+			id
 			label {
 			  color
 			  name
@@ -3822,6 +3849,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 		  }`,
 			`... on UnlockedEvent {
 			__typename
+			id
 			actor {
 			  login
 			  avatarUrl

--- a/shared/agent/src/providers/github.ts
+++ b/shared/agent/src/providers/github.ts
@@ -3582,6 +3582,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 			this._transform(`[... on ConvertToDraftEvent {
 				__typename
 				id
+				createdAt
 				actor {
 				  login
 				  avatarUrl
@@ -3887,9 +3888,15 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 			  }
 			}
 		  }`,
-			// 	`... on ReadyForReviewEvent {
-			// 	__typename
-			//   }`,
+			this._transform(`[... on ReadyForReviewEvent {
+			__typename
+			id
+			createdAt
+			actor {
+			  login
+			  avatarUrl
+			}
+		  }:>2.20.0]`),
 			`... on ReferencedEvent {
 			__typename
 			id

--- a/shared/agent/src/providers/registry.ts
+++ b/shared/agent/src/providers/registry.ts
@@ -110,7 +110,7 @@ export class ThirdPartyProviderRegistry {
 	private _pollingInterval: NodeJS.Timer | undefined;
 
 	constructor(public readonly session: CodeStreamSession) {
-		this._pollingInterval = setInterval(this.pullRequestsStateHandler.bind(this), 60000);
+		// this._pollingInterval = setInterval(this.pullRequestsStateHandler.bind(this), 60000);
 	}
 
 	private async pullRequestsStateHandler() {

--- a/shared/agent/src/providers/registry.ts
+++ b/shared/agent/src/providers/registry.ts
@@ -110,7 +110,7 @@ export class ThirdPartyProviderRegistry {
 	private _pollingInterval: NodeJS.Timer | undefined;
 
 	constructor(public readonly session: CodeStreamSession) {
-		// this._pollingInterval = setInterval(this.pullRequestsStateHandler.bind(this), 60000);
+		this._pollingInterval = setInterval(this.pullRequestsStateHandler.bind(this), 60000);
 	}
 
 	private async pullRequestsStateHandler() {

--- a/shared/ui/Stream/PullRequest.tsx
+++ b/shared/ui/Stream/PullRequest.tsx
@@ -378,9 +378,8 @@ export const PullRequest = () => {
 	const saveTitle = async () => {
 		setIsLoadingMessage("Saving Title...");
 		setSavingTitle(true);
-
 		await dispatch(api("updatePullRequestTitle", { title }));
-		fetch();
+		setSavingTitle(false);
 	};
 
 	const getOpenRepos = async () => {
@@ -497,7 +496,8 @@ export const PullRequest = () => {
 				}, 5000);
 			}
 			interval = setInterval(async () => {
-				if (intervalCounter >= 120) {
+				// checks for 1 hour
+				if (intervalCounter >= 60) {
 					interval && clearInterval(interval);
 					intervalCounter = 0;
 					console.warn(`stopped getPullRequestLastUpdated interval counter=${intervalCounter}`);
@@ -528,7 +528,7 @@ export const PullRequest = () => {
 					console.error(ex);
 					interval && clearInterval(interval);
 				}
-			}, 60000); //60000 === 1 minute
+			}, 300000); //300000 === 5 minute interval
 		}
 
 		return () => {

--- a/shared/ui/Stream/PullRequest.tsx
+++ b/shared/ui/Stream/PullRequest.tsx
@@ -60,6 +60,7 @@ import {
 } from "../store/providerPullRequests/actions";
 import {
 	getCurrentProviderPullRequest,
+	getCurrentProviderPullRequestLastUpdated,
 	getProviderPullRequestRepo
 } from "../store/providerPullRequests/reducer";
 import { confirmPopup } from "./Confirm";
@@ -114,6 +115,7 @@ export const PullRequest = () => {
 		const team = state.teams[state.context.currentTeamId];
 		const providerPullRequests = state.providerPullRequests.pullRequests;
 		const currentPullRequest = getCurrentProviderPullRequest(state);
+		const providerPullRequestLastUpdated = getCurrentProviderPullRequestLastUpdated(state);
 		return {
 			viewPreference: getPreferences(state).pullRequestView || "auto",
 			providerPullRequests: providerPullRequests,
@@ -130,6 +132,7 @@ export const PullRequest = () => {
 				? state.context.currentPullRequest.commentId
 				: undefined,
 			currentPullRequest: currentPullRequest,
+			currentPullRequestLastUpdated: providerPullRequestLastUpdated,
 			composeCodemarkActive: state.context.composeCodemarkActive,
 			team,
 			textEditorUri: state.editorContext.textEditorUri,
@@ -525,13 +528,12 @@ export const PullRequest = () => {
 				if (
 					derivedState.currentPullRequest &&
 					response &&
-					response.updatedAt !==
-						derivedState.currentPullRequest.conversations.repository.pullRequest.updatedAt
+					response.updatedAt !== derivedState.currentPullRequestLastUpdated
 				) {
-					console.log(
+					console.warn(
 						"getPullRequestLastUpdated is updating",
 						response.updatedAt,
-						derivedState.currentPullRequest.conversations.repository.pullRequest.updatedAt,
+						derivedState.currentPullRequestLastUpdated,
 						intervalCounter
 					);
 					intervalCounter = 0;
@@ -539,6 +541,7 @@ export const PullRequest = () => {
 					clearInterval(interval);
 				} else {
 					intervalCounter++;
+					console.log("incrementing counter", intervalCounter);
 				}
 			} catch (ex) {
 				console.error(ex);
@@ -549,7 +552,11 @@ export const PullRequest = () => {
 		return () => {
 			interval && clearInterval(interval);
 		};
-	}, [derivedState.currentPullRequest, autoCheckedMergeability]);
+	}, [
+		derivedState.currentPullRequestLastUpdated,
+		derivedState.currentPullRequest,
+		autoCheckedMergeability
+	]);
 
 	const iAmRequested = useMemo(() => {
 		if (pr) {

--- a/shared/ui/Stream/PullRequest.tsx
+++ b/shared/ui/Stream/PullRequest.tsx
@@ -507,7 +507,11 @@ export const PullRequest = () => {
 
 		if (
 			autoCheckedMergeability === "UNCHECKED" ||
-			derivedState.currentPullRequest.conversations.repository.pullRequest.mergeable === "UNKNOWN"
+			(derivedState.currentPullRequest.conversations &&
+				derivedState.currentPullRequest.conversations.repository &&
+				derivedState.currentPullRequest.conversations.repository.pullRequest &&
+				derivedState.currentPullRequest.conversations.repository.pullRequest.mergeable ===
+					"UNKNOWN")
 		) {
 			console.log("PullRequest pr mergeable is UNKNOWN");
 			setTimeout(() => {

--- a/shared/ui/Stream/PullRequest.tsx
+++ b/shared/ui/Stream/PullRequest.tsx
@@ -508,7 +508,7 @@ export const PullRequest = () => {
 		}
 		interval = setInterval(async () => {
 			// checks for 1 hour
-			if (intervalCounter >= 12) {
+			if (intervalCounter >= 60) {
 				interval && clearInterval(interval);
 				intervalCounter = 0;
 				console.warn(`stopped getPullRequestLastUpdated interval counter=${intervalCounter}`);
@@ -544,7 +544,7 @@ export const PullRequest = () => {
 				console.error(ex);
 				interval && clearInterval(interval);
 			}
-		}, 300000); //300000 === 5 minute interval
+		}, 60000); //60000 === 5 minute interval
 
 		return () => {
 			interval && clearInterval(interval);

--- a/shared/ui/Stream/PullRequest.tsx
+++ b/shared/ui/Stream/PullRequest.tsx
@@ -544,7 +544,7 @@ export const PullRequest = () => {
 				console.error(ex);
 				interval && clearInterval(interval);
 			}
-		}, 60000); //60000 === 5 minute interval
+		}, 60000); //60000 === 1 minute interval
 
 		return () => {
 			interval && clearInterval(interval);

--- a/shared/ui/Stream/PullRequest.tsx
+++ b/shared/ui/Stream/PullRequest.tsx
@@ -61,7 +61,8 @@ import {
 import {
 	getCurrentProviderPullRequest,
 	getCurrentProviderPullRequestLastUpdated,
-	getProviderPullRequestRepo
+	getProviderPullRequestRepo,
+	isAnHourOld
 } from "../store/providerPullRequests/reducer";
 import { confirmPopup } from "./Confirm";
 import { PullRequestFileComments } from "./PullRequestFileComments";
@@ -225,7 +226,13 @@ export const PullRequest = () => {
 		if (providerPullRequests) {
 			let data = providerPullRequests[derivedState.currentPullRequestId!];
 			if (data) {
-				_assignState(data.conversations);
+				if (isAnHourOld(data.conversationsLastFetch)) {
+					console.warn(`pr id=${derivedState.currentPullRequestId} is too old, resetting`);
+					// setPR to undefined to trigger loader
+					setPr(undefined);
+				} else {
+					_assignState(data.conversations);
+				}
 			}
 		}
 	}, [

--- a/shared/ui/Stream/PullRequestBottomComment.tsx
+++ b/shared/ui/Stream/PullRequestBottomComment.tsx
@@ -56,7 +56,7 @@ export const PullRequestBottomComment = styled((props: Props) => {
 			})
 		);
 		setText("");
-		fetch().then(() => setIsLoadingComment(false));
+		setIsLoadingComment(false);
 	};
 
 	const onCommentAndCloseClick = async e => {

--- a/shared/ui/Stream/PullRequestBottomComment.tsx
+++ b/shared/ui/Stream/PullRequestBottomComment.tsx
@@ -18,14 +18,13 @@ import { replaceHtml } from "../utils";
 interface Props {
 	pr: FetchThirdPartyPullRequestPullRequest;
 	setIsLoadingMessage: Function;
-	fetch: Function;
 	__onDidRender: Function;
 	className?: string;
 }
 
 export const PullRequestBottomComment = styled((props: Props) => {
 	const dispatch = useDispatch();
-	const { pr, fetch, setIsLoadingMessage } = props;
+	const { pr, setIsLoadingMessage } = props;
 	const derivedState = useSelector((state: CodeStreamState) => {
 		const currentUser = state.users[state.session.userId!] as CSMe;
 		return {
@@ -69,10 +68,8 @@ export const PullRequestBottomComment = styled((props: Props) => {
 			})
 		);
 		setText("");
-		fetch().then(() => {
-			dispatch(removeFromMyPullRequests(pr.providerId, derivedState.currentPullRequestId!));
-			setIsLoadingCommentAndClose(false);
-		});
+		dispatch(removeFromMyPullRequests(pr.providerId, derivedState.currentPullRequestId!));
+		setIsLoadingCommentAndClose(false);
 	};
 
 	const onCommentAndReopenClick = async e => {
@@ -85,7 +82,7 @@ export const PullRequestBottomComment = styled((props: Props) => {
 			})
 		);
 		setText("");
-		fetch().then(() => setIsLoadingCommentAndClose(false));
+		setIsLoadingCommentAndClose(false);
 	};
 
 	const map = {

--- a/shared/ui/Stream/PullRequestCodeComment.tsx
+++ b/shared/ui/Stream/PullRequestCodeComment.tsx
@@ -95,8 +95,6 @@ export const PullRequestCodeComment = (props: PropsWithChildren<Props>) => {
 					threadId: threadId
 				})
 			);
-
-			await props.fetch();
 		} catch (ex) {
 			console.warn(ex);
 		} finally {
@@ -112,8 +110,6 @@ export const PullRequestCodeComment = (props: PropsWithChildren<Props>) => {
 					threadId: threadId
 				})
 			);
-
-			await props.fetch();
 		} catch (ex) {
 			console.warn(ex);
 		} finally {
@@ -198,7 +194,6 @@ export const PullRequestCodeComment = (props: PropsWithChildren<Props>) => {
 						{editingComments[comment.id] ? (
 							<PullRequestEditingComment
 								pr={pr}
-								fetch={props.fetch}
 								setIsLoadingMessage={setIsLoadingMessage}
 								id={comment.id}
 								type={"REVIEW_COMMENT"}
@@ -265,7 +260,6 @@ export const PullRequestCodeComment = (props: PropsWithChildren<Props>) => {
 								{editingComments[c.id] ? (
 									<PullRequestEditingComment
 										pr={pr}
-										fetch={props.fetch}
 										setIsLoadingMessage={setIsLoadingMessage}
 										id={c.id}
 										type={"REVIEW_COMMENT"}

--- a/shared/ui/Stream/PullRequestCodeComment.tsx
+++ b/shared/ui/Stream/PullRequestCodeComment.tsx
@@ -49,7 +49,7 @@ interface Props {
 }
 
 export const PullRequestCodeComment = (props: PropsWithChildren<Props>) => {
-	const { item, comment, author, fetch, setIsLoadingMessage, pr } = props;
+	const { item, comment, author, setIsLoadingMessage, pr } = props;
 	const dispatch = useDispatch();
 
 	const [openComments, setOpenComments] = useState({});

--- a/shared/ui/Stream/PullRequestCodeComment.tsx
+++ b/shared/ui/Stream/PullRequestCodeComment.tsx
@@ -180,7 +180,6 @@ export const PullRequestCodeComment = (props: PropsWithChildren<Props>) => {
 									pr={pr}
 									targetId={comment.id}
 									setIsLoadingMessage={setIsLoadingMessage}
-									fetch={props.fetch}
 									reactionGroups={comment.reactionGroups}
 								/>
 								<PullRequestCommentMenu
@@ -220,7 +219,6 @@ export const PullRequestCodeComment = (props: PropsWithChildren<Props>) => {
 				pr={pr}
 				targetId={comment.id}
 				setIsLoadingMessage={setIsLoadingMessage}
-				fetch={props.fetch}
 				reactionGroups={comment.reactionGroups}
 			/>
 			{comment.replies &&
@@ -249,7 +247,6 @@ export const PullRequestCodeComment = (props: PropsWithChildren<Props>) => {
 											pr={pr}
 											targetId={c.id}
 											setIsLoadingMessage={setIsLoadingMessage}
-											fetch={props.fetch}
 											reactionGroups={c.reactionGroups}
 										/>
 										<PullRequestCommentMenu
@@ -287,7 +284,6 @@ export const PullRequestCodeComment = (props: PropsWithChildren<Props>) => {
 								pr={pr}
 								targetId={c.id}
 								setIsLoadingMessage={setIsLoadingMessage}
-								fetch={props.fetch}
 								reactionGroups={c.reactionGroups}
 							/>
 						</div>

--- a/shared/ui/Stream/PullRequestCommentMenu.tsx
+++ b/shared/ui/Stream/PullRequestCommentMenu.tsx
@@ -51,6 +51,7 @@ export const PullRequestCommentMenu = (props: CommentMenuProps) => {
 									pullRequestReviewId: node.id
 								})
 							);
+							fetch();
 						} else {
 							await dispatch(
 								api("deletePullRequestComment", {
@@ -60,7 +61,6 @@ export const PullRequestCommentMenu = (props: CommentMenuProps) => {
 								})
 							);
 						}
-						fetch();
 					}
 				}
 			]

--- a/shared/ui/Stream/PullRequestCommentMenu.tsx
+++ b/shared/ui/Stream/PullRequestCommentMenu.tsx
@@ -50,6 +50,9 @@ export const PullRequestCommentMenu = (props: CommentMenuProps) => {
 									pullRequestId: pr.id
 								})
 							);
+							if (props.nodeType !== "ISSUE_COMMENT") {
+								fetch();
+							}
 						}
 					}
 				}

--- a/shared/ui/Stream/PullRequestCommentMenu.tsx
+++ b/shared/ui/Stream/PullRequestCommentMenu.tsx
@@ -1,16 +1,6 @@
 import React from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { CodeStreamState } from "../store";
+import { useDispatch } from "react-redux";
 import Icon from "./Icon";
-import Menu from "./Menu";
-import { emojify } from "./Markdowner";
-import styled from "styled-components";
-import { PRReactions, PRReaction } from "./PullRequestComponents";
-import Tooltip from "./Tooltip";
-import { SmartFormattedList } from "./SmartFormattedList";
-import { HostApi } from "../webview-api";
-import { ExecuteThirdPartyTypedType } from "@codestream/protocols/agent";
-import { DropdownButton } from "./Review/DropdownButton";
 import { InlineMenu } from "../src/components/controls/InlineMenu";
 import copy from "copy-to-clipboard";
 import { confirmPopup } from "./Confirm";

--- a/shared/ui/Stream/PullRequestConversationTab.tsx
+++ b/shared/ui/Stream/PullRequestConversationTab.tsx
@@ -403,7 +403,6 @@ export const PullRequestConversationTab = (props: {
 				userId: id
 			})
 		);
-		fetch();
 	};
 	const addReviewer = async id => {
 		setIsLoadingMessage("Requesting Review...");
@@ -413,7 +412,6 @@ export const PullRequestConversationTab = (props: {
 				userId: id
 			})
 		);
-		fetch();
 	};
 
 	const fetchAvailableAssignees = async (e?) => {

--- a/shared/ui/Stream/PullRequestConversationTab.tsx
+++ b/shared/ui/Stream/PullRequestConversationTab.tsx
@@ -181,7 +181,7 @@ export const PullRequestConversationTab = (props: {
 	const [availableAssignees, setAvailableAssignees] = useState(EMPTY_ARRAY);
 	const [availableProjects, setAvailableProjects] = useState<[] | undefined>();
 	const [availableMilestones, setAvailableMilestones] = useState<[] | undefined>();
-	const [availableIssues, setAvailableIssues] = useState(EMPTY_ARRAY);
+	// const [availableIssues, setAvailableIssues] = useState(EMPTY_ARRAY);
 	const [isLocking, setIsLocking] = useState(false);
 	const [isLockingReason, setIsLockingReason] = useState("");
 	const [isLoadingLocking, setIsLoadingLocking] = useState(false);
@@ -394,7 +394,7 @@ export const PullRequestConversationTab = (props: {
 		} else {
 			return [{ label: <LoadingMessage>Loading Reviewers...</LoadingMessage>, noHover: true }];
 		}
-	}, [availableReviewers, pr]);
+	}, [derivedState.currentPullRequest, availableReviewers, pr]);
 
 	const removeReviewer = async id => {
 		setIsLoadingMessage("Removing Reviewer...");
@@ -463,7 +463,7 @@ export const PullRequestConversationTab = (props: {
 		} else {
 			return [{ label: <LoadingMessage>Loading Assignees...</LoadingMessage>, noHover: true }];
 		}
-	}, [availableAssignees, pr]);
+	}, [derivedState.currentPullRequest, availableAssignees, pr]);
 
 	const toggleAssignee = async (id: string, onOff: boolean) => {
 		setIsLoadingMessage(onOff ? "Adding Assignee..." : "Removing Assignee...");
@@ -509,7 +509,7 @@ export const PullRequestConversationTab = (props: {
 		} else {
 			return [{ label: <LoadingMessage>Loading Labels...</LoadingMessage>, noHover: true }];
 		}
-	}, [availableLabels, pr]);
+	}, [derivedState.currentPullRequest, availableLabels, pr]);
 
 	const setLabel = async (id: string, onOff: boolean) => {
 		setIsLoadingMessage(onOff ? "Adding Label..." : "Removing Label...");
@@ -554,7 +554,7 @@ export const PullRequestConversationTab = (props: {
 		} else {
 			return [{ label: <LoadingMessage>Loading Projects...</LoadingMessage>, noHover: true }];
 		}
-	}, [availableProjects, pr]);
+	}, [derivedState.currentPullRequest, availableProjects, pr]);
 
 	const setProject = async (id: string, onOff: boolean) => {
 		setIsLoadingMessage(onOff ? "Adding to Project..." : "Removing from Project...");
@@ -604,7 +604,7 @@ export const PullRequestConversationTab = (props: {
 		} else {
 			return [{ label: <LoadingMessage>Loading Milestones...</LoadingMessage>, noHover: true }];
 		}
-	}, [availableMilestones, pr]);
+	}, [derivedState.currentPullRequest, availableMilestones, pr]);
 
 	const setMilestone = async (id: string, onOff: boolean) => {
 		setIsLoadingMessage(onOff ? "Adding Milestone..." : "Clearing Milestone...");

--- a/shared/ui/Stream/PullRequestConversationTab.tsx
+++ b/shared/ui/Stream/PullRequestConversationTab.tsx
@@ -558,13 +558,12 @@ export const PullRequestConversationTab = (props: {
 
 	const setProject = async (id: string, onOff: boolean) => {
 		setIsLoadingMessage(onOff ? "Adding to Project..." : "Removing from Project...");
-		await dispatch(
+		dispatch(
 			api("toggleProjectOnPullRequest", {
 				projectId: id,
 				onOff
 			})
 		);
-		fetch();
 	};
 
 	const fetchAvailableMilestones = async (e?) => {
@@ -609,13 +608,12 @@ export const PullRequestConversationTab = (props: {
 
 	const setMilestone = async (id: string, onOff: boolean) => {
 		setIsLoadingMessage(onOff ? "Adding Milestone..." : "Clearing Milestone...");
-		await dispatch(
+		dispatch(
 			api("toggleMilestoneOnPullRequest", {
 				milestoneId: id,
 				onOff
 			})
 		);
-		fetch();
 	};
 
 	// const fetchAvailableIssues = async (e?) => {

--- a/shared/ui/Stream/PullRequestConversationTab.tsx
+++ b/shared/ui/Stream/PullRequestConversationTab.tsx
@@ -1114,7 +1114,6 @@ export const PullRequestConversationTab = (props: {
 				</PRComment>
 				<PullRequestBottomComment
 					pr={pr}
-					fetch={fetch}
 					setIsLoadingMessage={setIsLoadingMessage}
 					__onDidRender={__onDidRender}
 				/>

--- a/shared/ui/Stream/PullRequestConversationTab.tsx
+++ b/shared/ui/Stream/PullRequestConversationTab.tsx
@@ -205,14 +205,13 @@ export const PullRequestConversationTab = (props: {
 			});
 	};
 
-	const setIsDraftPullRequest = async (onOff: boolean) => {
+	const markPullRequestReadyForReview = async (onOff: boolean) => {
 		setIsLoadingMessage("Updating...");
 		await dispatch(
-			api("setIsDraftPullRequest", {
-				onOff
+			api("markPullRequestReadyForReview", {
+				isReady: onOff
 			})
 		);
-		fetch();
 	};
 
 	const mergePullRequest = useCallback(
@@ -257,24 +256,18 @@ export const PullRequestConversationTab = (props: {
 				break;
 		}
 
-		await dispatch(
-			api("lockPullRequest", {
-				lockReason: reason
-			})
-		);
-		fetch().then(() => {
-			setIsLocking(false);
-			setIsLoadingLocking(false);
-		});
+		await dispatch(api("lockPullRequest", { lockReason: reason }));
+
+		setIsLocking(false);
+		setIsLoadingLocking(false);
 	};
 
 	const unlockPullRequest = async () => {
 		setIsLoadingLocking(true);
 		await dispatch(api("unlockPullRequest", {}));
-		fetch().then(() => {
-			setIsLocking(false);
-			setIsLoadingLocking(false);
-		});
+
+		setIsLocking(false);
+		setIsLoadingLocking(false);
 	};
 
 	const numParticpants = ((pr.participants && pr.participants.nodes) || []).length;
@@ -482,7 +475,6 @@ export const PullRequestConversationTab = (props: {
 				onOff
 			})
 		);
-		fetch();
 	};
 
 	const fetchAvailableLabels = async (e?) => {
@@ -529,7 +521,6 @@ export const PullRequestConversationTab = (props: {
 				onOff
 			})
 		);
-		fetch();
 	};
 
 	const fetchAvailableProjects = async (e?) => {
@@ -660,18 +651,18 @@ export const PullRequestConversationTab = (props: {
 	// 	}
 	// }, [availableIssues, pr]);
 
-	const setIssue = async (id: string, onOff: boolean) => {
-		setIsLoadingMessage(onOff ? "Adding Issue..." : "Removing Issue...");
-		await dispatch(
-			api("setIssueOnPullRequest", {
-				owner: ghRepo.repoOwner,
-				repo: ghRepo.repoName,
-				issueId: id,
-				onOff
-			})
-		);
-		fetch();
-	};
+	// const setIssue = async (id: string, onOff: boolean) => {
+	// 	setIsLoadingMessage(onOff ? "Adding Issue..." : "Removing Issue...");
+	// 	await dispatch(
+	// 		api("setIssueOnPullRequest", {
+	// 			owner: ghRepo.repoOwner,
+	// 			repo: ghRepo.repoName,
+	// 			issueId: id,
+	// 			onOff
+	// 		})
+	// 	);
+	// 	fetch();
+	// };
 
 	const toggleSubscription = async () => {
 		const onOff = pr.viewerSubscription === "SUBSCRIBED" ? false : true;
@@ -683,7 +674,6 @@ export const PullRequestConversationTab = (props: {
 				onOff
 			})
 		);
-		fetch();
 	};
 
 	const requiredApprovingReviewCount = useMemo(() => {
@@ -822,7 +812,7 @@ export const PullRequestConversationTab = (props: {
 								<Button
 									className="no-wrap"
 									variant="secondary"
-									onClick={() => setIsDraftPullRequest(true)}
+									onClick={() => markPullRequestReadyForReview(true)}
 								>
 									Ready for review
 								</Button>

--- a/shared/ui/Stream/PullRequestConversationTab.tsx
+++ b/shared/ui/Stream/PullRequestConversationTab.tsx
@@ -225,9 +225,7 @@ export const PullRequestConversationTab = (props: {
 				})
 			)) as any;
 			if (response) {
-				fetch().then(_ => {
-					dispatch(removeFromMyPullRequests(pr.providerId, derivedState.currentPullRequestId!));
-				});
+				dispatch(removeFromMyPullRequests(pr.providerId, derivedState.currentPullRequestId!));
 			}
 		},
 		[

--- a/shared/ui/Stream/PullRequestEditingComment.tsx
+++ b/shared/ui/Stream/PullRequestEditingComment.tsx
@@ -62,10 +62,8 @@ export const PullRequestEditingComment = styled((props: Props) => {
 				)
 			);
 
-			fetch().then(() => {
-				setText("");
-				done();
-			});
+			setText("");
+			done();
 		} catch (ex) {
 			console.warn(ex);
 		} finally {

--- a/shared/ui/Stream/PullRequestEditingComment.tsx
+++ b/shared/ui/Stream/PullRequestEditingComment.tsx
@@ -3,11 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { CodeStreamState } from "../store";
 import styled from "styled-components";
 import { PRButtonRow } from "./PullRequestComponents";
-import { HostApi } from "../webview-api";
-import {
-	ExecuteThirdPartyTypedType,
-	FetchThirdPartyPullRequestPullRequest
-} from "@codestream/protocols/agent";
+import { FetchThirdPartyPullRequestPullRequest } from "@codestream/protocols/agent";
 import MessageInput from "./MessageInput";
 import { CSMe } from "@codestream/protocols/api";
 import { Button } from "../src/components/Button";
@@ -17,7 +13,6 @@ import { api } from "../store/providerPullRequests/actions";
 interface Props {
 	pr: FetchThirdPartyPullRequestPullRequest;
 	setIsLoadingMessage: Function;
-	fetch: Function;
 	className?: string;
 	id: string;
 	type: "PR" | "ISSUE" | "REVIEW" | "REVIEW_COMMENT";
@@ -27,17 +22,7 @@ interface Props {
 
 export const PullRequestEditingComment = styled((props: Props) => {
 	const dispatch = useDispatch();
-	const { pr, fetch, setIsLoadingMessage, type, id, done } = props;
-	const derivedState = useSelector((state: CodeStreamState) => {
-		const currentUser = state.users[state.session.userId!] as CSMe;
-		return {
-			currentUser,
-			currentPullRequestId: state.context.currentPullRequest
-				? state.context.currentPullRequest.id
-				: undefined
-		};
-	});
-
+	const { pr, setIsLoadingMessage, type, id, done } = props;
 	const [text, setText] = useState(props.text);
 
 	const handleEdit = async () => {

--- a/shared/ui/Stream/PullRequestReactions.tsx
+++ b/shared/ui/Stream/PullRequestReactions.tsx
@@ -15,7 +15,6 @@ interface Props {
 	pr: FetchThirdPartyPullRequestPullRequest;
 	targetId: string;
 	setIsLoadingMessage: Function;
-	fetch: Function;
 	className?: string;
 	reactionGroups?: any;
 }
@@ -40,10 +39,6 @@ export const PRReact = styled.div`
 
 export const PullRequestReactButton = styled((props: Props) => {
 	const dispatch = useDispatch();
-	const derivedState = useSelector((state: CodeStreamState) => {
-		return {};
-	});
-
 	const [open, setOpen] = React.useState<EventTarget | undefined>();
 	const [menuTitle, setMenuTitle] = React.useState("");
 
@@ -58,7 +53,6 @@ export const PullRequestReactButton = styled((props: Props) => {
 				onOff
 			})
 		);
-		props.fetch();
 	};
 
 	const isMine = (key: string) => {
@@ -131,7 +125,6 @@ interface ReactionProps {
 	reactionGroups: any;
 	targetId: string;
 	setIsLoadingMessage: Function;
-	fetch: Function;
 }
 
 const REACTION_MAP = {
@@ -171,7 +164,6 @@ export const PullRequestReactions = (props: ReactionProps) => {
 				onOff
 			})
 		);
-		props.fetch();
 	};
 
 	const me = props.pr.viewer.login;
@@ -209,7 +201,6 @@ export const PullRequestReactions = (props: ReactionProps) => {
 					pr={props.pr}
 					targetId={props.targetId}
 					setIsLoadingMessage={props.setIsLoadingMessage}
-					fetch={props.fetch}
 					reactionGroups={props.reactionGroups}
 				/>
 			</PRReactions>

--- a/shared/ui/Stream/PullRequestTimelineItems.tsx
+++ b/shared/ui/Stream/PullRequestTimelineItems.tsx
@@ -836,6 +836,30 @@ export const PullRequestTimelineItems = (props: PropsWithChildren<Props>) => {
 							</PRTimelineItem>
 						);
 					}
+					case "ConvertToDraftEvent": {
+						return (
+							<PRTimelineItem key={index} className="tall">
+								<Icon name="circle" className="circled" />
+								<PRTimelineItemBody>
+									<PRHeadshotName key={index} person={item.actor} />
+									marked this pull request as draft
+									<Timestamp time={item.createdAt!} relative />
+								</PRTimelineItemBody>
+							</PRTimelineItem>
+						);
+					}
+					case "ReadyForReviewEvent": {
+						return (
+							<PRTimelineItem key={index} className="tall">
+								<Icon name="eye" className="circled" />
+								<PRTimelineItemBody>
+									<PRHeadshotName key={index} person={item.actor} />
+									marked this pull request as ready for review
+									<Timestamp time={item.createdAt!} relative />
+								</PRTimelineItemBody>
+							</PRTimelineItem>
+						);
+					}
 					case "HeadRefForcePushedEvent":
 					case "BaseRefForcePushedEvent": {
 						return (

--- a/shared/ui/Stream/PullRequestTimelineItems.tsx
+++ b/shared/ui/Stream/PullRequestTimelineItems.tsx
@@ -137,49 +137,6 @@ export const PullRequestTimelineItems = (props: PropsWithChildren<Props>) => {
 		});
 	};
 
-	const handleEdit = async (id: string, type: "PR" | "ISSUE" | "REVIEW" | "REVIEW_COMMENT") => {
-		setIsLoadingMessage("Updating Comment...");
-		try {
-			const value = pendingComments[id];
-			if (value == null) return;
-
-			await dispatch(
-				api(
-					type === "REVIEW_COMMENT"
-						? "updateReviewComment"
-						: type === "ISSUE"
-						? "updateIssueComment"
-						: type === "PR"
-						? "updatePullRequestBody"
-						: "updateReview",
-					{
-						id,
-						body: value
-					}
-				)
-			);
-
-			fetch().then(() => {
-				setPendingComments({
-					...pendingComments,
-					[id]: undefined
-				});
-				setEditingComments({
-					...editingComments,
-					[id]: false
-				});
-			});
-		} catch (ex) {
-			console.warn(ex);
-		} finally {
-			setIsLoadingMessage();
-		}
-	};
-
-	const handleOnChangeReviewOptions = (value: string) => {
-		setReviewOption(value);
-	};
-
 	const derivedState = useSelector((state: CodeStreamState) => {
 		const currentUser = state.users[state.session.userId!] as CSMe;
 		return {
@@ -208,7 +165,6 @@ export const PullRequestTimelineItems = (props: PropsWithChildren<Props>) => {
 								pr={pr}
 								targetId={pr.id}
 								setIsLoadingMessage={setIsLoadingMessage}
-								fetch={fetch}
 								reactionGroups={pr.reactionGroups}
 							/>
 							<PullRequestCommentMenu
@@ -248,7 +204,6 @@ export const PullRequestTimelineItems = (props: PropsWithChildren<Props>) => {
 						pr={pr}
 						targetId={pr.id}
 						setIsLoadingMessage={setIsLoadingMessage}
-						fetch={fetch}
 						reactionGroups={pr.reactionGroups}
 					/>
 				</PRCommentCard>
@@ -282,7 +237,6 @@ export const PullRequestTimelineItems = (props: PropsWithChildren<Props>) => {
 														pr={pr}
 														targetId={item.id}
 														setIsLoadingMessage={setIsLoadingMessage}
-														fetch={fetch}
 														reactionGroups={item.reactionGroups}
 													/>
 													<PullRequestCommentMenu
@@ -320,7 +274,6 @@ export const PullRequestTimelineItems = (props: PropsWithChildren<Props>) => {
 												pr={pr}
 												targetId={item.id}
 												setIsLoadingMessage={setIsLoadingMessage}
-												fetch={fetch}
 												reactionGroups={item.reactionGroups}
 											/>
 										</>
@@ -374,7 +327,6 @@ export const PullRequestTimelineItems = (props: PropsWithChildren<Props>) => {
 															pr={pr}
 															targetId={item.id}
 															setIsLoadingMessage={setIsLoadingMessage}
-															fetch={fetch}
 															reactionGroups={item.reactionGroups}
 														/>
 														<PullRequestCommentMenu
@@ -414,7 +366,6 @@ export const PullRequestTimelineItems = (props: PropsWithChildren<Props>) => {
 													pr={pr}
 													targetId={item.id}
 													setIsLoadingMessage={setIsLoadingMessage}
-													fetch={fetch}
 													reactionGroups={item.reactionGroups}
 												/>
 											</>

--- a/shared/ui/Stream/PullRequestTimelineItems.tsx
+++ b/shared/ui/Stream/PullRequestTimelineItems.tsx
@@ -182,7 +182,6 @@ export const PullRequestTimelineItems = (props: PropsWithChildren<Props>) => {
 						{editingComments[pr.id] ? (
 							<PullRequestEditingComment
 								pr={pr}
-								fetch={fetch}
 								setIsLoadingMessage={setIsLoadingMessage}
 								id={pr.id}
 								type={"PR"}
@@ -255,7 +254,6 @@ export const PullRequestTimelineItems = (props: PropsWithChildren<Props>) => {
 												{editingComments[item.id] ? (
 													<PullRequestEditingComment
 														pr={pr}
-														fetch={fetch}
 														setIsLoadingMessage={setIsLoadingMessage}
 														id={item.id}
 														type={"ISSUE"}
@@ -347,7 +345,6 @@ export const PullRequestTimelineItems = (props: PropsWithChildren<Props>) => {
 													{editingComments[item.id] ? (
 														<PullRequestEditingComment
 															pr={pr}
-															fetch={fetch}
 															setIsLoadingMessage={setIsLoadingMessage}
 															id={item.id}
 															type={"REVIEW"}

--- a/shared/ui/store/providerPullRequests/actions.ts
+++ b/shared/ui/store/providerPullRequests/actions.ts
@@ -73,7 +73,7 @@ export const clearPullRequestError = (providerId: string, id: string) =>
 		undefined
 	});
 
-export const handleDirective = (providerId: string, id: string, data: any) =>
+export const handleDirectives = (providerId: string, id: string, data: any) =>
 	action(ProviderPullRequestActionsTypes.HandleDirectives, {
 		providerId,
 		id,
@@ -457,24 +457,9 @@ export const api = <T = any, R = any>(
 		if (response && (!options || (options && !options.preventClearError))) {
 			dispatch(clearPullRequestError(providerId, pullRequestId));
 		}
-		// if (response && response.directive) {
-		// 	if (response.directive === "add") {
-		// 		dispatch(addTimelineNode(providerId, pullRequestId, response.data));
-		// 	} else if (response.directive === "remove") {
-		// 		dispatch(removeTimelineNode(providerId, pullRequestId, response.data));
-		// 	} // else if (response.directive === "updateLabels") {
-		// 	// 	dispatch(updatePullRequestLabels(providerId, pullRequestId, response.data));
-		// 	// }
-		// 	else {
-		// 		console.warn("no directive");
-		// 		return response as R;
-		// 	}
-		// 	return {
-		// 		handled: true
-		// 	};
-		// }
+
 		if (response && response.directives) {
-			dispatch(handleDirective(providerId, pullRequestId, response.directives));
+			dispatch(handleDirectives(providerId, pullRequestId, response.directives));
 			return {
 				handled: true
 			};

--- a/shared/ui/store/providerPullRequests/reducer.ts
+++ b/shared/ui/store/providerPullRequests/reducer.ts
@@ -188,8 +188,6 @@ export function reduceProviderPullRequests(
 								node.reactionGroups
 									.find(_ => _.content === directive.data.reaction.content)
 									.users.nodes.push(directive.data.reaction.user);
-							} else {
-								console.warn(`Could not find node with id ${directive.data.subject.id}`);
 							}
 						}
 					} else if (directive.type === "removeReaction") {
@@ -207,8 +205,6 @@ export function reduceProviderPullRequests(
 								).users.nodes = node.reactionGroups
 									.find(_ => _.content === directive.data.reaction.content)
 									.users.nodes.filter(_ => _.login !== directive.data.reaction.user.login);
-							} else {
-								console.warn(`Could not find node with id ${directive.data.subject.id}`);
 							}
 						}
 					} else if (directive.type === "removeNode") {
@@ -219,16 +215,12 @@ export function reduceProviderPullRequests(
 							for (const key in directive.data) {
 								node[key] = directive.data[key];
 							}
-						} else {
-							console.warn(`Could not find node with id ${directive.data.subject.id}`);
 						}
 					} else if (directive.type === "addNode") {
 						if (!directive.data.id) continue;
 						const node = pr.timelineItems.nodes.find(_ => _.id === directive.data.id);
 						if (!node) {
 							pr.timelineItems.nodes.push(directive.data);
-						} else {
-							console.warn(`Could not find node with id ${directive.data.id}`);
 						}
 					} else if (directive.type === "addNodes") {
 						for (const newNode of directive.data) {
@@ -236,8 +228,6 @@ export function reduceProviderPullRequests(
 							const node = pr.timelineItems.nodes.find((_: any) => _.id === newNode.id);
 							if (!node) {
 								pr.timelineItems.nodes.push(newNode);
-							} else {
-								console.warn(`Node already exists: id ${newNode.id}`);
 							}
 						}
 					} else if (directive.type === "updatePullRequestReviewComment") {
@@ -267,8 +257,6 @@ export function reduceProviderPullRequests(
 								}
 								break;
 							}
-						} else {
-							console.warn(`Could not find node with id ${directive.data.id}`);
 						}
 					} else if (directive.type === "updatePullRequestReview") {
 						const node = pr.timelineItems.nodes.find(_ => _.id === directive.data.id);
@@ -276,8 +264,6 @@ export function reduceProviderPullRequests(
 							for (const key in directive.data) {
 								node[key] = directive.data[key];
 							}
-						} else {
-							console.warn(`Could not find node with id ${directive.data.id}`);
 						}
 					} else if (directive.type === "updatePullRequestReviewers") {
 						pr.reviewRequests.nodes.length = 0;
@@ -307,8 +293,6 @@ export function reduceProviderPullRequests(
 							for (const key in directive.data) {
 								nodeWrapper.node[key] = directive.data[key];
 							}
-						} else {
-							console.warn(`Could not find node with id ${directive.data.threadId}`);
 						}
 
 						const reviews = pr.timelineItems.nodes.filter(

--- a/shared/ui/store/providerPullRequests/reducer.ts
+++ b/shared/ui/store/providerPullRequests/reducer.ts
@@ -242,7 +242,7 @@ export function reduceProviderPullRequests(
 						if (!node) {
 							pr.timelineItems.nodes.push(directive.data);
 						} else {
-							console.warn(`Could not find node with id ${directive.data.subject.id}`);
+							console.warn(`Could not find node with id ${directive.data.id}`);
 						}
 					} else if (directive.type === "addNodes") {
 						for (const newNode of directive.data) {
@@ -251,7 +251,7 @@ export function reduceProviderPullRequests(
 							if (!node) {
 								pr.timelineItems.nodes.push(newNode);
 							} else {
-								console.warn(`Node already exists: id ${directive.data.subject.id}`);
+								console.warn(`Node already exists: id ${newNode.id}`);
 							}
 						}
 					} else if (directive.type === "updatePullRequestReviewComment") {

--- a/shared/ui/store/providerPullRequests/reducer.ts
+++ b/shared/ui/store/providerPullRequests/reducer.ts
@@ -177,21 +177,7 @@ export function reduceProviderPullRequests(
 			if (newState[providerId][id] && newState[providerId][id].conversations) {
 				const pr = newState[providerId][id].conversations.repository.pullRequest;
 				for (const directive of action.payload.data) {
-					if (directive.type === "replace") {
-						const paths = directive.target.split(".");
-						let result = "";
-						for (const path of paths) {
-							result += `['${path}']`;
-						}
-						eval(`pr${result} = directive.data`);
-					} else if (directive.type === "add") {
-						const paths = directive.target.split(".");
-						let result = "";
-						for (const path of paths) {
-							result += `['${path}']`;
-						}
-						eval(`pr${result}.push(directive.data)`);
-					} else if (directive.type === "addReaction") {
+					if (directive.type === "addReaction") {
 						if (directive.data.subject.__typename === "PullRequest") {
 							pr.reactionGroups
 								.find(_ => _.content === directive.data.reaction.content)

--- a/shared/ui/store/providerPullRequests/reducer.ts
+++ b/shared/ui/store/providerPullRequests/reducer.ts
@@ -237,11 +237,22 @@ export function reduceProviderPullRequests(
 							console.warn(`Could not find node with id ${directive.data.subject.id}`);
 						}
 					} else if (directive.type === "addNode") {
+						if (!directive.data.id) continue;
 						const node = pr.timelineItems.nodes.find(_ => _.id === directive.data.id);
 						if (!node) {
 							pr.timelineItems.nodes.push(directive.data);
 						} else {
 							console.warn(`Could not find node with id ${directive.data.subject.id}`);
+						}
+					} else if (directive.type === "addNodes") {
+						for (const newNode of directive.data) {
+							if (!newNode.id) continue;
+							const node = pr.timelineItems.nodes.find((_: any) => _.id === newNode.id);
+							if (!node) {
+								pr.timelineItems.nodes.push(newNode);
+							} else {
+								console.warn(`Node already exists: id ${directive.data.subject.id}`);
+							}
 						}
 					} else if (directive.type === "updatePullRequestReviewComment") {
 						let done = false;

--- a/shared/ui/store/providerPullRequests/reducer.ts
+++ b/shared/ui/store/providerPullRequests/reducer.ts
@@ -137,7 +137,8 @@ export function reduceProviderPullRequests(
 			const newState = createNewObject(state, action);
 			newState[action.payload.providerId][action.payload.id] = {
 				...newState[action.payload.providerId][action.payload.id],
-				conversations: action.payload.pullRequest
+				conversations: action.payload.pullRequest,
+				conversationsLastFetch: Date.now()
 			};
 			return {
 				myPullRequests: { ...state.myPullRequests },
@@ -353,7 +354,6 @@ export const getCurrentProviderPullRequest = createSelector(
 );
 export const getCurrentProviderPullRequestLastUpdated = createSelector(
 	getCurrentProviderPullRequest,
-
 	providerPullRequest => {
 		if (!providerPullRequest) return undefined;
 		return providerPullRequest &&
@@ -411,3 +411,7 @@ export const getProviderPullRequestCollaborators = createSelector(
 		return currentPr ? currentPr.collaborators : [];
 	}
 );
+
+export const isAnHourOld = conversationsLastFetch => {
+	return conversationsLastFetch > 0 && Date.now() - conversationsLastFetch > 60 * 60 * 1000;
+};

--- a/shared/ui/store/providerPullRequests/reducer.ts
+++ b/shared/ui/store/providerPullRequests/reducer.ts
@@ -279,6 +279,11 @@ export function reduceProviderPullRequests(
 						} else {
 							console.warn(`Could not find node with id ${directive.data.id}`);
 						}
+					} else if (directive.type === "updatePullRequestReviewers") {
+						pr.reviewRequests.nodes.length = 0;
+						for (const data of directive.data) {
+							pr.reviewRequests.nodes.push(data);
+						}
 					} else if (directive.type === "updatePullRequest") {
 						for (const key in directive.data) {
 							if (directive.data[key] && Array.isArray(directive.data[key].nodes)) {

--- a/shared/ui/store/providerPullRequests/reducer.ts
+++ b/shared/ui/store/providerPullRequests/reducer.ts
@@ -282,7 +282,7 @@ export function reduceProviderPullRequests(
 								break;
 							}
 						} else {
-							console.warn(`Could not find node with id ${directive.data.subject.id}`);
+							console.warn(`Could not find node with id ${directive.data.id}`);
 						}
 					} else if (directive.type === "updatePullRequestReview") {
 						const node = pr.timelineItems.nodes.find(_ => _.id === directive.data.id);
@@ -291,11 +291,42 @@ export function reduceProviderPullRequests(
 								node[key] = directive.data[key];
 							}
 						} else {
-							console.warn(`Could not find node with id ${directive.data.subject.id}`);
+							console.warn(`Could not find node with id ${directive.data.id}`);
 						}
 					} else if (directive.type === "updatePullRequest") {
 						for (const key in directive.data) {
 							pr[key] = directive.data[key];
+						}
+					} else if (
+						directive.type === "resolveReviewThread" ||
+						directive.type === "unresolveReviewThread"
+					) {
+						const nodeWrapper = pr.reviewThreads.edges.find(
+							_ => _.node.id === directive.data.threadId
+						);
+						if (nodeWrapper && nodeWrapper.node) {
+							for (const key in directive.data) {
+								nodeWrapper.node[key] = directive.data[key];
+							}
+						} else {
+							console.warn(`Could not find node with id ${directive.data.threadId}`);
+						}
+
+						const reviews = pr.timelineItems.nodes.filter(
+							_ => _.__typename === "PullRequestReview"
+						);
+						if (reviews) {
+							for (const review of reviews) {
+								for (const comment of review.comments.nodes) {
+									if (comment.threadId !== directive.data.threadId) continue;
+
+									for (const key in directive.data) {
+										comment[key] = directive.data[key];
+									}
+
+									break;
+								}
+							}
 						}
 					}
 				}

--- a/shared/ui/store/providerPullRequests/reducer.ts
+++ b/shared/ui/store/providerPullRequests/reducer.ts
@@ -351,7 +351,19 @@ export const getCurrentProviderPullRequest = createSelector(
 		return undefined;
 	}
 );
+export const getCurrentProviderPullRequestLastUpdated = createSelector(
+	getCurrentProviderPullRequest,
 
+	providerPullRequest => {
+		if (!providerPullRequest) return undefined;
+		return providerPullRequest &&
+			providerPullRequest.conversations &&
+			providerPullRequest.conversations.repository &&
+			providerPullRequest.conversations.repository.pullRequest
+			? providerPullRequest.conversations.repository.pullRequest.updatedAt
+			: undefined;
+	}
+);
 /**
  *  Attempts to get a CS repo for the current PR
  */

--- a/shared/ui/store/providerPullRequests/reducer.ts
+++ b/shared/ui/store/providerPullRequests/reducer.ts
@@ -281,7 +281,15 @@ export function reduceProviderPullRequests(
 						}
 					} else if (directive.type === "updatePullRequest") {
 						for (const key in directive.data) {
-							pr[key] = directive.data[key];
+							if (directive.data[key] && Array.isArray(directive.data[key].nodes)) {
+								// clear out the array, but keep its reference
+								pr[key].nodes.length = 0;
+								for (const n of directive.data[key].nodes) {
+									pr[key].nodes.push(n);
+								}
+							} else {
+								pr[key] = directive.data[key];
+							}
 						}
 					} else if (
 						directive.type === "resolveReviewThread" ||

--- a/shared/ui/store/providerPullRequests/types.ts
+++ b/shared/ui/store/providerPullRequests/types.ts
@@ -36,6 +36,13 @@ export type ProviderPullRequestsState = {
 	pullRequests: Index<
 		Index<{
 			conversations: any;
+
+			/**
+			 * Client side date tracking of when this was last added to the redux store
+			 *
+			 * @type {(number | undefined)}
+			 */
+			conversationsLastFetch: number | undefined;
 			files?: any[];
 			collaborators?: any[];
 			commits?: any[];

--- a/shared/ui/store/providerPullRequests/types.ts
+++ b/shared/ui/store/providerPullRequests/types.ts
@@ -12,7 +12,8 @@ export enum ProviderPullRequestActionsTypes {
 	ClearPullRequestFiles = "@providerPullRequests/ClearFiles",
 	ClearPullRequestCommits = "@providerPullRequests/ClearCommits",
 	AddPullRequestError = "@providerPullRequests/AddError",
-	ClearPullRequestError = "@providerPullRequests/ClearError"
+	ClearPullRequestError = "@providerPullRequests/ClearError",
+	HandleDirectives = "@providerPullRequests/HandleDirectives"
 }
 
 /**


### PR DESCRIPTION
This PR addresses:
https://trello.com/c/fI2rncPS/5221-deal-with-gh-rate-limiting
https://trello.com/c/B05DXmhA/5287-when-clicking-through-to-a-pr-from-the-list-check-cache-age
https://trello.com/c/IAg64kSs/5295-add-converttodraftevent-readyforreview-timeline-events


As part of the overall strategy to reduce the cost of our GH usage these changes have been made:

1) reduce the polling we do client-side from once a minute for two hours hour, to once a minute for 1 hour. this is the scenario where you're just sitting on a PR in the webview.
2) update agent responses to include _how_ to update the redux store rather than re-fetching the entire PR. this idea was borrowed from how our broadcaster works (hence `directives`). see below about directives.


directives:
updates how updates from GH GraphQl mutations are incorporated into the client-side code. Instead re-fetching the entire PR, now most GH responses include a `directives` object which includes the data that was updated, as well as a `type`. this `type` is used to update slices of the data in the redux store. 

Currently, the `x` methods have been re-worked to use a directive: 

```
X updateReviewComment 
X updateIssueComment
X updatePullRequestBody
x updateReview
x updateReviewComment
x toggleReactions
x lockPullRequest
x unlockPullRequest
x updatePullRequestTitle
x mergePullRequest
x toggleMilestoneOnPullRequest
x toggleProjectOnPullRequest
x resolveReviewThread
x unresolveReviewThread
x setAssigneeOnPullRequest
x setLabelOnPullRequest
x addReviewerToPullRequest
x removeReviewerFromPullRequest
x createPullRequestComment
x createPullRequestCommentAndClose
x createPullRequestCommentAndReopen
x deletePullRequestComment

deletePullRequestReview
addPullRequestReview
submitReview
```

Further areas for improvement:

1) complete the methods without an `x` above (slightly more complex scenarios)
2) cache labels, reviewers, assignees, projects, milestones. currently we get this at-will, but we could save 1 point for each `GET`
3) ensure PR comment fetching strategy is as streamlined as possible -- this query can be heavy.
4) consider paging or a "load more" for PRs instead of getting all timeline events
