### PR TITLE
add delay to initial load of third party cards in issues

### DIFF
--- a/shared/ui/Stream/CrossPostIssueControls/IssueDropdown.tsx
+++ b/shared/ui/Stream/CrossPostIssueControls/IssueDropdown.tsx
@@ -520,9 +520,11 @@ export const IssueList = React.memo((props: React.PropsWithChildren<IssueListPro
 			// dispatch(bootstrapCodemarks());
 		}
 		//setup blank data state for provider cards
-		props.providers.forEach(provider => {
-			updateDataState(provider.id, { cards: [] });
-		});
+		setTimeout(() => {
+			props.providers.forEach(provider => {
+				updateDataState(provider.id, { cards: [] });
+			});
+		}, 1000);
 	});
 
 	useEffect(() => {
@@ -593,11 +595,11 @@ export const IssueList = React.memo((props: React.PropsWithChildren<IssueListPro
 		};
 	}, [derivedState.providerIds, reload]);
 
-	const delay = n => {
-		return new Promise(resolve => {
-			setTimeout(resolve, n * 1000);
-		});
-	};
+	// const delay = n => {
+	// 	return new Promise(resolve => {
+	// 		setTimeout(resolve, n * 1000);
+	// 	});
+	// };
 
 	// Fetch initial cards here, api call triggered once initial updateDataState is complete
 	// Without doing this, we run into an issue where cards are fetched too early and nothing
@@ -616,7 +618,7 @@ export const IssueList = React.memo((props: React.PropsWithChildren<IssueListPro
 				// Calling this too early on initial load can cause an issue where
 				// nothing is returned.
 				// @TODO: See if there is further optimization that could be done here.
-				await delay(1);
+				// await delay(1);
 				await Promise.all(
 					props.providers.map(async provider => {
 						const filterCustom = getFilterCustom(provider.id);
@@ -1309,12 +1311,14 @@ export const IssueList = React.memo((props: React.PropsWithChildren<IssueListPro
 					{cards.length == 0 &&
 					selectedLabel !== "issues assigned to you" &&
 					!props.loadingMessage &&
+					initialLoadComplete &&
 					(props.providers.length > 0 || derivedState.skipConnect) ? (
 						<FilterMissing>The selected filter(s) did not return any issues.</FilterMissing>
 					) : (
 						!props.loadingMessage &&
 						(props.providers.length > 0 || derivedState.skipConnect) &&
-						cards.length == 0 && (
+						cards.length == 0 &&
+						initialLoadComplete && (
 							<FilterMissing>There are no open issues assigned to you.</FilterMissing>
 						)
 					)}

--- a/shared/ui/Stream/CrossPostIssueControls/IssueDropdown.tsx
+++ b/shared/ui/Stream/CrossPostIssueControls/IssueDropdown.tsx
@@ -520,11 +520,9 @@ export const IssueList = React.memo((props: React.PropsWithChildren<IssueListPro
 			// dispatch(bootstrapCodemarks());
 		}
 		//setup blank data state for provider cards
-		setTimeout(() => {
-			props.providers.forEach(provider => {
-				updateDataState(provider.id, { cards: [] });
-			});
-		}, 1000);
+		props.providers.forEach(provider => {
+			updateDataState(provider.id, { cards: [] });
+		});
 	});
 
 	useEffect(() => {

--- a/shared/ui/Stream/CrossPostIssueControls/IssueDropdown.tsx
+++ b/shared/ui/Stream/CrossPostIssueControls/IssueDropdown.tsx
@@ -593,6 +593,12 @@ export const IssueList = React.memo((props: React.PropsWithChildren<IssueListPro
 		};
 	}, [derivedState.providerIds, reload]);
 
+	const delay = n => {
+		return new Promise(resolve => {
+			setTimeout(resolve, n * 1000);
+		});
+	};
+
 	// Fetch initial cards here, api call triggered once initial updateDataState is complete
 	// Without doing this, we run into an issue where cards are fetched too early and nothing
 	// is loaded into cards array.  User would have to use reload button to see cards.
@@ -606,6 +612,11 @@ export const IssueList = React.memo((props: React.PropsWithChildren<IssueListPro
 		if (selectedProvidersHaveBeenInitialized && !initialLoadComplete) {
 			void (async () => {
 				setIsLoading(true);
+				// API needs a second to register with third party providers ???
+				// Calling this too early on initial load can cause an issue where
+				// nothing is returned.
+				// @TODO: See if there is further optimization that could be done here.
+				await delay(1);
 				await Promise.all(
 					props.providers.map(async provider => {
 						const filterCustom = getFilterCustom(provider.id);

--- a/shared/ui/Stream/CrossPostIssueControls/IssueDropdown.tsx
+++ b/shared/ui/Stream/CrossPostIssueControls/IssueDropdown.tsx
@@ -593,11 +593,11 @@ export const IssueList = React.memo((props: React.PropsWithChildren<IssueListPro
 		};
 	}, [derivedState.providerIds, reload]);
 
-	// const delay = n => {
-	// 	return new Promise(resolve => {
-	// 		setTimeout(resolve, n * 1000);
-	// 	});
-	// };
+	const delay = n => {
+		return new Promise(resolve => {
+			setTimeout(resolve, n * 1000);
+		});
+	};
 
 	// Fetch initial cards here, api call triggered once initial updateDataState is complete
 	// Without doing this, we run into an issue where cards are fetched too early and nothing
@@ -616,7 +616,7 @@ export const IssueList = React.memo((props: React.PropsWithChildren<IssueListPro
 				// Calling this too early on initial load can cause an issue where
 				// nothing is returned.
 				// @TODO: See if there is further optimization that could be done here.
-				// await delay(1);
+				await delay(1);
 				await Promise.all(
 					props.providers.map(async provider => {
 						const filterCustom = getFilterCustom(provider.id);


### PR DESCRIPTION
Not particularly happy about this, but its the best solution I could find. 
 
I discovered this was the issue when having only one filter in the issues section for non-git cards.  If there was a breakpoint in dev tools here, it would load.  If there was not, it would fail.  Thats how I eventually came to this solution, a second delay on initial card load.


[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/iqLejwNLRdGc8v9GWt-Ieg?src=GitHub) by bcanzanella on Mar 10, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>