### PR TITLE
Logging for broken nr1 open in ide flow

### DIFF
--- a/shared/ui/Stream/CodeErrorNav.tsx
+++ b/shared/ui/Stream/CodeErrorNav.tsx
@@ -797,6 +797,14 @@ export function CodeErrorNav(props: Props) {
 
 	if (error) {
 		// essentially a roadblock
+		logError(`${error?.title || "Error"}, Description: Internal Debugging Variables`, {
+			currentCodeErrorId: derivedState.currentCodeErrorId!,
+			errorGroupGuid: derivedState.codeError?.objectId || pendingErrorGroupGuid!,
+			parseableAccountId: derivedState.codeError?.objectId || pendingErrorGroupGuid!,
+			occurrenceId: occurrenceId,
+			entityGuid: derivedState.codeError?.objectInfo?.entityId,
+			timestamp: derivedState.currentCodeErrorData?.timestamp
+		});
 		return (
 			<Dismissable
 				title={error.title || "Error"}

--- a/shared/ui/store/codeErrors/actions.ts
+++ b/shared/ui/store/codeErrors/actions.ts
@@ -460,26 +460,36 @@ export const openErrorGroup = (
 		await dispatch(addCodeErrors([response.codeError]));
 	}
 
-	dispatch(findErrorGroupByObjectId(errorGroupGuid, occurrenceId)).then(codeError => {
-		// if we found an existing codeError, it exists in the data store
-		const pendingId = codeError ? codeError.id : PENDING_CODE_ERROR_ID_FORMAT(errorGroupGuid);
+	dispatch(findErrorGroupByObjectId(errorGroupGuid, occurrenceId))
+		.then(codeError => {
+			// if we found an existing codeError, it exists in the data store
+			const pendingId = codeError ? codeError.id : PENDING_CODE_ERROR_ID_FORMAT(errorGroupGuid);
 
-		// this signals that when the user provides an API key (which they don't have yet),
-		// we will circle back to this action to try to claim the code error again
-		if (response.needNRToken) {
-			data.claimWhenConnected = true;
-		} else {
-			data.pendingRequiresConnection = data.claimWhenConnected = false;
-		}
+			// this signals that when the user provides an API key (which they don't have yet),
+			// we will circle back to this action to try to claim the code error again
+			if (response.needNRToken) {
+				data.claimWhenConnected = true;
+			} else {
+				data.pendingRequiresConnection = data.claimWhenConnected = false;
+			}
 
-		// NOTE don't really like this "PENDING" business, but it's something to say we need to CREATE a codeError
-		// rationalie is: instead of creating _another_ codeError router-like UI,
-		// just re-use the CodeErrorNav component which already does some work for
-		// directing / opening a codeError
-		dispatch(setCurrentCodeError(pendingId, data));
+			// NOTE don't really like this "PENDING" business, but it's something to say we need to CREATE a codeError
+			// rationalie is: instead of creating _another_ codeError router-like UI,
+			// just re-use the CodeErrorNav component which already does some work for
+			// directing / opening a codeError
+			dispatch(setCurrentCodeError(pendingId, data));
 
-		dispatch(openPanel(WebviewPanels.CodemarksForFile));
-	});
+			dispatch(openPanel(WebviewPanels.CodemarksForFile));
+		})
+		.catch(ex => {
+			logError(`failed to findErrorGroupByObjectId`, {
+				ex,
+				errorGroupGuid,
+				occurrenceId,
+				claimResponse: response,
+				data
+			});
+		});
 };
 
 export const PENDING_CODE_ERROR_ID_PREFIX = "PENDING";


### PR DESCRIPTION
We need more data to figure out why some users are getting to the final stages of the open in ide sign up flow, but not viewing an actual error.


[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/KMx99m7jSyCr2cK_nAFCrg?src=GitHub) by bcanzanella on Feb 25, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>