### PR TITLE
user got error associating repo with entity

### DIFF
--- a/shared/agent/src/git/parsers/remoteParser.ts
+++ b/shared/agent/src/git/parsers/remoteParser.ts
@@ -136,11 +136,13 @@ export class GitRemoteParser {
 		if (parsed) {
 			if (httpOrSshEndpoint.indexOf("git") === 0) {
 				results.push({ type: "ssh", value: httpOrSshEndpoint });
+				results.push({ type: "ssh", value: `ssh://${httpOrSshEndpoint}` });
 				results.push({ type: "https", value: `https://${parsed[1]}/${parsed[2]}.git` });
 				results.push({ type: "https", value: `https://${parsed[1]}/${parsed[2]}` });
 			} else if (httpOrSshEndpoint.indexOf("http") === 0) {
 				results.push({ type: "https", value: httpOrSshEndpoint });
 				results.push({ type: "ssh", value: `git@${parsed[1]}:${parsed[2]}.git` });
+				results.push({ type: "ssh", value: `ssh://git@${parsed[1]}:${parsed[2]}.git` });
 			}
 		} else {
 			results.push({

--- a/shared/agent/src/protocol/agent.protocol.providers.ts
+++ b/shared/agent/src/protocol/agent.protocol.providers.ts
@@ -1039,6 +1039,7 @@ export const GetObservabilityReposRequestType = new RequestType<
 
 export interface GetObservabilityEntitiesRequest {
 	appName?: string;
+	appNames?: string[];
 }
 export interface GetObservabilityEntitiesResponse {
 	entities: { guid: string; name: string }[];

--- a/shared/agent/test/unit/git/git.spec.ts
+++ b/shared/agent/test/unit/git/git.spec.ts
@@ -17,6 +17,10 @@ describe("git", () => {
 					value: "git@gitlabratory.example.com:myorg/myrepo-sample-java.git"
 				},
 				{
+					type: "ssh",
+					value: "ssh://git@gitlabratory.example.com:myorg/myrepo-sample-java.git"
+				},
+				{
 					type: "https",
 					value: "https://gitlabratory.example.com/myorg/myrepo-sample-java.git"
 				},
@@ -34,6 +38,10 @@ describe("git", () => {
 				{
 					type: "ssh",
 					value: "git@gitlabratory.example.com:myorg/myrepo-sample-java.git"
+				},
+				{
+					type: "ssh",
+					value: "ssh://git@gitlabratory.example.com:myorg/myrepo-sample-java.git"
 				},
 				{
 					type: "https",
@@ -57,6 +65,10 @@ describe("git", () => {
 				{
 					type: "ssh",
 					value: "git@gitlabratory.example.com:myorg/myrepo-sample-java.git"
+				},
+				{
+					type: "ssh",
+					value: "ssh://git@gitlabratory.example.com:myorg/myrepo-sample-java.git"
 				}
 			]);
 		});

--- a/shared/ui/Stream/Observability.tsx
+++ b/shared/ui/Stream/Observability.tsx
@@ -279,10 +279,14 @@ export const Observability = React.memo((props: Props) => {
 							if (response?.repos) {
 								setObservabilityErrors(response.repos!);
 							}
-							HostApi.instance.send(GetObservabilityEntitiesRequestType, {}).then(_ => {
-								setHasEntities(!_isEmpty(_.entities));
-								setLoadingEntities(false);
-							});
+							HostApi.instance
+								.send(GetObservabilityEntitiesRequestType, {
+									appNames: response?.repos?.map(r => r.repoName)
+								})
+								.then(_ => {
+									setHasEntities(!_isEmpty(_.entities));
+									setLoadingEntities(false);
+								});
 							loading(repoIds, false);
 						});
 				} else {

--- a/shared/ui/Stream/WarningBox.tsx
+++ b/shared/ui/Stream/WarningBox.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import styled from "styled-components";
+import { WarningOrError } from "../protocols/agent/agent.protocol.nr";
+import Icon from "./Icon";
+import { Link } from "./Link";
+
+export const WarningBoxRoot = styled.div`
+	margin: 10px 10px 20px 0;
+	border: 1px solid rgba(249, 197, 19, 0.6);
+	background: rgba(255, 223, 0, 0.1);
+	border-radius: 5px;
+	padding: 10px;
+	display: flex;
+	align-items: center;
+	.icon.alert {
+		display: inline-block;
+		transform: scale(1.5);
+		margin: 0 10px;
+	}
+	.message {
+		margin-left: 10px;
+	}
+`;
+
+interface Props {
+	items: WarningOrError[];
+}
+
+export const WarningBox = (props: Props) => {
+	return (
+		<WarningBoxRoot>
+			<Icon name="alert" className="alert" />
+			<div className="message">
+				{props.items.map(_ => {
+					const split = _.message.split("\n");
+
+					return split.map((item, index) => {
+						const templateRe = /(.*)\[(.+)\](.*)/g;
+						const match = templateRe.exec(item);
+						if (match != null) {
+							const [, pre, linkText, post] = match;
+							return (
+								<div key={"warningOrError_" + index}>
+									{pre}
+									<Link href={_.helpUrl!}>{linkText}</Link>
+									{post}
+								</div>
+							);
+						} else {
+							return (
+								<div key={"warningOrError_" + index}>
+									{item}
+									{_.helpUrl && split.length - 1 === index && (
+										<>
+											{" "}
+											<Link href={_.helpUrl!}>Learn more</Link>
+										</>
+									)}
+									<br />
+								</div>
+							);
+						}
+					});
+				})}
+			</div>
+		</WarningBoxRoot>
+	);
+};


### PR DESCRIPTION
when passing along to referenceEntityCreateOrUpdateRepository

this fails:

git@source.foo.us/distributed-cheese/distributed_cheese_service.git 

this works:

ssh://git@source.foo.us/distributed-cheese/distributed_cheese_service.git

now, both will work!


I've also added some things from the MLT branch:

- adding error handling for that entity/repo picker in the OBS sidebar
- adding more sophisticated entity search. instead of just looking for entities named exactly what the git repo name is, we will split on split characters (-, _) and try to find entities with those words (this is what we use to generate that entity selector dropdown)
- related to above, i've added a search/filter to that dropdown
