### PR TITLE
Misc cleanup from pairing with Marcelo

### DIFF
--- a/jb/build.gradle
+++ b/jb/build.gradle
@@ -76,8 +76,6 @@ intellij {
     // version "PC-2018.2"
 
     intellij.updateSinceUntilBuild = false
-    // Run on a locally installed IDE, different from the build dependency specified via type/version
-    // intellij.alternativeIdePath = idePath
 
     plugins = ['git4idea', 'org.jetbrains.plugins.go:211.7142.36', 'Pythonid:211.7142.45']
 }
@@ -88,10 +86,16 @@ runIde {
 //    jvmArgs '-Dsun.java2d.uiScale.enabled=false'
 //    jvmArgs '-Dkotlinx.coroutines.debug=on'
 //    jvmArgs '-Dcom.codestream.recordRequests=true'
-    jvmArgs '-Dcom.codestream.webview=/Users/mfarias/Code/codestream/jb/src/main/resources/webview'
-    jvmArgs '-Dcom.codestream.agent=/Users/mfarias/Code/codestream/shared/agent/dist'
+    jvmArgs "-Dcom.codestream.webview=$projectDir/src/main/resources/webview"
+    jvmArgs "-Dcom.codestream.agent=$projectDir/../shared/agent/dist"
     jvmArgs '-Xmx2048m'
     jvmArgs '-Xms128m'
+    // M1 mac workaround - for now need to run on a locally installed IDE, different from the build dependency
+    // specified via type/version
+    // set ideDir in ~/.gradle/gradle.properties i.e. ideDir=/Applications/IntelliJ IDEA.app/Contents
+    if (project.ideDir && !project.ideDir.isEmpty()) {
+        ideDir.set(file(project.ideDir))
+    }
 }
 
 import org.gradle.internal.os.OperatingSystem

--- a/jb/gradle.properties
+++ b/jb/gradle.properties
@@ -1,2 +1,2 @@
 kotlin.code.style=official
-idePath=
+ideDir=

--- a/jb/src/main/kotlin/actions/OpenDevTools.kt
+++ b/jb/src/main/kotlin/actions/OpenDevTools.kt
@@ -1,10 +1,15 @@
 package com.codestream.actions
 
+import com.codestream.DEBUG
 import com.codestream.webViewService
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAwareAction
 
 class OpenDevTools : DumbAwareAction() {
+    override fun update(e: AnActionEvent) {
+        e.presentation.isVisible = DEBUG
+    }
+
     override fun actionPerformed(e: AnActionEvent) {
         e.project?.webViewService?.openDevTools()
     }


### PR DESCRIPTION
- Make codestream webview dynamic based on $projectDir
- Add conditional gradle property for `ideDir` so you can opt-in to pointing to local IDE install (needed for m1 mac)
- Make devtools only available when DEBUG set


[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/aQnk3CW5TAG1czcn4AtSaw?src=GitHub) by bcanzanella on Mar 9, 2022

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>