### PR TITLE
Youtrack issues never go away

### DIFF
--- a/shared/agent/src/providers/youtrack.ts
+++ b/shared/agent/src/providers/youtrack.ts
@@ -84,7 +84,7 @@ export class YouTrackProvider extends ThirdPartyIssueProviderBase<CSYouTrackProv
 		const response = await this.get<YouTrackCard[]>(
 			`/issues?${qs.stringify({
 				fields: "id,idReadable,modified,summary,description",
-				query: "for: me"
+				query: "for: me state:unresolved"
 			})}`
 		);
 		const url =


### PR DESCRIPTION
Added a filter to the YouTrack 'getCards' method to only get the issues that are 'unresolved'.

**This PR Addresses:**  
[YouTrack issues never go away in Issues section](https://trello.com/c/O697mJr9/5646-youtrack-issues-never-go-away-in-issues-section)  


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>