### PR TITLE
Add Source parameter for install nerdlet event

### DIFF
--- a/shared/ui/index.tsx
+++ b/shared/ui/index.tsx
@@ -514,9 +514,13 @@ function listenForEvents(store) {
 				switch (route.action) {
 					case "connect": {
 						const definedQuery = route as RouteWithQuery<{
-							apiKey: string;
+							apiKey?: string;
+							src?: string;
 						}>;
 						if (!store.getState().session.userId) {
+							store.dispatch(
+								setPendingProtocolHandlerUrl({ url: e.url, query: definedQuery.query })
+							);
 							store.dispatch(goToNewRelicSignup({}));
 						} else {
 							if (definedQuery.query.apiKey) {


### PR DESCRIPTION
This should make it so the Source parameter gets added to the Account Created event when coming from the install nerdlet.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>