### PR TITLE
feat: restyle notifications panel

### DIFF
--- a/shared/ui/Stream/Notifications.tsx
+++ b/shared/ui/Stream/Notifications.tsx
@@ -117,6 +117,23 @@ export const Notifications = props => {
 								Don't automatically follow any codemarks or feedback requests
 							</Radio>
 						</RadioGroup>
+						{derivedState.hasDesktopNotifications && derivedState.notificationDeliverySupported && (
+							<div style={{ marginTop: "20px" }}>
+								<p className="explainer">Deliver notifications via:</p>
+								<RadioGroup
+									name="delivery"
+									selectedValue={derivedState.notificationDeliveryPreference}
+									onChange={handleChangeDelivery}
+									loading={loadingDelivery}
+								>
+									<Radio value={CSNotificationDeliveryPreference.All}>Email &amp; Desktop</Radio>
+									<Radio value={CSNotificationDeliveryPreference.EmailOnly}>Email only</Radio>
+									<Radio value={CSNotificationDeliveryPreference.ToastOnly}>Desktop only</Radio>
+									<Radio value={CSNotificationDeliveryPreference.Off}>None</Radio>
+								</RadioGroup>
+							</div>
+						)}
+						<h3>Other Email Notifications</h3>
 						<div style={{ marginTop: "20px" }}>
 							<Checkbox
 								name="frReminders"
@@ -147,22 +164,6 @@ export const Notifications = props => {
 								Send me weekly emails summarizing my activity
 							</Checkbox>
 						</div>
-						{derivedState.hasDesktopNotifications && derivedState.notificationDeliverySupported && (
-							<div style={{ marginTop: "20px" }}>
-								<p className="explainer">Deliver notifications via:</p>
-								<RadioGroup
-									name="delivery"
-									selectedValue={derivedState.notificationDeliveryPreference}
-									onChange={handleChangeDelivery}
-									loading={loadingDelivery}
-								>
-									<Radio value={CSNotificationDeliveryPreference.All}>Email &amp; Desktop</Radio>
-									<Radio value={CSNotificationDeliveryPreference.EmailOnly}>Email only</Radio>
-									<Radio value={CSNotificationDeliveryPreference.ToastOnly}>Desktop only</Radio>
-									<Radio value={CSNotificationDeliveryPreference.Off}>None</Radio>
-								</RadioGroup>
-							</div>
-						)}
 						<p>&nbsp;</p>
 
 						<p>


### PR DESCRIPTION
Extremely simple html change: Just moved the 3 checkboxes down and added an "Other Email Notifications" header as described in the ticket.


[Changes reviewed on CodeStream](https://api.codestream.com/r/W75JY6zGmBhgt48D/UtBX8Yt3T9eIl9WUp66pWg?src=GitHub) by brian on Mar 11, 2021

**This PR Addresses:**  
[Update Notification Settings page](https://trello.com/c/pZdJeNQK/5785-update-notification-settings-page)  


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>