### PR TITLE
Object not found opening an errorGroup

### DIFF
--- a/shared/ui/Stream/CodeErrorNav.tsx
+++ b/shared/ui/Stream/CodeErrorNav.tsx
@@ -353,7 +353,9 @@ export function CodeErrorNav(props: Props) {
 			// we get here if the code error is not yet claimed by the current team,
 			// in which case we need to circle back and "reopen" it again
 			dispatch(closeAllPanels());
-			return dispatch(openErrorGroup(pendingErrorGroupGuid!, occurrenceId));
+			return dispatch(
+				openErrorGroup(pendingErrorGroupGuid!, occurrenceId, derivedState.currentCodeErrorData)
+			);
 		} else if (pendingErrorGroupGuid) {
 			errorGroupGuidToUse = pendingErrorGroupGuid;
 			occurrenceIdToUse = occurrenceId;

--- a/shared/ui/store/codeErrors/actions.ts
+++ b/shared/ui/store/codeErrors/actions.ts
@@ -73,6 +73,8 @@ export const resolveStackTraceLine = (notification: DidResolveStackTraceLineNoti
 
 	const state = getState();
 	const codeError = state.codeErrors?.codeErrors[codeErrorId];
+	if (!codeError) return;
+
 	let stackTraceIndex = codeError.stackTraces.findIndex(_ => _.occurrenceId === occurrenceId);
 
 	// FIXME occurrenceId mapping is not reliable, so assume it's the only one that exists
@@ -465,6 +467,8 @@ export const openErrorGroup = (
 		// we will circle back to this action to try to claim the code error again
 		if (response.needNRToken) {
 			data.claimWhenConnected = true;
+		} else {
+			data.pendingRequiresConnection = data.claimWhenConnected = false;
 		}
 
 		// NOTE don't really like this "PENDING" business, but it's something to say we need to CREATE a codeError


### PR DESCRIPTION
this fixes an issue in the open codeError flow as described in https://newrelic.atlassian.net/browse/CDSTRM-1510


[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/4zmuRLWMT2m1tfGMYkV2AA?src=GitHub) by cstryker on Feb 18, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>