### PR TITLE
Fix start review

### DIFF
--- a/shared/ui/Stream/CodemarkForm.tsx
+++ b/shared/ui/Stream/CodemarkForm.tsx
@@ -549,11 +549,11 @@ class CodemarkForm extends React.Component<Props, State> {
 
 					let prRange;
 					switch (codeBlock.scm.branch) {
-						case textEditorUriContext.baseBranch:
-							prRange = changedPrLine.baseLinesChanged;
-							break;
 						case textEditorUriContext.headBranch:
 							prRange = changedPrLine.headLinesChanged;
+							break;
+						case textEditorUriContext.baseBranch:
+							prRange = changedPrLine.baseLinesChanged;
 							break;
 						default:
 							return false;
@@ -570,6 +570,8 @@ class CodemarkForm extends React.Component<Props, State> {
 					);
 				});
 			});
+			console.log("isInsidePR was judged here:", isInsidePrChangeSet);
+
 
 			this.setState({ isInsidePrChangeSet });
 		}
@@ -2454,7 +2456,15 @@ class CodemarkForm extends React.Component<Props, State> {
 										: "Submit"}
 								</Button>
 							</Tooltip>
+							{console.log("pr context:", this.props.textEditorUriHasPullRequestContext)}
+							{console.log("isInsidePrChangeSet:", this.state.isInsidePrChangeSet)}
+
 							{this.props.textEditorUriHasPullRequestContext && this.state.isInsidePrChangeSet && (
+								<>
+								{/* {console.log("hi", hasError)}
+								{console.log(this.props.textEditorUriHasPullRequestContext)}
+								{console.log(hasExistingPullRequestReview)} */}
+
 								<Tooltip title={hasError ? null : reviewTooltip} placement="bottom" delay={1}>
 									<Button
 										key="submit-review"
@@ -2479,6 +2489,7 @@ class CodemarkForm extends React.Component<Props, State> {
 										{!hasExistingPullRequestReview && <>Start a review</>}
 									</Button>
 								</Tooltip>
+								</>
 							)}
 							{/*
 							<span className="hint">Styling with Markdown is supported</span>

--- a/shared/ui/Stream/CodemarkForm.tsx
+++ b/shared/ui/Stream/CodemarkForm.tsx
@@ -570,8 +570,6 @@ class CodemarkForm extends React.Component<Props, State> {
 					);
 				});
 			});
-			console.log("isInsidePR was judged here:", isInsidePrChangeSet);
-
 
 			this.setState({ isInsidePrChangeSet });
 		}
@@ -2461,34 +2459,34 @@ class CodemarkForm extends React.Component<Props, State> {
 
 							{this.props.textEditorUriHasPullRequestContext && this.state.isInsidePrChangeSet && (
 								<>
-								{/* {console.log("hi", hasError)}
+									{/* {console.log("hi", hasError)}
 								{console.log(this.props.textEditorUriHasPullRequestContext)}
 								{console.log(hasExistingPullRequestReview)} */}
 
-								<Tooltip title={hasError ? null : reviewTooltip} placement="bottom" delay={1}>
-									<Button
-										key="submit-review"
-										loading={this.state.isReviewLoading}
-										disabled={hasError}
-										onClick={e => {
-											this.setState({ isProviderReview: true }, () => {
-												this.handleClickSubmit(e);
-											});
-										}}
-										style={{
-											paddingLeft: "10px",
-											paddingRight: "10px",
-											// fixed width to handle the isReviewLoading case
-											width: "auto",
-											marginRight: 0
-										}}
-										className="control-button"
-										type="submit"
-									>
-										{hasExistingPullRequestReview && <>Add to review</>}
-										{!hasExistingPullRequestReview && <>Start a review</>}
-									</Button>
-								</Tooltip>
+									<Tooltip title={hasError ? null : reviewTooltip} placement="bottom" delay={1}>
+										<Button
+											key="submit-review"
+											loading={this.state.isReviewLoading}
+											disabled={hasError}
+											onClick={e => {
+												this.setState({ isProviderReview: true }, () => {
+													this.handleClickSubmit(e);
+												});
+											}}
+											style={{
+												paddingLeft: "10px",
+												paddingRight: "10px",
+												// fixed width to handle the isReviewLoading case
+												width: "auto",
+												marginRight: 0
+											}}
+											className="control-button"
+											type="submit"
+										>
+											{hasExistingPullRequestReview && <>Add to review</>}
+											{!hasExistingPullRequestReview && <>Start a review</>}
+										</Button>
+									</Tooltip>
 								</>
 							)}
 							{/*

--- a/shared/ui/Stream/CodemarkForm.tsx
+++ b/shared/ui/Stream/CodemarkForm.tsx
@@ -2454,40 +2454,31 @@ class CodemarkForm extends React.Component<Props, State> {
 										: "Submit"}
 								</Button>
 							</Tooltip>
-							{console.log("pr context:", this.props.textEditorUriHasPullRequestContext)}
-							{console.log("isInsidePrChangeSet:", this.state.isInsidePrChangeSet)}
-
 							{this.props.textEditorUriHasPullRequestContext && this.state.isInsidePrChangeSet && (
-								<>
-									{/* {console.log("hi", hasError)}
-								{console.log(this.props.textEditorUriHasPullRequestContext)}
-								{console.log(hasExistingPullRequestReview)} */}
-
-									<Tooltip title={hasError ? null : reviewTooltip} placement="bottom" delay={1}>
-										<Button
-											key="submit-review"
-											loading={this.state.isReviewLoading}
-											disabled={hasError}
-											onClick={e => {
-												this.setState({ isProviderReview: true }, () => {
-													this.handleClickSubmit(e);
-												});
-											}}
-											style={{
-												paddingLeft: "10px",
-												paddingRight: "10px",
-												// fixed width to handle the isReviewLoading case
-												width: "auto",
-												marginRight: 0
-											}}
-											className="control-button"
-											type="submit"
-										>
-											{hasExistingPullRequestReview && <>Add to review</>}
-											{!hasExistingPullRequestReview && <>Start a review</>}
-										</Button>
-									</Tooltip>
-								</>
+								<Tooltip title={hasError ? null : reviewTooltip} placement="bottom" delay={1}>
+									<Button
+										key="submit-review"
+										loading={this.state.isReviewLoading}
+										disabled={hasError}
+										onClick={e => {
+											this.setState({ isProviderReview: true }, () => {
+												this.handleClickSubmit(e);
+											});
+										}}
+										style={{
+											paddingLeft: "10px",
+											paddingRight: "10px",
+											// fixed width to handle the isReviewLoading case
+											width: "auto",
+											marginRight: 0
+										}}
+										className="control-button"
+										type="submit"
+									>
+										{hasExistingPullRequestReview && <>Add to review</>}
+										{!hasExistingPullRequestReview && <>Start a review</>}
+									</Button>
+								</Tooltip>
 							)}
 							{/*
 							<span className="hint">Styling with Markdown is supported</span>


### PR DESCRIPTION
There was a bug where if you tried to  start a review on a PR by commenting on the  code and you weren't selecting "all commits" you weren't able to start a review.

The issue was that when you weren't selecting all commits the textEditorUriContext.headbranch and basebranch were both the branch name (for example 'my-cool-branch'). But, if you were selecting all commits the basebranch would be 'main' and the headBranch would be the base branch (e.g. 'my-cool-branch') therefore it was entering the wrong case in the switch statement.


Therefore, switching the order of the cases sets the prRange to the, what I believe to be, correct values.