### PR TITLE
git remote ssh alias

### DIFF
--- a/shared/agent/src/git/gitService.ts
+++ b/shared/agent/src/git/gitService.ts
@@ -644,7 +644,7 @@ export class GitService implements IGitService, Disposable {
 	private async _getRepoRemotes(repoPath: string) {
 		try {
 			const data = await git({ cwd: repoPath }, "remote", "-v");
-			return GitRemoteParser.parse(data, repoPath);
+			return await GitRemoteParser.parse(data, repoPath);
 		} catch {
 			return [];
 		}


### PR DESCRIPTION
you can recreate this with the following setup...

there are some github & gitlab cloud users that have ssh aliases setup, including some CodeStream users. this PR addresses those users. With a setup like below, you can replicate the issues these users have faced. 

1) This prevents us from certain scenarios where we try to figure out which provider is tied to a remote -- there's some logic that checks if `domain === github.com` and `domain === gitlab.com` -- which will fail in these aliased cases.
2) We end up storing bad data to Mongo. In the case of my beer & cheese remote, we're currently storing a normalizedUrl that looks like `beer.github.com/TeamCodeStream/codestream` which is invalid. it should be `github.com/TeamCodeStream/codestream`

remote...
```
origin  git@beer.github.com-cheese:TeamCodeStream/codestream.git (fetch)
origin  git@beer.github.com-cheese:TeamCodeStream/codestream.git (push)
```

and ssh config entry...

```
Host beer.github.com-cheese
	HostName github.com
	User brian
	IdentityFile ~/.ssh/id_rsa
```

local .git/config

```
[remote "origin"]
	url = git@beer.github.com-cheese:TeamCodeStream/codestream.git
	fetch = +refs/heads/*:refs/remotes/origin/*
```


My main question is to see if there's a scenario where `ssh -G` would fail or be unavailable? it's guarded and will fallback to the current logic if it fails.