### PR TITLE
Feature/updated pr doesnt2

### DIFF
--- a/shared/agent/src/protocol/agent.protocol.providers.ts
+++ b/shared/agent/src/protocol/agent.protocol.providers.ts
@@ -478,14 +478,7 @@ export interface FetchThirdPartyPullRequestPullRequest {
 		url: string;
 	};
 	headRefOid: string;
-	labels: {
-		nodes: {
-			id: string;
-			color: string;
-			description: string;
-			name: string;
-		}[];
-	};
+	labels: Labels;
 	number: number;
 	state: string;
 	isDraft?: boolean;
@@ -772,6 +765,10 @@ export interface GetMyPullRequestsRequest {
 	isOpen?: boolean;
 }
 
+export interface Labels { 
+	nodes: { color: string; description: string; name: string; id: string }[] 
+}
+
 export interface GetMyPullRequestsResponse {
 	id: string;
 	providerId: string;
@@ -795,7 +792,11 @@ export interface GetMyPullRequestsResponse {
 	isDraft?: boolean;
 	updatedAt: string;
 	lastEditedAt: string;
-	labels: { nodes: { color: string; description: string; name: string; id: string }[] };
+	labels: Labels;
+}
+
+export interface PullRequestGroups {
+	[key: string]: GetMyPullRequestsResponse[][];
 }
 
 export type MergeMethod = "MERGE" | "SQUASH" | "REBASE";

--- a/shared/agent/src/protocol/agent.protocol.providers.ts
+++ b/shared/agent/src/protocol/agent.protocol.providers.ts
@@ -795,10 +795,6 @@ export interface GetMyPullRequestsResponse {
 	labels: Labels;
 }
 
-export interface PullRequestGroups {
-	[key: string]: GetMyPullRequestsResponse[][];
-}
-
 export type MergeMethod = "MERGE" | "SQUASH" | "REBASE";
 
 export interface MergePullRequestRequest {

--- a/shared/ui/Stream/OpenPullRequests.tsx
+++ b/shared/ui/Stream/OpenPullRequests.tsx
@@ -404,7 +404,6 @@ export const OpenPullRequests = React.memo((props: Props) => {
 		// need to check if it was new/editing pullRequestQueries or just updating other preferences
 		if (!isEqual(queries, newQueries)) {
 			setQueries(newQueries);
-			// update store
 		}
 	}, [derivedState.pullRequestQueries]);
 

--- a/shared/ui/Stream/PullRequest.tsx
+++ b/shared/ui/Stream/PullRequest.tsx
@@ -118,10 +118,10 @@ export const PullRequest = () => {
 		const currentUser = state.users[state.session.userId!] as CSMe;
 		const team = state.teams[state.context.currentTeamId];
 		const currentPullRequest = getCurrentProviderPullRequest(state);
-		console.log("CURRENT PULL REQEUST")
-		console.log(currentPullRequest);
-		console.log(state.context.currentPullRequest);
-		console.log(state);
+		// console.log("CURRENT PULL REQEUST")
+		// console.log(currentPullRequest);
+		// console.log(state.context.currentPullRequest);
+		// console.log(state);
 		const providerPullRequestLastUpdated = getCurrentProviderPullRequestLastUpdated(state);
 		return {
 			viewPreference: getPreferences(state).pullRequestView || "auto",
@@ -380,14 +380,13 @@ export const PullRequest = () => {
 		setIsLoadingMessage("Saving Title...");
 		setSavingTitle(true);
 		await dispatch(api("updatePullRequestTitle", { title }));
-		console.log("check hERE");
-		console.log(derivedState.currentPullRequestProviderId!,
-			derivedState.currentPullRequestId!);
-		console.log('------')
-		// call action to update myPullRequests
-		dispatch(updateMyPullRequests(derivedState.currentPullRequestProviderId!,
-			derivedState.currentPullRequestId!, {title: title, labels: derivedState.labels}))
-		console.log("did some titling!!");
+		dispatch(
+			updateMyPullRequests(
+				derivedState.currentPullRequestProviderId!,
+				derivedState.currentPullRequestId!,
+				{ title: title, labels: derivedState.labels }
+			)
+		);
 		setSavingTitle(false);
 		setEditingTitle(false);
 		setIsLoadingMessage("");

--- a/shared/ui/Stream/PullRequest.tsx
+++ b/shared/ui/Stream/PullRequest.tsx
@@ -57,7 +57,8 @@ import {
 	clearPullRequestFiles,
 	getPullRequestConversations,
 	clearPullRequestCommits,
-	api
+	api,
+	updateMyPullRequests
 } from "../store/providerPullRequests/actions";
 import {
 	getCurrentProviderPullRequest,
@@ -117,6 +118,10 @@ export const PullRequest = () => {
 		const currentUser = state.users[state.session.userId!] as CSMe;
 		const team = state.teams[state.context.currentTeamId];
 		const currentPullRequest = getCurrentProviderPullRequest(state);
+		console.log("CURRENT PULL REQEUST")
+		console.log(currentPullRequest);
+		console.log(state.context.currentPullRequest);
+		console.log(state);
 		const providerPullRequestLastUpdated = getCurrentProviderPullRequestLastUpdated(state);
 		return {
 			viewPreference: getPreferences(state).pullRequestView || "auto",
@@ -142,7 +147,8 @@ export const PullRequest = () => {
 			textEditorUri: state.editorContext.textEditorUri,
 			reposState: state.repos,
 			checkoutBranch: state.context.pullRequestCheckoutBranch,
-			currentRepo: getProviderPullRequestRepo(state)
+			currentRepo: getProviderPullRequestRepo(state),
+			labels: currentPullRequest?.conversations?.repository?.pullRequest?.labels
 		};
 	});
 
@@ -374,6 +380,14 @@ export const PullRequest = () => {
 		setIsLoadingMessage("Saving Title...");
 		setSavingTitle(true);
 		await dispatch(api("updatePullRequestTitle", { title }));
+		console.log("check hERE");
+		console.log(derivedState.currentPullRequestProviderId!,
+			derivedState.currentPullRequestId!);
+		console.log('------')
+		// call action to update myPullRequests
+		dispatch(updateMyPullRequests(derivedState.currentPullRequestProviderId!,
+			derivedState.currentPullRequestId!, {title: title, labels: derivedState.labels}))
+		console.log("did some titling!!");
 		setSavingTitle(false);
 		setEditingTitle(false);
 		setIsLoadingMessage("");

--- a/shared/ui/Stream/PullRequestConversationTab.tsx
+++ b/shared/ui/Stream/PullRequestConversationTab.tsx
@@ -658,16 +658,12 @@ export const PullRequestConversationTab = (props: {
 							true
 						)
 					);
-
-					if (resp && resp.length) {
-						console.warn("conversationed some pulls: ", resp);
-					}
 				}
 			} catch (error) {
 				console.error(error);
 			}
 		}
-	}
+	};
 
 	const fetchAvailableProjects = async (e?) => {
 		const projects = (await dispatch(

--- a/shared/ui/Stream/PullRequestConversationTab.tsx
+++ b/shared/ui/Stream/PullRequestConversationTab.tsx
@@ -58,12 +58,13 @@ import { setUserPreference } from "./actions";
 import copy from "copy-to-clipboard";
 import { PullRequestBottomComment } from "./PullRequestBottomComment";
 import { reduce as _reduce, groupBy as _groupBy, map as _map } from "lodash-es";
-import { api } from "../store/providerPullRequests/actions";
+import { api, updatePullRequestLabels } from "../store/providerPullRequests/actions";
 import { ColorDonut, PullRequestReviewStatus } from "./PullRequestReviewStatus";
 import { autoCheckedMergeabilityStatus } from "./PullRequest";
 import cx from "classnames";
 import { getPRLabel } from "../store/providers/reducer";
 import { useDidMount } from "../utilities/hooks";
+import { ProviderPullRequestActionsTypes } from "../store/providerPullRequests/types";
 
 const emojiMap: { [key: string]: string } = require("../../agent/emoji/emojis.json");
 const emojiRegex = /:([-+_a-z0-9]+):/g;
@@ -227,6 +228,9 @@ export const PullRequestConversationTab = (props: {
 				: undefined,
 			blameMap,
 			currentPullRequest: currentPullRequest,
+			currentPullRequestProviderId: state.context.currentPullRequest
+				? state.context.currentPullRequest.providerId
+				: undefined,
 			pr:
 				currentPullRequest &&
 				currentPullRequest.conversations &&
@@ -596,6 +600,21 @@ export const PullRequestConversationTab = (props: {
 				onOff
 			})
 		);
+		console.log('FIND MEEEEEE')
+		if (availableLabels && availableLabels.length) {
+			console.log(availableLabels);
+			const label: any = availableLabels.find(elem => elem['id'] === id);
+			console.log(label);
+			dispatch(
+				updatePullRequestLabels(
+					derivedState.currentPullRequestProviderId!,
+					derivedState.currentPullRequestId!,
+					label,
+					onOff
+				)
+			);
+		}
+		
 		setIsLoadingMessage("");
 	};
 

--- a/shared/ui/Stream/PullRequestConversationTab.tsx
+++ b/shared/ui/Stream/PullRequestConversationTab.tsx
@@ -499,6 +499,11 @@ export const PullRequestConversationTab = (props: {
 		);
 
 		setIsLoadingMessage("");
+
+		await new Promise(resolve => {
+			setTimeout(resolve, 2000);
+		});
+		fetchPRs();
 	};
 	const addReviewer = async id => {
 		setIsLoadingMessage("Requesting Review...");
@@ -509,6 +514,11 @@ export const PullRequestConversationTab = (props: {
 			})
 		);
 		setIsLoadingMessage("");
+
+		await new Promise(resolve => {
+			setTimeout(resolve, 2000);
+		});
+		fetchPRs();
 	};
 
 	const fetchAvailableAssignees = async (e?) => {
@@ -569,6 +579,11 @@ export const PullRequestConversationTab = (props: {
 			})
 		);
 		setIsLoadingMessage("");
+
+		await new Promise(resolve => {
+			setTimeout(resolve, 2000);
+		});
+		fetchPRs();
 	};
 
 	const fetchAvailableLabels = async (e?) => {
@@ -619,10 +634,12 @@ export const PullRequestConversationTab = (props: {
 		setIsLoadingMessage("");
 
 		await new Promise(resolve => {
-			setTimeout(resolve, 2000);
+			setTimeout(resolve, 5000);
 		});
-		console.log("starting...");
+		fetchPRs();
+	};
 
+	const fetchPRs = async () => {
 		// We need to delay these api requests as we are making a request to make a change (e.g. adding a label)
 		// then refreshing the new data and it takes some time for the back-end to do this
 		for (const connectedProvider of derivedState.PRConnectedProviders) {
@@ -631,8 +648,6 @@ export const PullRequestConversationTab = (props: {
 					const options = { force: true, alreadyLoading: false };
 					const providerQuery: PullRequestQuery[] = queries[connectedProvider.id];
 					const queryStrings = Object.values(providerQuery).map(_ => _.query);
-
-					console.log("queryStrings", queryStrings);
 
 					const resp: any = await dispatch(
 						getMyPullRequests(
@@ -652,7 +667,7 @@ export const PullRequestConversationTab = (props: {
 				console.error(error);
 			}
 		}
-	};
+	}
 
 	const fetchAvailableProjects = async (e?) => {
 		const projects = (await dispatch(
@@ -698,6 +713,11 @@ export const PullRequestConversationTab = (props: {
 			})
 		);
 		setIsLoadingMessage("");
+
+		await new Promise(resolve => {
+			setTimeout(resolve, 2000);
+		});
+		fetchPRs();
 	};
 
 	const fetchAvailableMilestones = async (e?) => {
@@ -749,6 +769,11 @@ export const PullRequestConversationTab = (props: {
 			})
 		);
 		setIsLoadingMessage("");
+
+		await new Promise(resolve => {
+			setTimeout(resolve, 2000);
+		});
+		fetchPRs();
 	};
 
 	// const fetchAvailableIssues = async (e?) => {

--- a/shared/ui/Stream/PullRequestConversationTab.tsx
+++ b/shared/ui/Stream/PullRequestConversationTab.tsx
@@ -634,7 +634,7 @@ export const PullRequestConversationTab = (props: {
 		setIsLoadingMessage("");
 
 		await new Promise(resolve => {
-			setTimeout(resolve, 5000);
+			setTimeout(resolve, 2000);
 		});
 		fetchPRs();
 	};

--- a/shared/ui/src/components/controls/InlineMenu.tsx
+++ b/shared/ui/src/components/controls/InlineMenu.tsx
@@ -74,7 +74,9 @@ export function InlineMenu(props: InlineMenuProps) {
 	};
 
 	const maybeToggleMenu = action => {
-		if (action !== "noop") toggleMenu(action);
+		if (action !== "noop") {
+			toggleMenu(action);
+		}
 		if (props.onChange) props.onChange(action);
 	};
 

--- a/shared/ui/store/providerPullRequests/actions.ts
+++ b/shared/ui/store/providerPullRequests/actions.ts
@@ -15,8 +15,7 @@ import {
 	FetchAssignableUsersRequestType,
 	FetchAssignableUsersResponse,
 	GetCommitsFilesRequestType,
-	GetCommitsFilesResponse,
-	PullRequestGroups
+	GetCommitsFilesResponse
 } from "@codestream/protocols/agent";
 import { CodeStreamState } from "..";
 import { RequestType } from "vscode-languageserver-protocol";

--- a/shared/ui/store/providerPullRequests/actions.ts
+++ b/shared/ui/store/providerPullRequests/actions.ts
@@ -42,14 +42,20 @@ export const _addPullRequestCollaborators = (providerId: string, id: string, col
 		collaborators
 	});
 
-export const updateMyPullRequests = (providerId: string, id: string, pullRequestData: any) => {
-	// update pull request action creator
-	action(ProviderPullRequestActionsTypes.updateMyPullRequests, {
+export const updateMyPullRequests = (providerId: string, id: string, pullRequestData: any) =>
+	action(ProviderPullRequestActionsTypes.UpdateMyPullRequests, {
 		providerId,
 		id,
 		pullRequestData
-	})
-}
+	});
+
+export const updatePullRequestLabels = (providerId: string, prId: string, label: any, onOff: boolean, ) =>
+	action(ProviderPullRequestActionsTypes.UpdatePullRequestLabels, {
+		providerId,
+		prId,
+		label,
+		onOff
+	});
 
 export const _addPullRequestFiles = (
 	providerId: string,
@@ -571,7 +577,7 @@ export const api = <T = any, R = any>(
 			providerId: providerId,
 			params: params
 		})) as any;
-		console.log('check the reesponse here interestting');
+		console.log("check the reesponse here interestting");
 		console.log(response);
 		if (response && (!options || (options && !options.preventClearError))) {
 			dispatch(clearPullRequestError(providerId, pullRequestId));

--- a/shared/ui/store/providerPullRequests/actions.ts
+++ b/shared/ui/store/providerPullRequests/actions.ts
@@ -42,6 +42,15 @@ export const _addPullRequestCollaborators = (providerId: string, id: string, col
 		collaborators
 	});
 
+export const updateMyPullRequests = (providerId: string, id: string, pullRequestData: any) => {
+	// update pull request action creator
+	action(ProviderPullRequestActionsTypes.updateMyPullRequests, {
+		providerId,
+		id,
+		pullRequestData
+	})
+}
+
 export const _addPullRequestFiles = (
 	providerId: string,
 	id: string,
@@ -528,10 +537,13 @@ export const api = <T = any, R = any>(
 		preventErrorReporting?: boolean;
 	}
 ) => async (dispatch, getState: () => CodeStreamState) => {
+	console.log("in api function");
 	let providerId;
 	let pullRequestId;
 	try {
 		const state = getState();
+		console.log("current state");
+		console.log(state);
 		const currentPullRequest = state.context.currentPullRequest;
 		if (!currentPullRequest) {
 			dispatch(
@@ -542,18 +554,25 @@ export const api = <T = any, R = any>(
 			return;
 		}
 		({ providerId, id: pullRequestId } = currentPullRequest);
-
+		console.log("at the params line");
 		params = params || {};
 		if (!params.pullRequestId) params.pullRequestId = pullRequestId;
 		if (currentPullRequest.metadata) {
 			params = { ...params, ...currentPullRequest.metadata };
 			params.metadata = currentPullRequest.metadata;
 		}
+		console.log("executing 3rd party sending ??");
+		console.log(method);
+		console.log(providerId);
+		console.log(params);
+
 		const response = (await HostApi.instance.send(new ExecuteThirdPartyTypedType<T, R>(), {
 			method: method,
 			providerId: providerId,
 			params: params
 		})) as any;
+		console.log('check the reesponse here interestting');
+		console.log(response);
 		if (response && (!options || (options && !options.preventClearError))) {
 			dispatch(clearPullRequestError(providerId, pullRequestId));
 		}
@@ -564,6 +583,8 @@ export const api = <T = any, R = any>(
 				handled: true
 			};
 		}
+		console.log("response:");
+		console.log(response);
 		return response as R;
 	} catch (error) {
 		let errorString = typeof error === "string" ? error : error.message;

--- a/shared/ui/store/providerPullRequests/actions.ts
+++ b/shared/ui/store/providerPullRequests/actions.ts
@@ -43,28 +43,11 @@ export const _addPullRequestCollaborators = (providerId: string, id: string, col
 		collaborators
 	});
 
-export const updatePullRequestGroups = (newGroups: PullRequestGroups) => {
-	return (
-		{
-			type: ProviderPullRequestActionsTypes.UpdatePullRequestGroups,
-			payload: newGroups
-		}
-	)
-};
-
 export const updatePullRequestTitle = (providerId: string, id: string, pullRequestData: any) =>
 	action(ProviderPullRequestActionsTypes.UpdatePullRequestTitle, {
 		providerId,
 		id,
 		pullRequestData
-	});
-
-export const updatePullRequestLabels = (providerId: string, prId: string, label: any, onOff: boolean, ) =>
-	action(ProviderPullRequestActionsTypes.UpdatePullRequestLabels, {
-		providerId,
-		prId,
-		label,
-		onOff
 	});
 
 export const _addPullRequestFiles = (

--- a/shared/ui/store/providerPullRequests/reducer.ts
+++ b/shared/ui/store/providerPullRequests/reducer.ts
@@ -18,7 +18,7 @@ type ProviderPullRequestActions =
 	| ActionType<typeof setCurrentPullRequest>
 	| ActionType<typeof clearCurrentPullRequest>;
 
-const initialState: ProviderPullRequestsState = { pullRequests: {}, myPullRequests: {}, pullRequestGroups: {} };
+const initialState: ProviderPullRequestsState = { pullRequests: {}, myPullRequests: {} };
 
 const createNewObject = (state, action) => {
 	const newState = { ...state.pullRequests };
@@ -51,7 +51,6 @@ export function reduceProviderPullRequests(
 				return {
 					myPullRequests: { ...state.myPullRequests },
 					pullRequests: newState,
-					pullRequestGroups: {...state.pullRequestGroups}
 				};
 			} else if (action.payload) {
 				const newState = { ...state };
@@ -70,10 +69,11 @@ export function reduceProviderPullRequests(
 			newState[action.payload.providerId] = {
 				data: action.payload.data
 			};
+			console.log('REDUCER CHANGED PRS');
+			console.log(newState);
 			return {
 				myPullRequests: newState,
 				pullRequests: { ...state.pullRequests },
-				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.AddPullRequestFiles: {
@@ -90,7 +90,6 @@ export function reduceProviderPullRequests(
 			return {
 				myPullRequests: { ...state.myPullRequests },
 				pullRequests: newState,
-				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.ClearPullRequestFiles: {
@@ -102,7 +101,6 @@ export function reduceProviderPullRequests(
 			return {
 				myPullRequests: { ...state.myPullRequests },
 				pullRequests: newState,
-				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.AddPullRequestCommits: {
@@ -114,7 +112,6 @@ export function reduceProviderPullRequests(
 			return {
 				myPullRequests: { ...state.myPullRequests },
 				pullRequests: newState,
-				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.ClearPullRequestCommits: {
@@ -126,7 +123,6 @@ export function reduceProviderPullRequests(
 			return {
 				myPullRequests: { ...state.myPullRequests },
 				pullRequests: newState,
-				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.AddPullRequestCollaborators: {
@@ -138,22 +134,7 @@ export function reduceProviderPullRequests(
 			return {
 				myPullRequests: { ...state.myPullRequests },
 				pullRequests: newState,
-				pullRequestGroups: {...state.pullRequestGroups}
 			};
-		}
-		case ProviderPullRequestActionsTypes.UpdatePullRequestGroups: {
-			// const newState = {...state.pullRequestGroups};
-
-			console.log('NEW GROUPS RECEIBVED');
-			// console.log(newState);
-			console.log(action);
-			// newState
-
-			return {
-				myPullRequests: {...state.myPullRequests},
-				pullRequests: { ...state.pullRequests },
-				pullRequestGroups: action.payload
-			}
 		}
 		case ProviderPullRequestActionsTypes.UpdatePullRequestTitle: {
 			const newState = {...state.myPullRequests};
@@ -175,47 +156,7 @@ export function reduceProviderPullRequests(
 			return {
 				myPullRequests: newState,
 				pullRequests: {...state.pullRequests},
-				pullRequestGroups: {...state.pullRequestGroups}
 			};
-		}
-		case ProviderPullRequestActionsTypes.UpdatePullRequestLabels: {
-			const newState = {...state.myPullRequests};
-			console.log("reducer entered beast mode.");
-			console.log(action);
-			console.log("new state");
-			console.log(newState);
-
-			newState[action.payload.providerId]['data']?.forEach((arr: any, index) => {
-				// arr?.forEach
-				arr?.forEach((pr, i) => {
-					if (pr.id === action.payload.prId) {
-						if (action.payload.onOff === true) {
-							// add label
-							const labelNodes = newState[action.payload.providerId]['data']![index][i].labels;
-							// console.log("label nodes");
-							// console.log(labelNodes);
-							labelNodes.nodes.push(action.payload.label);
-							// console.log("new label nodes");
-							// console.log(labelNodes);
-							newState[action.payload.providerId]['data']![index][i] = {
-								...newState[action.payload.providerId]['data']![index][i],
-								labels: labelNodes
-							};
-							console.log('updated labels ');
-							console.log(newState);
-						} else {
-							// remove label
-							newState[action.payload.providerId]['data']![index][i].labels.nodes = newState[action.payload.providerId]['data']![index][i].labels.nodes.filter(itm => itm.id !== action.payload.label.id)
-							console.log("label removed")
-							console.log(newState);
-							// pr.labels.nodes = pr.labels.nodes.
-						}
-					}
-					// console.log(pr);
-				})
-			})
-
-			return state;
 		}
 		case ProviderPullRequestActionsTypes.AddPullRequestConversations: {
 			const newState = createNewObject(state, action);
@@ -227,7 +168,6 @@ export function reduceProviderPullRequests(
 			return {
 				myPullRequests: { ...state.myPullRequests },
 				pullRequests: newState,
-				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.ClearPullRequestError: {
@@ -239,7 +179,6 @@ export function reduceProviderPullRequests(
 			return {
 				myPullRequests: { ...state.myPullRequests },
 				pullRequests: newState,
-				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.AddPullRequestError: {
@@ -251,7 +190,6 @@ export function reduceProviderPullRequests(
 			return {
 				myPullRequests: { ...state.myPullRequests },
 				pullRequests: newState,
-				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.HandleDirectives: {
@@ -776,7 +714,6 @@ export function reduceProviderPullRequests(
 			return {
 				myPullRequests: { ...state.myPullRequests },
 				pullRequests: newState,
-				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		// case ProviderPullRequestActionsTypes.ClearPullRequestError: {

--- a/shared/ui/store/providerPullRequests/reducer.ts
+++ b/shared/ui/store/providerPullRequests/reducer.ts
@@ -12,14 +12,13 @@ import {
 	FetchThirdPartyPullRequestPullRequest,
 	GitLabMergeRequest
 } from "@codestream/protocols/agent";
-import { CompletionList } from "vscode-languageserver-types";
 
 type ProviderPullRequestActions =
 	| ActionType<typeof actions>
 	| ActionType<typeof setCurrentPullRequest>
 	| ActionType<typeof clearCurrentPullRequest>;
 
-const initialState: ProviderPullRequestsState = { pullRequests: {}, myPullRequests: {} };
+const initialState: ProviderPullRequestsState = { pullRequests: {}, myPullRequests: {}, pullRequestGroups: {} };
 
 const createNewObject = (state, action) => {
 	const newState = { ...state.pullRequests };
@@ -51,7 +50,8 @@ export function reduceProviderPullRequests(
 				newState[action.payload.providerId][id].error = undefined;
 				return {
 					myPullRequests: { ...state.myPullRequests },
-					pullRequests: newState
+					pullRequests: newState,
+					pullRequestGroups: {...state.pullRequestGroups}
 				};
 			} else if (action.payload) {
 				const newState = { ...state };
@@ -72,7 +72,8 @@ export function reduceProviderPullRequests(
 			};
 			return {
 				myPullRequests: newState,
-				pullRequests: { ...state.pullRequests }
+				pullRequests: { ...state.pullRequests },
+				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.AddPullRequestFiles: {
@@ -88,7 +89,8 @@ export function reduceProviderPullRequests(
 			};
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState
+				pullRequests: newState,
+				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.ClearPullRequestFiles: {
@@ -99,7 +101,8 @@ export function reduceProviderPullRequests(
 			};
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState
+				pullRequests: newState,
+				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.AddPullRequestCommits: {
@@ -110,7 +113,8 @@ export function reduceProviderPullRequests(
 			};
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState
+				pullRequests: newState,
+				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.ClearPullRequestCommits: {
@@ -121,7 +125,8 @@ export function reduceProviderPullRequests(
 			};
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState
+				pullRequests: newState,
+				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.AddPullRequestCollaborators: {
@@ -132,10 +137,25 @@ export function reduceProviderPullRequests(
 			};
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState
+				pullRequests: newState,
+				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
-		case ProviderPullRequestActionsTypes.UpdateMyPullRequests: {
+		case ProviderPullRequestActionsTypes.UpdatePullRequestGroups: {
+			// const newState = {...state.pullRequestGroups};
+
+			console.log('NEW GROUPS RECEIBVED');
+			// console.log(newState);
+			console.log(action);
+			// newState
+
+			return {
+				myPullRequests: {...state.myPullRequests},
+				pullRequests: { ...state.pullRequests },
+				pullRequestGroups: action.payload
+			}
+		}
+		case ProviderPullRequestActionsTypes.UpdatePullRequestTitle: {
 			const newState = {...state.myPullRequests};
 			console.log("reducer called... updating state in here");
 			console.log(newState);
@@ -146,8 +166,7 @@ export function reduceProviderPullRequests(
 					if (pr.id === action.payload.id) {	
 						newState[action.payload.providerId]['data']![index][i] = {
 							...newState[action.payload.providerId]['data']![index][i],
-							title: action.payload.pullRequestData.title,
-							labels: action.payload.pullRequestData.labels
+							title: action.payload.pullRequestData.title
 						};
 					}
 				})
@@ -155,7 +174,8 @@ export function reduceProviderPullRequests(
 			)
 			return {
 				myPullRequests: newState,
-				pullRequests: {...state.pullRequests}
+				pullRequests: {...state.pullRequests},
+				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.UpdatePullRequestLabels: {
@@ -167,7 +187,6 @@ export function reduceProviderPullRequests(
 
 			newState[action.payload.providerId]['data']?.forEach((arr: any, index) => {
 				// arr?.forEach
-				console.log(arr);
 				arr?.forEach((pr, i) => {
 					if (pr.id === action.payload.prId) {
 						if (action.payload.onOff === true) {
@@ -196,9 +215,6 @@ export function reduceProviderPullRequests(
 				})
 			})
 
-			console.log('check this state yo')
-			console.log(newState);
-
 			return state;
 		}
 		case ProviderPullRequestActionsTypes.AddPullRequestConversations: {
@@ -210,7 +226,8 @@ export function reduceProviderPullRequests(
 			};
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState
+				pullRequests: newState,
+				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.ClearPullRequestError: {
@@ -221,7 +238,8 @@ export function reduceProviderPullRequests(
 			newState[action.payload.providerId][id].error = undefined;
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState
+				pullRequests: newState,
+				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.AddPullRequestError: {
@@ -232,7 +250,8 @@ export function reduceProviderPullRequests(
 			newState[action.payload.providerId][id].error = action.payload.error;
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState
+				pullRequests: newState,
+				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		case ProviderPullRequestActionsTypes.HandleDirectives: {
@@ -756,7 +775,8 @@ export function reduceProviderPullRequests(
 			}
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState
+				pullRequests: newState,
+				pullRequestGroups: {...state.pullRequestGroups}
 			};
 		}
 		// case ProviderPullRequestActionsTypes.ClearPullRequestError: {

--- a/shared/ui/store/providerPullRequests/reducer.ts
+++ b/shared/ui/store/providerPullRequests/reducer.ts
@@ -134,6 +134,10 @@ export function reduceProviderPullRequests(
 				pullRequests: newState
 			};
 		}
+		case ProviderPullRequestActionsTypes.updateMyPullRequests: {
+			// reducer to update state: updates labels and title of the pull requests in `myPullRequests` object
+			return state;
+		}
 		case ProviderPullRequestActionsTypes.AddPullRequestConversations: {
 			const newState = createNewObject(state, action);
 			newState[action.payload.providerId][id] = {
@@ -692,6 +696,20 @@ export function reduceProviderPullRequests(
 				pullRequests: newState
 			};
 		}
+		case ProviderPullRequestActionsTypes.updateMyPullRequests: {
+			return state;
+		}
+		// case ProviderPullRequestActionsTypes.ClearPullRequestError: {
+		// 	const newState = createNewObject(state, action);
+		// 	newState[action.payload.providerId][id] = {
+		// 		...newState[action.payload.providerId][id]
+		// 	};
+		// 	newState[action.payload.providerId][id].error = undefined;
+		// 	return {
+		// 		myPullRequests: { ...state.myPullRequests },
+		// 		pullRequests: newState
+		// 	};
+		// }
 		case "RESET":
 			return initialState;
 		default:

--- a/shared/ui/store/providerPullRequests/reducer.ts
+++ b/shared/ui/store/providerPullRequests/reducer.ts
@@ -12,6 +12,7 @@ import {
 	FetchThirdPartyPullRequestPullRequest,
 	GitLabMergeRequest
 } from "@codestream/protocols/agent";
+import { CompletionList } from "vscode-languageserver-types";
 
 type ProviderPullRequestActions =
 	| ActionType<typeof actions>
@@ -134,8 +135,70 @@ export function reduceProviderPullRequests(
 				pullRequests: newState
 			};
 		}
-		case ProviderPullRequestActionsTypes.updateMyPullRequests: {
-			// reducer to update state: updates labels and title of the pull requests in `myPullRequests` object
+		case ProviderPullRequestActionsTypes.UpdateMyPullRequests: {
+			const newState = {...state.myPullRequests};
+			console.log("reducer called... updating state in here");
+			console.log(newState);
+			console.log(state);
+
+			newState[action.payload.providerId]['data']?.forEach((arr: any, index) => {
+				arr?.forEach((pr, i) => {
+					if (pr.id === action.payload.id) {	
+						newState[action.payload.providerId]['data']![index][i] = {
+							...newState[action.payload.providerId]['data']![index][i],
+							title: action.payload.pullRequestData.title,
+							labels: action.payload.pullRequestData.labels
+						};
+					}
+				})
+			}
+			)
+			return {
+				myPullRequests: newState,
+				pullRequests: {...state.pullRequests}
+			};
+		}
+		case ProviderPullRequestActionsTypes.UpdatePullRequestLabels: {
+			const newState = {...state.myPullRequests};
+			console.log("reducer entered beast mode.");
+			console.log(action);
+			console.log("new state");
+			console.log(newState);
+
+			newState[action.payload.providerId]['data']?.forEach((arr: any, index) => {
+				// arr?.forEach
+				console.log(arr);
+				arr?.forEach((pr, i) => {
+					if (pr.id === action.payload.prId) {
+						if (action.payload.onOff === true) {
+							// add label
+							const labelNodes = newState[action.payload.providerId]['data']![index][i].labels;
+							// console.log("label nodes");
+							// console.log(labelNodes);
+							labelNodes.nodes.push(action.payload.label);
+							// console.log("new label nodes");
+							// console.log(labelNodes);
+							newState[action.payload.providerId]['data']![index][i] = {
+								...newState[action.payload.providerId]['data']![index][i],
+								labels: labelNodes
+							};
+							console.log('updated labels ');
+							console.log(newState);
+						} else {
+							// remove label
+							newState[action.payload.providerId]['data']![index][i].labels.nodes = newState[action.payload.providerId]['data']![index][i].labels.nodes.filter(itm => itm.id !== action.payload.label.id)
+							console.log("label removed")
+							console.log(newState);
+							// pr.labels.nodes = pr.labels.nodes.
+						}
+					}
+					// console.log(pr);
+				})
+			})
+
+			console.log('check this state yo')
+			console.log(newState);
+
 			return state;
 		}
 		case ProviderPullRequestActionsTypes.AddPullRequestConversations: {
@@ -695,9 +758,6 @@ export function reduceProviderPullRequests(
 				myPullRequests: { ...state.myPullRequests },
 				pullRequests: newState
 			};
-		}
-		case ProviderPullRequestActionsTypes.updateMyPullRequests: {
-			return state;
 		}
 		// case ProviderPullRequestActionsTypes.ClearPullRequestError: {
 		// 	const newState = createNewObject(state, action);

--- a/shared/ui/store/providerPullRequests/reducer.ts
+++ b/shared/ui/store/providerPullRequests/reducer.ts
@@ -50,7 +50,7 @@ export function reduceProviderPullRequests(
 				newState[action.payload.providerId][id].error = undefined;
 				return {
 					myPullRequests: { ...state.myPullRequests },
-					pullRequests: newState,
+					pullRequests: newState
 				};
 			} else if (action.payload) {
 				const newState = { ...state };
@@ -71,7 +71,7 @@ export function reduceProviderPullRequests(
 			};
 			return {
 				myPullRequests: newState,
-				pullRequests: { ...state.pullRequests },
+				pullRequests: { ...state.pullRequests }
 			};
 		}
 		case ProviderPullRequestActionsTypes.AddPullRequestFiles: {
@@ -87,7 +87,7 @@ export function reduceProviderPullRequests(
 			};
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState,
+				pullRequests: newState
 			};
 		}
 		case ProviderPullRequestActionsTypes.ClearPullRequestFiles: {
@@ -98,7 +98,7 @@ export function reduceProviderPullRequests(
 			};
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState,
+				pullRequests: newState
 			};
 		}
 		case ProviderPullRequestActionsTypes.AddPullRequestCommits: {
@@ -109,7 +109,7 @@ export function reduceProviderPullRequests(
 			};
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState,
+				pullRequests: newState
 			};
 		}
 		case ProviderPullRequestActionsTypes.ClearPullRequestCommits: {
@@ -120,7 +120,7 @@ export function reduceProviderPullRequests(
 			};
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState,
+				pullRequests: newState
 			};
 		}
 		case ProviderPullRequestActionsTypes.AddPullRequestCollaborators: {
@@ -131,25 +131,24 @@ export function reduceProviderPullRequests(
 			};
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState,
+				pullRequests: newState
 			};
 		}
 		case ProviderPullRequestActionsTypes.UpdatePullRequestTitle: {
-			const newState = {...state.myPullRequests};
-			newState[action.payload.providerId]['data']?.forEach((arr: any, index) => {
+			const newState = { ...state.myPullRequests };
+			newState[action.payload.providerId]["data"]?.forEach((arr: any, index) => {
 				arr?.forEach((pr, i) => {
-					if (pr.id === action.payload.id) {	
-						newState[action.payload.providerId]['data']![index][i] = {
-							...newState[action.payload.providerId]['data']![index][i],
+					if (pr.id === action.payload.id) {
+						newState[action.payload.providerId]["data"]![index][i] = {
+							...newState[action.payload.providerId]["data"]![index][i],
 							title: action.payload.pullRequestData.title
 						};
 					}
-				})
-			}
-			)
+				});
+			});
 			return {
 				myPullRequests: newState,
-				pullRequests: {...state.pullRequests},
+				pullRequests: { ...state.pullRequests }
 			};
 		}
 		case ProviderPullRequestActionsTypes.AddPullRequestConversations: {
@@ -161,7 +160,7 @@ export function reduceProviderPullRequests(
 			};
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState,
+				pullRequests: newState
 			};
 		}
 		case ProviderPullRequestActionsTypes.ClearPullRequestError: {
@@ -172,7 +171,7 @@ export function reduceProviderPullRequests(
 			newState[action.payload.providerId][id].error = undefined;
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState,
+				pullRequests: newState
 			};
 		}
 		case ProviderPullRequestActionsTypes.AddPullRequestError: {
@@ -183,7 +182,7 @@ export function reduceProviderPullRequests(
 			newState[action.payload.providerId][id].error = action.payload.error;
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState,
+				pullRequests: newState
 			};
 		}
 		case ProviderPullRequestActionsTypes.HandleDirectives: {
@@ -707,20 +706,9 @@ export function reduceProviderPullRequests(
 			}
 			return {
 				myPullRequests: { ...state.myPullRequests },
-				pullRequests: newState,
+				pullRequests: newState
 			};
 		}
-		// case ProviderPullRequestActionsTypes.ClearPullRequestError: {
-		// 	const newState = createNewObject(state, action);
-		// 	newState[action.payload.providerId][id] = {
-		// 		...newState[action.payload.providerId][id]
-		// 	};
-		// 	newState[action.payload.providerId][id].error = undefined;
-		// 	return {
-		// 		myPullRequests: { ...state.myPullRequests },
-		// 		pullRequests: newState
-		// 	};
-		// }
 		case "RESET":
 			return initialState;
 		default:

--- a/shared/ui/store/providerPullRequests/reducer.ts
+++ b/shared/ui/store/providerPullRequests/reducer.ts
@@ -69,8 +69,6 @@ export function reduceProviderPullRequests(
 			newState[action.payload.providerId] = {
 				data: action.payload.data
 			};
-			console.log('REDUCER CHANGED PRS');
-			console.log(newState);
 			return {
 				myPullRequests: newState,
 				pullRequests: { ...state.pullRequests },
@@ -138,10 +136,6 @@ export function reduceProviderPullRequests(
 		}
 		case ProviderPullRequestActionsTypes.UpdatePullRequestTitle: {
 			const newState = {...state.myPullRequests};
-			console.log("reducer called... updating state in here");
-			console.log(newState);
-			console.log(state);
-
 			newState[action.payload.providerId]['data']?.forEach((arr: any, index) => {
 				arr?.forEach((pr, i) => {
 					if (pr.id === action.payload.id) {	

--- a/shared/ui/store/providerPullRequests/types.ts
+++ b/shared/ui/store/providerPullRequests/types.ts
@@ -1,5 +1,5 @@
 import { Index } from "../common";
-import { GetMyPullRequestsResponse, PullRequestGroups } from "@codestream/protocols/agent";
+import { GetMyPullRequestsResponse } from "@codestream/protocols/agent";
 
 export enum ProviderPullRequestActionsTypes {
 	AddPullRequestConversations = "@providerPullRequests/AddConversations",
@@ -12,9 +12,7 @@ export enum ProviderPullRequestActionsTypes {
 	AddPullRequestError = "@providerPullRequests/AddError",
 	ClearPullRequestError = "@providerPullRequests/ClearError",
 	HandleDirectives = "@providerPullRequests/HandleDirectives",
-	UpdatePullRequestTitle = "@providerPullRequests/UpdatePullRequestTitle",
-	UpdatePullRequestLabels = "@providerPullRequests/UpdatePullRequestLabels",
-	UpdatePullRequestGroups = "@providerPullRequests/UpdatePullRequestGroups"
+	UpdatePullRequestTitle = "@providerPullRequests/UpdatePullRequestTitle"
 }
 
 /**
@@ -51,5 +49,4 @@ export type ProviderPullRequestsState = {
 			accessRawDiffs?: boolean;
 		}>
 	>;
-	pullRequestGroups: PullRequestGroups;
 };

--- a/shared/ui/store/providerPullRequests/types.ts
+++ b/shared/ui/store/providerPullRequests/types.ts
@@ -1,5 +1,5 @@
 import { Index } from "../common";
-import { GetMyPullRequestsResponse } from "@codestream/protocols/agent";
+import { GetMyPullRequestsResponse, PullRequestGroups } from "@codestream/protocols/agent";
 
 export enum ProviderPullRequestActionsTypes {
 	AddPullRequestConversations = "@providerPullRequests/AddConversations",
@@ -12,8 +12,9 @@ export enum ProviderPullRequestActionsTypes {
 	AddPullRequestError = "@providerPullRequests/AddError",
 	ClearPullRequestError = "@providerPullRequests/ClearError",
 	HandleDirectives = "@providerPullRequests/HandleDirectives",
-	UpdateMyPullRequests = "@providerPullRequests/UpdateMyPullRequests",
-	UpdatePullRequestLabels = "@providerPullRequests/UpdatePullRequestLabels"
+	UpdatePullRequestTitle = "@providerPullRequests/UpdatePullRequestTitle",
+	UpdatePullRequestLabels = "@providerPullRequests/UpdatePullRequestLabels",
+	UpdatePullRequestGroups = "@providerPullRequests/UpdatePullRequestGroups"
 }
 
 /**
@@ -50,4 +51,5 @@ export type ProviderPullRequestsState = {
 			accessRawDiffs?: boolean;
 		}>
 	>;
+	pullRequestGroups: PullRequestGroups;
 };

--- a/shared/ui/store/providerPullRequests/types.ts
+++ b/shared/ui/store/providerPullRequests/types.ts
@@ -12,8 +12,8 @@ export enum ProviderPullRequestActionsTypes {
 	AddPullRequestError = "@providerPullRequests/AddError",
 	ClearPullRequestError = "@providerPullRequests/ClearError",
 	HandleDirectives = "@providerPullRequests/HandleDirectives",
-	updateMyPullRequests = "@providerPullRequests/updateMyPullRequests"
-	// this type is the new action type
+	UpdateMyPullRequests = "@providerPullRequests/UpdateMyPullRequests",
+	UpdatePullRequestLabels = "@providerPullRequests/UpdatePullRequestLabels"
 }
 
 /**

--- a/shared/ui/store/providerPullRequests/types.ts
+++ b/shared/ui/store/providerPullRequests/types.ts
@@ -11,7 +11,9 @@ export enum ProviderPullRequestActionsTypes {
 	ClearPullRequestCommits = "@providerPullRequests/ClearCommits",
 	AddPullRequestError = "@providerPullRequests/AddError",
 	ClearPullRequestError = "@providerPullRequests/ClearError",
-	HandleDirectives = "@providerPullRequests/HandleDirectives"
+	HandleDirectives = "@providerPullRequests/HandleDirectives",
+	updateMyPullRequests = "@providerPullRequests/updateMyPullRequests"
+	// this type is the new action type
 }
 
 /**


### PR DESCRIPTION
Added functionality so that when a user changes an item on the pullrequestconversationtab pane we refresh the user's prs asynchronously so that when they exit out of the pr their pull requests are up to date for each query listed.

Currently using a timeout to delay the refreshing of the prs long enough for GH's servers to process the update (e.g. adding a label, assignee, etc), the timeout is set to 2 seconds but this means that sometimes the data will be refreshed too early and not be displayed properly. There is surely a better way to do this.