### PR TITLE
duplicate repos in observibility section

### DIFF
--- a/shared/agent/src/providers/newrelic.ts
+++ b/shared/agent/src/providers/newrelic.ts
@@ -647,10 +647,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 		try {
 			const { scm } = SessionContainer.instance();
 			const reposResponse = await scm.getRepos({ inEditorOnly: true, includeRemotes: true });
-			console.warn("eric reposResponse", reposResponse);
 			let filteredRepos: ReposScm[] | undefined = reposResponse?.repositories;
-			console.warn("eric filteredRepos", filteredRepos);
-			console.warn("eric request", request);
 			if (request?.filters?.length) {
 				const repoIds = request.filters.map(_ => _.repoId);
 				filteredRepos = reposResponse.repositories?.filter(r => r.id && repoIds.includes(r.id))!;

--- a/shared/agent/src/providers/newrelic.ts
+++ b/shared/agent/src/providers/newrelic.ts
@@ -647,7 +647,10 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 		try {
 			const { scm } = SessionContainer.instance();
 			const reposResponse = await scm.getRepos({ inEditorOnly: true, includeRemotes: true });
+			console.warn("eric reposResponse", reposResponse);
 			let filteredRepos: ReposScm[] | undefined = reposResponse?.repositories;
+			console.warn("eric filteredRepos", filteredRepos);
+			console.warn("eric request", request);
 			if (request?.filters?.length) {
 				const repoIds = request.filters.map(_ => _.repoId);
 				filteredRepos = reposResponse.repositories?.filter(r => r.id && repoIds.includes(r.id))!;
@@ -666,7 +669,15 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 					);
 					continue;
 				}
-				const folderName = this.getRepoName(repo);
+				const folderName = this.getRepoName(repo.folder);
+
+				if (response.repos.some(_ => _?.repoName === folderName)) {
+					ContextLogger.warn("getObservabilityRepos skipping duplicate repo name", {
+						repo: repo
+					});
+					continue;
+				}
+
 				let remotes: string[] = [];
 				for (const remote of repo.remotes) {
 					if (remote.name === "origin" || remote.remoteWeight === 0) {


### PR DESCRIPTION
in the unlikey chance there are duplciate repo names, don't return the duplicate repo in the agent response.


[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/n-i4khVaRX2yMnC_P6q8DA?src=GitHub) by bcanzanella on Mar 1, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>