### PR TITLE
CDSTRM-1345: Open-in-IDE to NR sign up page

### DIFF
--- a/shared/ui/index.tsx
+++ b/shared/ui/index.tsx
@@ -83,7 +83,8 @@ import {
 	setStartWorkCard,
 	closeAllPanels,
 	clearCurrentPullRequest,
-	setPendingProtocolHandlerUrl
+	setPendingProtocolHandlerUrl,
+	goToNewRelicSignup
 } from "./store/context/actions";
 import { URI } from "vscode-uri";
 import { moveCursorToLine } from "./Stream/api-functions";
@@ -557,6 +558,7 @@ function listenForEvents(store) {
 									anonymousId: route.query["anonymousId"]
 								});
 							}
+							store.dispatch(goToNewRelicSignup({}));
 							break;
 						}
 


### PR DESCRIPTION
This makes it so when you load CodeStream from the "Open in IDE" button in NR1, instead of showing the main sign in page, we take the user directly to the "Sign Up with New Relic" page.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>