### PR TITLE
CDSTRM-1599: Clean up review requested team list

### DIFF
--- a/shared/ui/Stream/PullRequestReviewStatus.tsx
+++ b/shared/ui/Stream/PullRequestReviewStatus.tsx
@@ -107,6 +107,7 @@ export const PullRequestReviewStatus = (props: {
 
 	const { pr, opinionatedReviews = [] } = props;
 	const pendingReviewers = pr.reviewRequests.nodes;
+	const pendingReviewersTeams = pendingReviewers.filter(_ => !_.requestedReviewer).length;
 
 	const reviewState = useMemo(() => {
 		const approvals = opinionatedReviews.filter(review => review.state === "APPROVED");
@@ -241,12 +242,24 @@ export const PullRequestReviewStatus = (props: {
 				<PRShortStatusRow>
 					<div style={{ width: "30px", height: "30px" }} />
 					<div className="middle">
-						{pendingReviewers.map(review => (
+						{pendingReviewersTeams && (
 							<div style={{ padding: "5px 0" }}>
-								<PRHeadshotName person={review.requestedReviewer} />{" "}
-								<span className="subtle">was requested for review</span>
+								<b>
+									{pendingReviewersTeams} {pendingReviewersTeams === 1 ? "team" : "teams"}
+								</b>{" "}
+								<span className="subtle">
+									{pendingReviewersTeams === 1 ? "was" : "were"} requested for review
+								</span>
 							</div>
-						))}
+						)}
+						{pendingReviewers
+							.filter(review => review.requestedReviewer)
+							.map(review => (
+								<div style={{ padding: "5px 0" }}>
+									<PRHeadshotName person={review.requestedReviewer} />{" "}
+									<span className="subtle">was requested for review</span>
+								</div>
+							))}
 					</div>
 				</PRShortStatusRow>
 			)}


### PR DESCRIPTION
We can't actually get the team names that have been requested for review on GitHub PRs, so this updates the PR status display to render a generic count of the number of teams requested for review, similar to what we do in the timeline view already, rather than attempting and failing to render the team name and avatar.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>