### PR TITLE
CDSTRM-1347: Fix NR signup "Get your API key" link

### DIFF
--- a/shared/ui/Authentication/SignupNewRelic.tsx
+++ b/shared/ui/Authentication/SignupNewRelic.tsx
@@ -51,6 +51,10 @@ export const SignupNewRelic = () => {
 		}
 	});
 
+	const getApiKeyUrl = derivedState.isProductionCloud
+		? "https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher"
+		: "https://staging-one.newrelic.com/launcher/api-keys-ui.api-keys-launcher";
+
 	const onSubmit = async (event: React.SyntheticEvent) => {
 		event.preventDefault();
 		setLoading(true);
@@ -118,20 +122,6 @@ export const SignupNewRelic = () => {
 		}
 	};
 
-	const handleGetApiKeyClick = async () => {
-		const { token, baseLandingUrl } = await HostApi.instance.send(
-			GetNewRelicSignupJwtTokenRequestType,
-			{}
-		);
-		const url =
-			`${baseLandingUrl}/codestream/signup` +
-			`?token=${token}` +
-			`&utm_source=codestream` +
-			`&utm_medium=${derivedState.ide.name}` +
-			`&utm_campaign=nr_getapikey`;
-		void HostApi.instance.send(OpenUrlRequestType, { url });
-	};
-
 	return (
 		<div className="standard-form vscroll">
 			<fieldset className="form-body">
@@ -167,14 +157,7 @@ export const SignupNewRelic = () => {
 							)}
 							<label>
 								Enter your New Relic user API key.{" "}
-								<Link
-									onClick={e => {
-										e.preventDefault();
-										handleGetApiKeyClick();
-									}}
-								>
-									Get your API key.
-								</Link>
+								<Link href={getApiKeyUrl}>Get your API key.</Link>
 							</label>
 							<div
 								style={{


### PR DESCRIPTION
This changes the "Get your API key" link on the Sign Up with New Relic page to just link to the appropriate page to view and create API keys instead of hitting the landing service since we need to be authenticated in order to generate the JWT token necessary for going through the landing service.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>