### PR TITLE
CDSTRM-1470: Use default merge method from GitHub

### DIFF
--- a/shared/agent/src/protocol/agent.protocol.providers.ts
+++ b/shared/agent/src/protocol/agent.protocol.providers.ts
@@ -638,6 +638,7 @@ export interface FetchThirdPartyPullRequestRepository {
 	repoName: string;
 	pullRequest: FetchThirdPartyPullRequestPullRequest;
 	providerId: string;
+	viewerDefaultMergeMethod: "MERGE" | "REBASE" | "SQUASH";
 	viewerPermission: "ADMIN" | "MAINTAIN" | "READ" | "TRIAGE" | "WRITE";
 	branchProtectionRules: BranchProtectionRules;
 }

--- a/shared/agent/src/providers/github.ts
+++ b/shared/agent/src/providers/github.ts
@@ -5392,6 +5392,7 @@ export class GitHubProvider extends ThirdPartyIssueProviderBase<CSGitHubProvider
 				  rebaseMergeAllowed
 				  squashMergeAllowed
 				  mergeCommitAllowed
+				  viewerDefaultMergeMethod
 				  viewerPermission
 				  branchProtectionRules(first:100) {
 				  	nodes {

--- a/shared/ui/Stream/PullRequestConversationTab.tsx
+++ b/shared/ui/Stream/PullRequestConversationTab.tsx
@@ -254,6 +254,7 @@ export const PullRequestConversationTab = (props: {
 		};
 	});
 	const { pr } = derivedState;
+	const defaultMergeMethod = ghRepo.viewerDefaultMergeMethod || derivedState.defaultMergeMethod;
 
 	const [availableLabels, setAvailableLabels] = useState(EMPTY_ARRAY);
 	const [availableReviewers, setAvailableReviewers] = useState(EMPTY_ARRAY);
@@ -264,7 +265,7 @@ export const PullRequestConversationTab = (props: {
 	const [isLocking, setIsLocking] = useState(false);
 	const [isLockingReason, setIsLockingReason] = useState("");
 	const [isLoadingLocking, setIsLoadingLocking] = useState(false);
-	const [mergeMethod, setMergeMethod] = useState(derivedState.defaultMergeMethod);
+	const [mergeMethod, setMergeMethod] = useState(defaultMergeMethod);
 	const [clInstructionsIsOpen, toggleClInstructions] = useReducer((open: boolean) => !open, false);
 	const [cloneURLType, setCloneURLType] = useState("https");
 	const [cloneURL, setCloneURL] = useState(pr && pr.repository ? `${pr.repository.url}.git` : "");
@@ -331,12 +332,7 @@ export const PullRequestConversationTab = (props: {
 			}
 			setIsLoadingMessage("");
 		},
-		[
-			pr.providerId,
-			derivedState.currentPullRequestId!,
-			derivedState.defaultMergeMethod,
-			mergeMethod
-		]
+		[pr.providerId, derivedState.currentPullRequestId!, defaultMergeMethod, mergeMethod]
 	);
 
 	const lockPullRequest = async () => {
@@ -1060,7 +1056,7 @@ export const PullRequestConversationTab = (props: {
 												ghRepo={ghRepo}
 												action={mergePullRequest}
 												onSelect={setMergeMethod}
-												defaultMergeMethod={derivedState.defaultMergeMethod}
+												defaultMergeMethod={defaultMergeMethod}
 												mergeText="As an administrator, you may still merge this pull request."
 											/>
 										)}
@@ -1143,7 +1139,7 @@ export const PullRequestConversationTab = (props: {
 									ghRepo={ghRepo}
 									action={mergePullRequest}
 									onSelect={setMergeMethod}
-									defaultMergeMethod={derivedState.defaultMergeMethod}
+									defaultMergeMethod={defaultMergeMethod}
 								/>
 							)}
 						</PRCommentCard>


### PR DESCRIPTION
This updates GitHub pull requests to fetch the default merge method from GitHub and preferentially use that.


[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/C-WXDCyGQFqWbHlwBrOPiQ?src=GitHub) by bcanzanella on Feb 11, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>