### PR TITLE
repo not open tracking event for code errors

### DIFF
--- a/shared/ui/Stream/CodeErrorNav.tsx
+++ b/shared/ui/Stream/CodeErrorNav.tsx
@@ -499,6 +499,7 @@ export function CodeErrorNav(props: Props) {
 							targetRemote,
 							timestamp: derivedState.currentCodeErrorData?.timestamp
 						});
+						HostApi.instance.track("Page Viewed", { "Page Name": "NR Repo Not Open" });
 						return;
 					}
 					repoId = reposResponse.repos[0].id!;


### PR DESCRIPTION



[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/OiZRZ4r_Qj6PzwvOa46X0w?src=GitHub) by bcanzanella on Mar 10, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>