### PR TITLE
Added button below issue dropdown to request issue providers

### DIFF
--- a/shared/ui/Stream/CrossPostIssueControls/IssueDropdown.tsx
+++ b/shared/ui/Stream/CrossPostIssueControls/IssueDropdown.tsx
@@ -1094,6 +1094,12 @@ export const IssueList = React.memo((props: React.PropsWithChildren<IssueListPro
 									);
 								})}
 							</IntegrationButtons>
+							<IssueMissing>
+								Don't see your service?{" "}
+								<a href="https://github.com/TeamCodeStream/codestream/issues?q=is%3Aissue+is%3Aopen+label%3A%22issue+tracker%22">
+									Let us know.
+								</a>
+							</IssueMissing>
 						</>
 					)}
 					{firstLoad && <LoadingMessage align="left">Loading...</LoadingMessage>}
@@ -1308,4 +1314,9 @@ const Linkish = styled.span`
 	:hover {
 		color: var(--text-color-highlight);
 	}
+`;
+
+const IssueMissing = styled.div`
+	text-align: center;
+	padding: 0px 20px 0px 20px;
 `;

--- a/shared/ui/Stream/CrossPostIssueControls/IssueDropdown.tsx
+++ b/shared/ui/Stream/CrossPostIssueControls/IssueDropdown.tsx
@@ -42,6 +42,7 @@ import { PaneHeader, PaneBody, PaneState } from "@codestream/webview/src/compone
 import { StartWork } from "../StartWork";
 import { mapFilter } from "@codestream/webview/utils";
 import { isOnPrem } from "../../store/configs/reducer";
+import { Link } from "../Link";
 
 interface ProviderInfo {
 	provider: ThirdPartyProviderConfig;
@@ -1096,9 +1097,9 @@ export const IssueList = React.memo((props: React.PropsWithChildren<IssueListPro
 							</IntegrationButtons>
 							<IssueMissing>
 								Don't see your service?{" "}
-								<a href="https://github.com/TeamCodeStream/codestream/issues?q=is%3Aissue+is%3Aopen+label%3A%22issue+tracker%22">
+								<Link href="https://github.com/TeamCodeStream/codestream/issues?q=is%3Aissue+is%3Aopen+label%3A%22issue+tracker%22">
 									Let us know.
-								</a>
+								</Link>
 							</IssueMissing>
 						</>
 					)}


### PR DESCRIPTION
Added a "Don't see your service? Let us know." button below the issue dropdown that links to Github to request a new issue provider. Simple ui change in issuedropdown.tsx.

**This PR Addresses:**  
[add a "my issue tracker isn't listed" UX below the buttons](https://trello.com/c/y4hWqLP2/4984-add-a-my-issue-tracker-isnt-listed-ux-below-the-buttons)  


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>