### PR TITLE
CDSTRM-1346: Send Account Created on NR signup

### DIFF
--- a/shared/ui/Authentication/SignupNewRelic.tsx
+++ b/shared/ui/Authentication/SignupNewRelic.tsx
@@ -74,11 +74,19 @@ export const SignupNewRelic = () => {
 			});
 			setLoading(false);
 
+			const sendTelemetry = () => {
+				HostApi.instance.track("Account Created", {
+					email: email,
+					"Auth Provider": "New Relic"
+				});
+			};
+
 			switch (status) {
 				// CompanyCreation should handle routing on success
 				case LoginResult.Success:
 				case LoginResult.NotInCompany:
 				case LoginResult.NotOnTeam: {
+					sendTelemetry();
 					if (email && token) {
 						dispatch(
 							goToCompanyCreation({
@@ -100,6 +108,7 @@ export const SignupNewRelic = () => {
 					}
 					// invited @TODO: this could be handled cleaner
 					if (email && token && teamId) {
+						sendTelemetry();
 						completeSignup(email, token!, teamId!, {
 							createdTeam: false
 						});


### PR DESCRIPTION
This modifies the New Relic signup flow to send the "Account Created" telemetry event when a new user is registered.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>