### PR TITLE
CDSTRM-91: Preserve organization on sign-in

### DIFF
--- a/shared/agent/src/api/codestream/codestreamApi.ts
+++ b/shared/agent/src/api/codestream/codestreamApi.ts
@@ -544,10 +544,16 @@ export class CodeStreamApiProvider implements ApiProvider {
 					}
 				}
 
+				// Check the lastTeamId preference and use that, if available.
 				// If we still can't find a team, then just pick the first one
 				if (options.teamId == null) {
+					if (response.user.preferences?.lastTeamId) {
+						options.teamId = response.user.preferences.lastTeamId;
+						pickedTeamReason = " because the team was the last saved team";
+					}
+
 					// Pick the oldest (first) Slack team if there is one
-					if (User.isSlack(response.user)) {
+					if (options.teamId == null && User.isSlack(response.user)) {
 						const team = teams.find(t => Team.isSlack(t));
 						if (team) {
 							options.teamId = team.id;

--- a/shared/agent/src/protocol/api.protocol.models.ts
+++ b/shared/agent/src/protocol/api.protocol.models.ts
@@ -771,6 +771,7 @@ export interface CSMePreferences {
 	/** teamId to settings */
 	activityFilter?: { [key: string]: ActivityFilter | undefined };
 	demoMode?: boolean;
+	lastTeamId?: string;
 	observabilityRepoEntities?: any;
 }
 

--- a/shared/ui/store/session/actions.ts
+++ b/shared/ui/store/session/actions.ts
@@ -86,6 +86,8 @@ export const switchToTeam = (
 		return dispatch(setBootstrapped(true));
 	}
 
+	dispatch(setUserPreference(['lastTeamId'], teamId));
+
 	return dispatch(onLogin(response));
 };
 


### PR DESCRIPTION
This adds storing the last selected organization in the user.preferences
object in the database as `lastTeamId` and checking that value on login
so that we maintain the last selected organization across logout/login
instead of just falling back to the oldest organization.