### PR TITLE
optional folder.name when attempting to match currentrepo

### DIFF
--- a/shared/ui/Stream/PullRequest.tsx
+++ b/shared/ui/Stream/PullRequest.tsx
@@ -350,7 +350,7 @@ export const PullRequest = () => {
 						const currentOpenRepo = openRepos.find(
 							_ =>
 								_?.name.toLowerCase() === pr.repository?.name?.toLowerCase() ||
-								_?.folder.name.toLowerCase() === pr.repository?.name?.toLowerCase()
+								_?.folder?.name?.toLowerCase() === pr.repository?.name?.toLowerCase()
 						);
 						setCurrentRepoChanged(
 							!!(e.data.repo && currentOpenRepo && currentOpenRepo.currentBranch == pr.headRefName)
@@ -371,7 +371,7 @@ export const PullRequest = () => {
 			const currentRepo = openRepos.find(
 				_ =>
 					_?.name.toLowerCase() === pr.repository?.name?.toLowerCase() ||
-					_?.folder.name.toLowerCase() === pr.repository?.name?.toLowerCase()
+					_?.folder?.name?.toLowerCase() === pr.repository?.name?.toLowerCase()
 			);
 			if (!currentRepo) {
 				return `You don't have the ${pr.repository?.name} repo open in your IDE`;


### PR DESCRIPTION
Introduced when fixing customer issue edge case where a repo was recently renamed.


[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/wGLMWXvGTaKbSKE06qnW9g?src=GitHub) by bcanzanella on Feb 24, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>