### PR TITLE
CDSTRM-1389: Handle unauthenticated NR connect

### DIFF
--- a/shared/ui/index.tsx
+++ b/shared/ui/index.tsx
@@ -516,13 +516,16 @@ function listenForEvents(store) {
 						const definedQuery = route as RouteWithQuery<{
 							apiKey: string;
 						}>;
-						if (definedQuery.query.apiKey) {
-							store.dispatch(
-								configureProvider("newrelic*com", { apiKey: definedQuery.query.apiKey }, true)
-							);
+						if (!store.getState().session.userId) {
+							store.dispatch(goToNewRelicSignup({}));
 						} else {
-							console.error("missing apiKey, opening panel");
-							store.dispatch(openPanel("configure-provider-newrelic-newrelic*com"));
+							if (definedQuery.query.apiKey) {
+								store.dispatch(
+									configureProvider("newrelic*com", { apiKey: definedQuery.query.apiKey }, true)
+								);
+							} else {
+								store.dispatch(openPanel("configure-provider-newrelic-newrelic*com"));
+							}
 						}
 						break;
 					}


### PR DESCRIPTION
This updates the routing to support NR connect links when unauthenticated, redirecting to the NR signup page. It also removes an error message when such a link comes without an API key, since we're going to stop passing the API key along.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>