### PR TITLE
CDSTRM-1459: Hide NR connect page after signup

### DIFF
--- a/shared/ui/Stream/ConfigureNewRelic.tsx
+++ b/shared/ui/Stream/ConfigureNewRelic.tsx
@@ -57,6 +57,9 @@ class ConfigureNewRelic extends Component<Props> {
 	state = this.initialState;
 
 	componentDidMount() {
+		if (this.props.isNewRelicConnected) {
+			this.props.closeAllPanels();
+		}
 		const el = document.getElementById("configure-provider-initial-input");
 		el && el.focus();
 	}
@@ -168,6 +171,9 @@ class ConfigureNewRelic extends Component<Props> {
 	};
 
 	render() {
+		if (this.props.isNewRelicConnected) {
+			return null;
+		}
 		const { providerId, headerChildren, showSignupUrl } = this.props;
 		const { name } = this.props.providers[providerId] || {};
 		const providerName = PROVIDER_MAPPINGS[name] ? PROVIDER_MAPPINGS[name].displayName : "";

--- a/shared/ui/index.tsx
+++ b/shared/ui/index.tsx
@@ -514,9 +514,13 @@ function listenForEvents(store) {
 				switch (route.action) {
 					case "connect": {
 						const definedQuery = route as RouteWithQuery<{
-							apiKey: string;
+							apiKey?: string;
+							src?: string;
 						}>;
 						if (!store.getState().session.userId) {
+							store.dispatch(
+								setPendingProtocolHandlerUrl({ url: e.url, query: definedQuery.query })
+							);
 							store.dispatch(goToNewRelicSignup({}));
 						} else {
 							if (definedQuery.query.apiKey) {


### PR DESCRIPTION
This ensures that after signing up with NR, we don't show the "Connect to NR" page. Otherwise, that happens because we attempt to follow the connect link from NR which directs to the connect page if logged in.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>