### PR TITLE
add check for uppercase pr template files

### DIFF
--- a/shared/agent/src/managers/reviewsManager.ts
+++ b/shared/agent/src/managers/reviewsManager.ts
@@ -813,8 +813,11 @@ export class ReviewsManager extends CachedEntityManagerBase<CSReview> {
 
 			const pullRequestTemplate =
 				(await xfs.readText(path.join(repo.path, "pull_request_template.md"))) ||
+				(await xfs.readText(path.join(repo.path, "PULL_REQUEST_TEMPLATE.md"))) ||
 				(await xfs.readText(path.join(repo.path, "docs/pull_request_template.md"))) ||
-				(await xfs.readText(path.join(repo.path, ".github/pull_request_template.md")));
+				(await xfs.readText(path.join(repo.path, "docs/PULL_REQUEST_TEMPLATE.md"))) ||
+				(await xfs.readText(path.join(repo.path, ".github/pull_request_template.md"))) ||
+				(await xfs.readText(path.join(repo.path, ".github/PULL_REQUEST_TEMPLATE.md")));
 
 			const baseBranchRemote = await git.getBranchRemote(repo.path, baseRefName!);
 			const commitsBehindOrigin = await git.getBranchCommitsStatus(


### PR DESCRIPTION
Unsure if should be checking for uppercase directories as well as if .md should be uppercase. Just added checks for uppercase file names


[Changes reviewed on CodeStream](https://api.codestream.com/r/W75JY6zGmBhgt48D/KUjDLoEHQGSh8UeZWcWX8Q?src=GitHub) by brian on Mar 8, 2021

**This PR Addresses:**  
[Check for PR template file should be case insensitive](https://trello.com/c/nl2JVXd6/5737-check-for-pr-template-file-should-be-case-insensitive)  


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>