### PR TITLE
CDSTRM-1332: Disable FROP by default for new users

### DIFF
--- a/shared/agent/src/session.ts
+++ b/shared/agent/src/session.ts
@@ -1415,7 +1415,16 @@ export class CodeStreamSession {
 		markerLocations.flushUncommittedLocations(repo);
 
 		const me = await users.getMe();
-		if (me.user.preferences?.reviewCreateOnDetectUnreviewedCommits !== false) {
+		// disable FROP for new users by default
+		let createReviewOnDetectUnreviewedCommits;
+		if (me.user.createdAt > 1641405000000) {
+			createReviewOnDetectUnreviewedCommits =
+				me.user.preferences?.reviewCreateOnDetectUnreviewedCommits === true ? true : false;
+		} else {
+			createReviewOnDetectUnreviewedCommits =
+				me.user.preferences?.reviewCreateOnDetectUnreviewedCommits === false ? false : true;
+		}
+		if (createReviewOnDetectUnreviewedCommits) {
 			reviews.checkUnreviewedCommits(repo).then(unreviewedCommitCount => {
 				Logger.log(`Detected ${unreviewedCommitCount} unreviewed commits`);
 			});

--- a/shared/ui/Stream/Notifications.tsx
+++ b/shared/ui/Stream/Notifications.tsx
@@ -20,13 +20,24 @@ export const Notifications = props => {
 		const hasDesktopNotifications = state.ide.name === "VSC" || state.ide.name === "JETBRAINS";
 		const notificationDeliverySupported = isFeatureEnabled(state, "notificationDeliveryPreference");
 		const emailSupported = isFeatureEnabled(state, "emailSupport");
+
+		// disable FROP for new users by default
+		const me = state.users[state.session.userId!];
+		let createReviewOnDetectUnreviewedCommits;
+		if (me.createdAt > 1641405000000) {
+			createReviewOnDetectUnreviewedCommits =
+				state.preferences.reviewCreateOnDetectUnreviewedCommits === true ? true : false;
+		} else {
+			createReviewOnDetectUnreviewedCommits =
+				state.preferences.reviewCreateOnDetectUnreviewedCommits === false ? false : true;
+		}
+
 		return {
 			notificationPreference: state.preferences.notifications || CSNotificationPreference.InvolveMe,
 			notificationDeliveryPreference:
 				state.preferences.notificationDelivery || CSNotificationDeliveryPreference.All,
 			reviewReminderDelivery: state.preferences.reviewReminderDelivery === false ? false : true,
-			createReviewOnDetectUnreviewedCommits:
-				state.preferences.reviewCreateOnDetectUnreviewedCommits === false ? false : true,
+			createReviewOnDetectUnreviewedCommits: createReviewOnDetectUnreviewedCommits,
 			weeklyEmailDelivery: state.preferences.weeklyEmailDelivery === false ? false : true,
 			hasDesktopNotifications,
 			notificationDeliverySupported,


### PR DESCRIPTION
This changes the default for new users for the feature which shows a toast notification prompting you to review unreviewed commits when you pull new code. New users are arbitrarily defined as anyone who joined after 2022-01-05T17:50:00Z, mostly because the number looked kind of nice and was appropriate to make it easy to test that it works. It does mean there will probably be a few users who join between that time and when this releases who get their value changed, but that's probably okay.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>