### PR TITLE
Feature/gh #406   inject as comment inse

### DIFF
--- a/shared/ui/Stream/InjectAsComment.tsx
+++ b/shared/ui/Stream/InjectAsComment.tsx
@@ -21,7 +21,6 @@ interface Props {
 	setPinned: Function;
 	codemark: CodemarkPlus;
 	replies: any[];
-	marker?: CSMarker;
 	author: CSUser;
 	fetchThread: Function;
 	markerId: String;
@@ -64,43 +63,14 @@ export const InjectAsComment = (connect(mapStateToProps, { fetchThread }) as any
 		const [hasPosts, setHasPosts] = useState(false);
 
 		const inject = () => {
-			const { markerId } = props;
-
-			// let localMarker: CSMarker = {
-			// 	branchWhenCreated: "",
-			// 	code: "",
-			// 	codemarkId: "",
-			// 	commitHashWhenCreated: "",
-			// 	createdAt: 0,
-			// 	creatorId: "",
-			// 	deactivated: false,
-			// 	file: "",
-			// 	fileStreamId: "",
-			// 	id: "",
-			// 	modifiedAt: 0,
-			// 	postId: "",
-			// 	postStreamId: "",
-			// 	referenceLocations: [],
-			// 	remoteCodeUrl: {displayName: "", name: "", url: ""},
-			// 	locationWhenCreated: [],
-			// 	repoId: "",
-			// 	teamId: "",
-			// 	version: 1,
-			// };
-			let localMarker: CSMarker;
-
-			for (let i = 0; i < props.codemark.markers!.length; ++i) {
-				if (markerId == props.codemark.markers![i].id) {
-					localMarker = props.codemark.markers![i];
-				}
-			}			
+			const marker: CSMarker = props.codemark.markers!.find(marker => marker.id === props.markerId)!;
 			
 			HostApi.instance.send(TelemetryRequestType, {
 				eventName: "InjectAsComment",
 				properties: { "Author?": false }
 			});
 			HostApi.instance.send(InsertTextRequestType, {
-				marker: localMarker,
+				marker: marker,
 				text: codemarkAsCommentString(),
 				indentAfterInsert: false // set this to true once vscode fixes their bug
 			});

--- a/shared/ui/Stream/InjectAsComment.tsx
+++ b/shared/ui/Stream/InjectAsComment.tsx
@@ -24,6 +24,7 @@ interface Props {
 	marker?: CSMarker;
 	author: CSUser;
 	fetchThread: Function;
+	markerId: String;
 }
 
 const mapStateToProps = (state, props) => {
@@ -63,12 +64,43 @@ export const InjectAsComment = (connect(mapStateToProps, { fetchThread }) as any
 		const [hasPosts, setHasPosts] = useState(false);
 
 		const inject = () => {
+			const { markerId } = props;
+
+			// let localMarker: CSMarker = {
+			// 	branchWhenCreated: "",
+			// 	code: "",
+			// 	codemarkId: "",
+			// 	commitHashWhenCreated: "",
+			// 	createdAt: 0,
+			// 	creatorId: "",
+			// 	deactivated: false,
+			// 	file: "",
+			// 	fileStreamId: "",
+			// 	id: "",
+			// 	modifiedAt: 0,
+			// 	postId: "",
+			// 	postStreamId: "",
+			// 	referenceLocations: [],
+			// 	remoteCodeUrl: {displayName: "", name: "", url: ""},
+			// 	locationWhenCreated: [],
+			// 	repoId: "",
+			// 	teamId: "",
+			// 	version: 1,
+			// };
+			let localMarker: CSMarker;
+
+			for (let i = 0; i < props.codemark.markers!.length; ++i) {
+				if (markerId == props.codemark.markers![i].id) {
+					localMarker = props.codemark.markers![i];
+				}
+			}			
+			
 			HostApi.instance.send(TelemetryRequestType, {
 				eventName: "InjectAsComment",
 				properties: { "Author?": false }
 			});
 			HostApi.instance.send(InsertTextRequestType, {
-				marker: props.marker || props.codemark.markers![0],
+				marker: localMarker,
 				text: codemarkAsCommentString(),
 				indentAfterInsert: false // set this to true once vscode fixes their bug
 			});


### PR DESCRIPTION
Fixes customer issue GH #406 where comments inject in wrong location when there are multiple markers.