### PR TITLE
CDSTRM-1318: Add login by code

### DIFF
--- a/shared/agent/src/api/apiProvider.ts
+++ b/shared/agent/src/api/apiProvider.ts
@@ -85,6 +85,7 @@ import {
 	FollowCodemarkResponse,
 	FollowReviewRequest,
 	FollowReviewResponse,
+	GenerateLoginCodeRequest,
 	GetCodeErrorRequest,
 	GetCodeErrorResponse,
 	GetCodemarkRequest,
@@ -232,7 +233,17 @@ export interface TokenLoginOptions extends BasicLoginOptions {
 	token: AccessToken;
 }
 
-export type LoginOptions = CredentialsLoginOptions | OneTimeCodeLoginOptions | TokenLoginOptions;
+export interface LoginCodeLoginOptions extends BasicLoginOptions {
+	type: "loginCode";
+	email: string;
+	code: string;
+}
+
+export type LoginOptions =
+	| CredentialsLoginOptions
+	| OneTimeCodeLoginOptions
+	| TokenLoginOptions
+	| LoginCodeLoginOptions;
 
 export enum MessageType {
 	Connection = "connection",
@@ -367,6 +378,7 @@ export interface ApiProvider {
 	dispose(): Promise<void>;
 
 	login(options: LoginOptions): Promise<ApiProviderLoginResponse>;
+	generateLoginCode(request: GenerateLoginCodeRequest): Promise<void>;
 	subscribe(types?: MessageType[]): Promise<void>;
 
 	grantBroadcasterChannelAccess(token: string, channel: string): Promise<{}>;

--- a/shared/agent/src/api/codestream/codestreamApi.ts
+++ b/shared/agent/src/api/codestream/codestreamApi.ts
@@ -170,7 +170,8 @@ import {
 	VerifyConnectivityResponse,
 	DeleteCompanyRequest,
 	DeleteCompanyResponse,
-	DeleteCompanyRequestType
+	DeleteCompanyRequestType,
+	GenerateLoginCodeRequest
 } from "../../protocol/agent.protocol";
 import {
 	CSAddMarkersRequest,
@@ -294,7 +295,8 @@ import {
 	ProviderType,
 	StreamType,
 	TriggerMsTeamsProactiveMessageRequest,
-	TriggerMsTeamsProactiveMessageResponse
+	TriggerMsTeamsProactiveMessageResponse,
+	CSCodeLoginRequest
 } from "../../protocol/api.protocol";
 import { NewRelicProvider } from "../../providers/newrelic";
 import { VersionInfo } from "../../session";
@@ -444,6 +446,14 @@ export class CodeStreamApiProvider implements ApiProvider {
 				response.provider = options.token.provider;
 				response.providerAccess = options.token.providerAccess;
 				response.teamId = options.token.teamId;
+
+				break;
+
+			case "loginCode":
+				response = await this.put<CSCodeLoginRequest, CSLoginResponse>("/no-auth/login-by-code", {
+					email: options.email,
+					loginCode: options.code
+				});
 
 				break;
 			default:
@@ -620,6 +630,10 @@ export class CodeStreamApiProvider implements ApiProvider {
 		};
 
 		return { ...response, token: token };
+	}
+
+	async generateLoginCode(request: GenerateLoginCodeRequest): Promise<void> {
+		await this.post<GenerateLoginCodeRequest, {}>("/no-auth/generate-login-code", request);
 	}
 
 	async register(request: CSRegisterRequest) {

--- a/shared/agent/src/protocol/agent.protocol.auth.ts
+++ b/shared/agent/src/protocol/agent.protocol.auth.ts
@@ -68,6 +68,35 @@ export const OtcLoginRequestType = new RequestType<OtcLoginRequest, LoginRespons
 	"codestream/login/otc"
 );
 
+export interface GenerateLoginCodeRequest {
+	email: string;
+}
+
+export interface GenerateLoginCodeResponse {
+	status: LoginResult;
+}
+
+export const GenerateLoginCodeRequestType = new RequestType<
+	GenerateLoginCodeRequest,
+	GenerateLoginCodeResponse,
+	void,
+	void
+>("codestream/login/generate-code");
+
+export interface ConfirmLoginCodeRequest {
+	email: string;
+	code: string;
+	teamId?: string;
+	team?: string;
+}
+
+export const ConfirmLoginCodeRequestType = new RequestType<
+	ConfirmLoginCodeRequest,
+	LoginResponse,
+	void,
+	void
+>("codestream/login/confirm");
+
 export interface RegisterUserRequest extends CSRegisterRequest {
 	checkForWebmail?: boolean;
 }

--- a/shared/agent/src/protocol/agent.protocol.notifications.ts
+++ b/shared/agent/src/protocol/agent.protocol.notifications.ts
@@ -317,6 +317,14 @@ export const DidFailLoginNotificationType = new NotificationType<void, void>(
 	"codestream/didFailLogin"
 );
 
+export const DidStartLoginCodeGenerationNotificationType = new NotificationType<void, void>(
+	"codestream/didStartLoginCodeGeneration"
+);
+
+export const DidFailLoginCodeGenerationNotificationType = new NotificationType<void, void>(
+	"codestream/didFailLoginCodeGeneration"
+);
+
 export type DidEncounterMaintenanceModeNotification = TokenLoginRequest;
 
 export const DidEncounterMaintenanceModeNotificationType = new NotificationType<

--- a/shared/agent/src/protocol/api.protocol.ts
+++ b/shared/agent/src/protocol/api.protocol.ts
@@ -68,7 +68,10 @@ export enum LoginResult {
 	SignInRequired = "SIGNIN_REQUIRED",
 	MaintenanceMode = "MAINTENANCE_MODE",
 	MustSetPassword = "MUST_SET_PASSWORD",
-	Timeout = "TIMEOUT"
+	Timeout = "TIMEOUT",
+	ExpiredCode = "CODE_EXPIRED",
+	TooManyAttempts = "TOO_MANY_ATTEMPTS",
+	InvalidCode = "CODE_INVALID"
 }
 
 export interface CSCompleteSignupRequest {
@@ -80,6 +83,11 @@ export interface CSLoginRequest {
 	email: string;
 	password?: string;
 	token?: string;
+}
+
+export interface CSCodeLoginRequest {
+	email: string;
+	loginCode: string;
 }
 
 export interface CSEligibleJoinCompany {

--- a/shared/agent/src/session.ts
+++ b/shared/agent/src/session.ts
@@ -85,7 +85,13 @@ import {
 	UserDidCommitNotificationType,
 	VerifyConnectivityRequestType,
 	VerifyConnectivityResponse,
-	VersionCompatibility
+	VersionCompatibility,
+	GenerateLoginCodeRequest,
+	DidStartLoginCodeGenerationNotificationType,
+	DidFailLoginCodeGenerationNotificationType,
+	GenerateLoginCodeRequestType,
+	ConfirmLoginCodeRequest,
+	ConfirmLoginCodeRequestType
 } from "./protocol/agent.protocol";
 import {
 	CSApiCapabilities,
@@ -140,6 +146,9 @@ export const loginApiErrorMappings: { [k: string]: LoginResult } = {
 	"USRC-1023": LoginResult.MaintenanceMode,
 	"USRC-1024": LoginResult.MustSetPassword,
 	"USRC-1022": LoginResult.ProviderConnectFailed,
+	"USRC-1028": LoginResult.ExpiredCode,
+	"USRC-1029": LoginResult.TooManyAttempts,
+	"USRC-1030": LoginResult.InvalidCode,
 	"USRC-1015": LoginResult.MultipleWorkspaces, // deprecated in favor of below...
 	"PRVD-1002": LoginResult.MultipleWorkspaces,
 	"PRVD-1005": LoginResult.SignupRequired,
@@ -436,6 +445,8 @@ export class CodeStreamSession {
 		this.agent.registerHandler(PasswordLoginRequestType, e => this.passwordLogin(e));
 		this.agent.registerHandler(TokenLoginRequestType, e => this.tokenLogin(e));
 		this.agent.registerHandler(OtcLoginRequestType, e => this.otcLogin(e));
+		this.agent.registerHandler(ConfirmLoginCodeRequestType, e => this.codeLogin(e));
+		this.agent.registerHandler(GenerateLoginCodeRequestType, e => this.generateLoginCode(e));
 		this.agent.registerHandler(RegisterUserRequestType, e => this.register(e));
 		this.agent.registerHandler(RegisterNrUserRequestType, e => this.registerNr(e));
 		this.agent.registerHandler(ConfirmRegistrationRequestType, e => this.confirmRegistration(e));
@@ -885,6 +896,63 @@ export class CodeStreamSession {
 			debugger;
 			throw new Error();
 		}
+	}
+
+	@log({ singleLine: true })
+	async codeLogin(request: ConfirmLoginCodeRequest) {
+		const cc = Logger.getCorrelationContext();
+		Logger.log(cc, `Logging into Codestream (@ ${this._options.serverUrl}) via login code...`);
+
+		return this.login({
+			type: "loginCode",
+			...request
+		});
+	}
+
+	@log({ singleLine: true })
+	async generateLoginCode(request: GenerateLoginCodeRequest) {
+		if (this.status === SessionStatus.SignedIn) {
+			Container.instance().errorReporter.reportMessage({
+				type: ReportingMessageType.Warning,
+				source: "agent",
+				message: "There was a redundant attempt to login while already logged in.",
+				extra: {
+					loginType: "loginCode"
+				}
+			});
+			return { status: LoginResult.AlreadySignedIn };
+		}
+
+		this.agent.sendNotification(DidStartLoginCodeGenerationNotificationType, undefined);
+
+		try {
+			await this.api.generateLoginCode(request);
+		} catch (ex) {
+			this.agent.sendNotification(DidFailLoginCodeGenerationNotificationType, undefined);
+			if (ex instanceof ServerError) {
+				if (ex.statusCode !== undefined && ex.statusCode >= 400 && ex.statusCode < 500) {
+					let error = loginApiErrorMappings[ex.info.code] || LoginResult.Unknown;
+					return {
+						status: error,
+						extra: ex.info
+					};
+				}
+			}
+
+			Container.instance().errorReporter.reportMessage({
+				type: ReportingMessageType.Error,
+				message: "Unexpected error generating login code",
+				source: "agent",
+				extra: {
+					...ex
+				}
+			});
+			throw AgentError.wrap(ex, `Login failed:\n${ex.message}`);
+		}
+
+		return {
+			status: LoginResult.Success
+		};
 	}
 
 	@log({

--- a/shared/ui/Authentication/Signup.tsx
+++ b/shared/ui/Authentication/Signup.tsx
@@ -217,6 +217,7 @@ export const Signup = (props: Props) => {
 					sendTelemetry();
 					dispatch(
 						goToEmailConfirmation({
+							confirmationType: "signup",
 							email: attributes.email,
 							teamId: props.teamId,
 							registrationParams: attributes

--- a/shared/ui/store/context/actions.ts
+++ b/shared/ui/store/context/actions.ts
@@ -277,6 +277,7 @@ export const goToJoinTeam = (params = {}) =>
 	action(ContextActionsType.SetRoute, { name: Route.JoinTeam, params });
 
 export const goToEmailConfirmation = (params: {
+	confirmationType: "signup" | "login";
 	email: string;
 	teamId?: string;
 	registrationParams: RegisterUserRequest;

--- a/shared/ui/store/context/types.ts
+++ b/shared/ui/store/context/types.ts
@@ -121,6 +121,7 @@ export enum Route {
 	NewRelicSignup = "newRelicSignup",
 	JoinTeam = "joinTeam",
 	EmailConfirmation = "emailConfirmation",
+	LoginCodeConfirmation = "loginCodeConfirmation",
 	TeamCreation = "teamCreation",
 	CompanyCreation = "companyCreation",
 	ForgotPassword = "forgotPassword",

--- a/shared/ui/store/session/actions.ts
+++ b/shared/ui/store/session/actions.ts
@@ -10,7 +10,8 @@ import {
 	GetAccessTokenRequestType,
 	isLoginFailResponse,
 	TokenLoginRequest,
-	DeleteMeUserRequestType
+	DeleteMeUserRequestType,
+	ConfirmLoginCodeRequest
 } from "@codestream/protocols/agent";
 import { CodeStreamState } from "../index";
 import { CSMe } from "@codestream/protocols/api";
@@ -38,7 +39,7 @@ export const acceptTOS = () => async (dispatch, getState: () => CodeStreamState)
 
 export const setMaintenanceMode = (
 	value: boolean,
-	meta?: PasswordLoginParams | TokenLoginRequest
+	meta?: PasswordLoginParams | TokenLoginRequest | ConfirmLoginCodeRequest
 ) => action(SessionActionType.SetMaintenanceMode, value, meta);
 
 export const logout = () => async (dispatch, getState: () => CodeStreamState) => {
@@ -86,7 +87,7 @@ export const switchToTeam = (
 		return dispatch(setBootstrapped(true));
 	}
 
-	dispatch(setUserPreference(['lastTeamId'], teamId));
+	dispatch(setUserPreference(["lastTeamId"], teamId));
 
 	return dispatch(onLogin(response));
 };

--- a/shared/ui/translations/en.js
+++ b/shared/ui/translations/en.js
@@ -32,6 +32,7 @@ export default {
 	"signup.complete.button": "CONTINUE",
 	"confirmation.invalid": "Invalid code.",
 	"confirmation.expired": "Sorry, that code has expired.",
+	"confirmation.tooManyAttempts": "Code expired: Too many attempts.",
 	"confirmation.emailSent": "Email Sent!",
 	"confirmation.header": "You're almost there!",
 	"confirmation.instructions":


### PR DESCRIPTION
This adds a new path for logging in: requesting a code be sent to the email address of an existing user, then allowing the user to provide that code to log in, rather than having to enter a password.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>