### PR TITLE
fixed rendering markdown in issue comments

### DIFF
--- a/shared/ui/Stream/Codemark.tsx
+++ b/shared/ui/Stream/Codemark.tsx
@@ -1638,7 +1638,9 @@ export class Codemark extends React.Component<Props, State> {
 										<div className="description-body" style={{ display: "flex" }}>
 											<Icon name="description" />
 											<div className="description-text" style={{ paddingLeft: "5px" }}>
-												{description}
+												{codemark.type === "issue"
+													? this.renderTextReplaceCodeBlocks(description.props.text)
+													: description}
 											</div>
 										</div>
 									</div>


### PR DESCRIPTION
Added code so issues description codeblocks are rendered as codeblocks.


[Changes reviewed on CodeStream](https://api.codestream.com/r/W75JY6zGmBhgt48D/yP78QzcxTOeknb7hXtdipg?src=GitHub) by brian on Jul 26, 2021

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>