### PR TITLE
customer with @ signs in filepath was failing to parse stack trace when open in ide

### DIFF
--- a/shared/agent/src/managers/stackTraceParsers/javaStackTraceParser.ts
+++ b/shared/agent/src/managers/stackTraceParsers/javaStackTraceParser.ts
@@ -2,11 +2,14 @@
 
 import { CSStackTraceInfo } from "../../protocol/api.protocol.models";
 import { Strings } from "../../system/string";
+import { Logger } from "../../logger";
 
 let regex: RegExp;
 
 export function Parser(stack: string): CSStackTraceInfo {
 	const info: CSStackTraceInfo = { lines: [] };
+
+	Logger.log(`Stacktrace to be parsed by javaStackTraceParser.ts: ${stack}`);
 
 	if (!regex) {
 		// NOTE: there's no great way to have a multiline regex in js (except for this hackery ;)
@@ -16,7 +19,7 @@ export function Parser(stack: string): CSStackTraceInfo {
 			\s*
 			(at)? // at
 			\s+
-			((?:(?:[\d\w\/]*\.)*[\d\w\/]*))\. // package
+			((?:(?:[\d\w\/\@]*\.)*[\d\w\/]*))\. // package
 			([\d\w\$]*)\. // class
 			([\d\w\$]*) // method
 			\(


### PR DESCRIPTION



[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/n9VEwOvVRk2uWsm0YM0sRg?src=GitHub) by bcanzanella on Mar 22, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>