### PR TITLE
NR User ID fails to be set in scenario where newrelic data is not nested within providerInfo[teamID]

### DIFF
--- a/shared/agent/src/protocol/api.protocol.models.ts
+++ b/shared/agent/src/protocol/api.protocol.models.ts
@@ -543,6 +543,7 @@ export interface CSProviderInfo {
 	userId?: string;
 	isApiToken?: boolean;
 	hosts?: { [host: string]: CSProviderInfos };
+	orgIds?: number[];
 	data?: {
 		baseUrl?: string;
 		scopes?: string;

--- a/shared/agent/src/session.ts
+++ b/shared/agent/src/session.ts
@@ -1538,13 +1538,14 @@ export class CodeStreamSession {
 			user.firstSessionStartedAt <= Date.now() + FIRST_SESSION_TIMEOUT;
 
 		if (user.providerInfo) {
-			const data = team && user.providerInfo[team.id]?.newrelic?.data;
+			const data =
+				(team && user.providerInfo[team.id]?.newrelic?.data) || user.providerInfo.newrelic.data;
 			if (data) {
 				if (data.userId) {
 					props["NR User ID"] = data.userId;
 				}
-				if (data.orgIds && data.orgIds.length) {
-					props["NR Organization ID"] = data.orgIds[0];
+				if (data?.orgIds && data.orgIds?.length) {
+					props["NR Organization ID"] = data?.orgIds[0];
 				}
 			}
 		}


### PR DESCRIPTION



[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/qrWqj99PTNiyVswGlII-TQ?src=GitHub) by cstryker on Mar 30, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>