### PR TITLE
CDSTRM-1373: Filter non-emails from invitee list

### DIFF
--- a/shared/ui/Stream/BlameMap.tsx
+++ b/shared/ui/Stream/BlameMap.tsx
@@ -103,6 +103,8 @@ export function BlameMap() {
 			// allow some emails through that shouldn't be through, but
 			// won't block any that shouldn't be
 			if (email.match(/(?<!"") (?!"")(?=((?:[^"]*"){2})*[^"]*$)/)) return;
+			// If no period in domain, invalid email
+			if (!email.match(/.*@.*\..*/)) return;
 			if (members.find(user => user.email === email)) return;
 			if (invited.find(user => user.email === email)) return;
 			if (dontSuggestInvitees[email.replace(/\./g, "*")]) return;

--- a/shared/ui/Stream/Invite.tsx
+++ b/shared/ui/Stream/Invite.tsx
@@ -251,6 +251,8 @@ class Invite extends React.Component<Props, State> {
 			// allow some emails through that shouldn't be through, but
 			// won't block any that shouldn't be
 			if (email.match(/(?<!"") (?!"")(?=((?:[^"]*"){2})*[^"]*$)/)) return;
+			// If no period in domain, invalid email
+			if (!email.match(/.*@.*\..*/)) return;
 			if (members.find(user => user.email === email)) return;
 			if (invited.find(user => user.email === email)) return;
 			if (dontSuggestInvitees[email.replace(/\./g, "*")]) return;

--- a/shared/ui/Stream/Onboard.tsx
+++ b/shared/ui/Stream/Onboard.tsx
@@ -1124,6 +1124,8 @@ export const InviteTeammates = (props: { className: string; skip: Function; unwr
 			// allow some emails through that shouldn't be through, but
 			// won't block any that shouldn't be
 			if (email.match(/(?<!"") (?!"")(?=((?:[^"]*"){2})*[^"]*$)/)) return;
+			// If no period in domain, invalid email
+			if (!email.match(/.*@.*\..*/)) return;
 			if (teamMembers?.find(user => user.email === email)) return;
 			if (dontSuggestInvitees[email.replace(/\./g, "*")]) return;
 			suggested.push({ email, fullName: committers[email] || email });

--- a/shared/ui/Stream/Team.tsx
+++ b/shared/ui/Stream/Team.tsx
@@ -252,6 +252,8 @@ class Team extends React.Component<Props, State> {
 			// allow some emails through that shouldn't be through, but
 			// won't block any that shouldn't be
 			if (email.match(/(?<!"") (?!"")(?=((?:[^"]*"){2})*[^"]*$)/)) return;
+			// If no period in domain, invalid email
+			if (!email.match(/.*@.*\..*/)) return;
 			if (members.find(user => user.email === email)) return;
 			if (invited.find(user => user.email === email)) return;
 			if (dontSuggestInvitees[email.replace(/\./g, "*")]) return;

--- a/shared/ui/Stream/TeamPanel.tsx
+++ b/shared/ui/Stream/TeamPanel.tsx
@@ -243,6 +243,8 @@ class TeamPanel extends React.Component<Props, State> {
 			// allow some emails through that shouldn't be through, but
 			// won't block any that shouldn't be
 			if (email.match(/(?<!"") (?!"")(?=((?:[^"]*"){2})*[^"]*$)/)) return;
+			// If no period in domain, invalid email
+			if (!email.match(/.*@.*\..*/)) return;
 			if (members.find(user => user.email === email)) return;
 			if (invited.find(user => user.email === email)) return;
 			if (dontSuggestInvitees[email.replace(/\./g, "*")]) return;


### PR DESCRIPTION
This filters out "emails" that don't have a period in the domain name from the list of potential invitees in various places we prompt for invitees.


[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/i4iX_3qITaGEEtbfX1VXBw?src=GitHub) by ericjones on Jan 18, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>