### PR TITLE
Made issue filter layout consistent with PR layout

### DIFF
--- a/shared/ui/Stream/ConfigurePullRequestQuery.tsx
+++ b/shared/ui/Stream/ConfigurePullRequestQuery.tsx
@@ -191,7 +191,7 @@ export function ConfigurePullRequestQuery(props: Props) {
 								)}
 								<input
 									autoFocus
-									placeholder="Label"
+									placeholder="Name Your Custom Query (optional)"
 									name="query-name"
 									value={nameField}
 									className="input-text control"

--- a/shared/ui/Stream/CrossPostIssueControls/IssueDropdown.tsx
+++ b/shared/ui/Stream/CrossPostIssueControls/IssueDropdown.tsx
@@ -950,6 +950,16 @@ export const IssueList = React.memo((props: React.PropsWithChildren<IssueListPro
 				<Dialog title="Create a Custom Filter" onClose={closeCustomFilter}>
 					<div className="standard-form">
 						<fieldset className="form-body">
+						<span dangerouslySetInnerHTML={{ __html: providerDisplay.customFilterHelp || "" }} />
+						<span> {providerDisplay.customFilterExample}</span>
+						<input
+								type="text"
+								className="input-text control"
+								value={newCustomFilterName}
+								onChange={e => setNewCustomFilterName(e.target.value)}
+								placeholder="Name Your Custom Filter (optional)"
+								style={{ margin: "20px 0 10px 0" }}
+							/>
 							{!validQuery && (
 								<ErrorMessage>
 									<small className="error-message">
@@ -967,17 +977,7 @@ export const IssueList = React.memo((props: React.PropsWithChildren<IssueListPro
 								value={newCustomFilter}
 								onChange={e => setNewCustomFilter(e.target.value)}
 								placeholder="Enter Custom Filter"
-							/>
-							<div style={{ margin: "10px 0" }}>{providerDisplay.customFilterExample}</div>
-							<span dangerouslySetInnerHTML={{ __html: providerDisplay.customFilterHelp || "" }} />
-							<input
-								type="text"
-								className="input-text control"
-								value={newCustomFilterName}
-								onChange={e => setNewCustomFilterName(e.target.value)}
-								placeholder="Name Your Custom Filter (optional)"
-								style={{ margin: "20px 0 15px 0" }}
-							/>
+							/>							
 							<ButtonRow>
 								<Button
 									disabled={newCustomFilter.length == 0}


### PR DESCRIPTION
Just made the issue filter layout consistent with PR layout, also changed PR query filter title as I thought "label" was ambigous.


[Changes reviewed on CodeStream](https://api.codestream.com/r/W75JY6zGmBhgt48D/s-1LAl1uRWGNO2OHOzCtJw?src=GitHub) by brian on May 17, 2021

**This PR Addresses:**  
[updated PR doesn't reflect that change in the my PRs list](https://trello.com/c/xtgVpcE4/5296-updated-pr-doesnt-reflect-that-change-in-the-my-prs-list)  


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>