### PR TITLE
CDSTRM-1301: Allow saving the "recent" PR query …

### DIFF
--- a/shared/ui/Stream/ConfigurePullRequestQuery.tsx
+++ b/shared/ui/Stream/ConfigurePullRequestQuery.tsx
@@ -134,6 +134,11 @@ export function ConfigurePullRequestQuery(props: Props) {
 	}, [providerIdField]);
 
 	const isValidQuery = query => {
+		// "recent" is a special query string that we handle specifically
+		if (query === "recent") {
+			setValidQuery(true);
+			return true;
+		}
 		if (providerIdField === "github*com" || providerIdField === "github/enterprise") {
 			// Verify if valid query for Github
 			const queryStr = query.replace(/:/g, " ").split(/\s+/);


### PR DESCRIPTION
This enables users to save the default "recent" PR query, which is a special string we handle specifically. This allows them to recreate it if they've changed it.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>