### PR TITLE
When getting repo name for observability, we should base it off of path not folder.file

### DIFF
--- a/shared/agent/src/managers/scmManager.ts
+++ b/shared/agent/src/managers/scmManager.ts
@@ -166,6 +166,7 @@ export class ScmManager {
 		try {
 			const { git } = SessionContainer.instance();
 			repositories = Array.from(await git.getRepositories());
+			console.warn("eric repositories", repositories);
 			if (request && request.inEditorOnly && repositories) {
 				repositories = repositories.filter(_ => _.isInWorkspace);
 			}
@@ -1591,7 +1592,7 @@ export class ScmManager {
 		try {
 			let fetchReferenceFailed = false;
 			if (repo && request.ref) {
-				fetchReferenceFailed = !await git.fetchReference(repo, request.ref);
+				fetchReferenceFailed = !(await git.fetchReference(repo, request.ref));
 			}
 			const shas = [request.baseSha, request.headSha];
 			const results = await Promise.all(

--- a/shared/agent/src/managers/scmManager.ts
+++ b/shared/agent/src/managers/scmManager.ts
@@ -166,7 +166,6 @@ export class ScmManager {
 		try {
 			const { git } = SessionContainer.instance();
 			repositories = Array.from(await git.getRepositories());
-			console.warn("eric repositories", repositories);
 			if (request && request.inEditorOnly && repositories) {
 				repositories = repositories.filter(_ => _.isInWorkspace);
 			}

--- a/shared/agent/src/providers/newrelic.ts
+++ b/shared/agent/src/providers/newrelic.ts
@@ -462,6 +462,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 		request: GetObservabilityEntitiesRequest
 	): Promise<GetObservabilityEntitiesResponse> {
 		try {
+			console.warn("eric", request);
 			const key = request.appName
 				? request.appName
 				: request.appNames?.length
@@ -695,6 +696,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 		try {
 			const { scm } = SessionContainer.instance();
 			const reposResponse = await scm.getRepos({ inEditorOnly: true, includeRemotes: true });
+			console.warn("eric reposResponse newrelic.ts", reposResponse);
 			let filteredRepos: ReposScm[] | undefined = reposResponse?.repositories;
 			if (request?.filters?.length) {
 				const repoIds = request.filters.map(_ => _.repoId);
@@ -703,6 +705,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 
 			filteredRepos = filteredRepos?.filter(_ => _.id);
 			if (!filteredRepos || !filteredRepos.length) return response;
+			console.warn("eric filteredRepos newrelic.ts", filteredRepos);
 
 			for (const repo of filteredRepos) {
 				if (!repo.id || !repo.remotes || !repo.remotes.length) {
@@ -714,7 +717,9 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 					);
 					continue;
 				}
-				const folderName = this.getRepoName(repo);
+				const folderName = this.getRepoName({ path: repo.path });
+
+				console.warn("eric folderName", folderName);
 
 				if (response.repos.some(_ => _?.repoName === folderName)) {
 					ContextLogger.warn("getObservabilityRepos skipping duplicate repo name", {
@@ -861,6 +866,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 			// NOTE: might be able to eliminate some of this if we can get a list of entities
 			const { scm } = SessionContainer.instance();
 			const reposResponse = await scm.getRepos({ inEditorOnly: true, includeRemotes: true });
+			console.warn("eric reposResponse", reposResponse);
 			let filteredRepos: ReposScm[] | undefined = reposResponse?.repositories;
 			let filteredRepoIds: string[] = [];
 			if (request?.filters?.length) {
@@ -3231,7 +3237,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 		return undefined;
 	}
 
-	private getRepoName(repoLike: { folder: { name?: string; uri: string }; path: string }) {
+	private getRepoName(repoLike: { folder?: { name?: string; uri: string }; path: string }) {
 		try {
 			if (!repoLike) return "repo";
 

--- a/shared/agent/src/providers/newrelic.ts
+++ b/shared/agent/src/providers/newrelic.ts
@@ -462,7 +462,6 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 		request: GetObservabilityEntitiesRequest
 	): Promise<GetObservabilityEntitiesResponse> {
 		try {
-			console.warn("eric", request);
 			const key = request.appName
 				? request.appName
 				: request.appNames?.length
@@ -696,7 +695,6 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 		try {
 			const { scm } = SessionContainer.instance();
 			const reposResponse = await scm.getRepos({ inEditorOnly: true, includeRemotes: true });
-			console.warn("eric reposResponse newrelic.ts", reposResponse);
 			let filteredRepos: ReposScm[] | undefined = reposResponse?.repositories;
 			if (request?.filters?.length) {
 				const repoIds = request.filters.map(_ => _.repoId);
@@ -705,7 +703,6 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 
 			filteredRepos = filteredRepos?.filter(_ => _.id);
 			if (!filteredRepos || !filteredRepos.length) return response;
-			console.warn("eric filteredRepos newrelic.ts", filteredRepos);
 
 			for (const repo of filteredRepos) {
 				if (!repo.id || !repo.remotes || !repo.remotes.length) {
@@ -718,8 +715,6 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 					continue;
 				}
 				const folderName = this.getRepoName({ path: repo.path });
-
-				console.warn("eric folderName", folderName);
 
 				if (response.repos.some(_ => _?.repoName === folderName)) {
 					ContextLogger.warn("getObservabilityRepos skipping duplicate repo name", {
@@ -866,7 +861,6 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 			// NOTE: might be able to eliminate some of this if we can get a list of entities
 			const { scm } = SessionContainer.instance();
 			const reposResponse = await scm.getRepos({ inEditorOnly: true, includeRemotes: true });
-			console.warn("eric reposResponse", reposResponse);
 			let filteredRepos: ReposScm[] | undefined = reposResponse?.repositories;
 			let filteredRepoIds: string[] = [];
 			if (request?.filters?.length) {


### PR DESCRIPTION



[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/YXgWCMmiRZq27a4uM8SDvQ?src=GitHub) by bcanzanella on Mar 25, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>