### PR TITLE
NR-439 Remove dependence on createmeta for Jira and Jira Server

### DIFF
--- a/shared/agent/src/providers/jira.ts
+++ b/shared/agent/src/providers/jira.ts
@@ -249,21 +249,6 @@ export class JiraProvider extends ThirdPartyIssueProviderBase<CSJiraProviderInfo
 		}
 	}
 
-	/*
-	This is the start of an idea based on this link:
-	https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html
-	which suggests that the createmeta endpoint is problematic and going away
-	Indeed, it is very slow, but so far I have not been able to get their suggested replacement to work,
-	so am leaving this alternate method commented out for now, perhaps to be revisited later - Colin
-	*/
-	private async isCompatibleProject(project: JiraProject): Promise<JiraBoard | undefined> {
-		const response = await this.get<JiraProjectsMetaResponse>(
-			`/rest/api/2/issue/createmeta/${project.id}/issuetypes`
-		);
-		// TODO: do something with this response, like what filterBoards does, below
-		return undefined;
-	}
-
 	private async filterBoards(projects: JiraProject[]): Promise<JiraBoard[]> {
 		Logger.debug("Jira: Filtering for compatible projects");
 		try {

--- a/shared/agent/src/providers/jiraserver.ts
+++ b/shared/agent/src/providers/jiraserver.ts
@@ -28,6 +28,18 @@ import { CSJiraServerProviderInfo } from "../protocol/api.protocol";
 import { CodeStreamSession } from "../session";
 import { Iterables, log, lspProvider } from "../system";
 import { makeCardFromJira } from "./jira";
+import {
+	CardSearchResponse,
+	CreateJiraIssueResponse,
+	IssueType,
+	IssueTypeDescriptor,
+	IssueTypeDetails,
+	IssueTypeFields,
+	JiraPaginateValues,
+	JiraProject,
+	JiraProjectsMetaResponse,
+	JiraServerOauthParams
+} from "./jiraserver.types";
 import { ThirdPartyIssueProviderBase } from "./provider";
 
 export type jsonCallback = (
@@ -101,44 +113,6 @@ class OAuthExtended extends OAuth {
 		const httpModel = sslEnabled ? Https : Http;
 		return httpModel.request(options);
 	}
-}
-
-interface JiraServerOauthParams {
-	consumerKey: string;
-	privateKey: string;
-}
-
-interface JiraProject {
-	id: string;
-	name: string;
-	key: string;
-}
-
-interface IssueTypeDescriptor {
-	name: string;
-	iconUrl: string;
-	fields: { [name: string]: { required: boolean; hasDefaultValue: boolean } };
-}
-
-interface JiraProjectMeta extends JiraProject {
-	issuetypes: IssueTypeDescriptor[];
-}
-
-interface JiraProjectsMetaResponse {
-	projects: JiraProjectMeta[];
-}
-
-interface CreateJiraIssueResponse {
-	id: string;
-	key: string;
-	self: string;
-}
-
-interface CardSearchResponse {
-	issues: JiraCard[];
-	nextPage?: string;
-	isLast: boolean;
-	total: number;
 }
 
 @lspProvider("jiraserver")
@@ -228,11 +202,38 @@ export class JiraServerProvider extends ThirdPartyIssueProviderBase<CSJiraServer
 				this._providerInfo!.accessToken,
 				this._providerInfo!.oauthTokenSecret,
 				(error, result) => {
-					if (error) reject(error);
-					else resolve(result);
+					if (error) {
+						reject(error);
+					} else {
+						resolve(result);
+					}
 				}
 			);
 		});
+	}
+
+	async _getJiraPaged<R extends object>(path: string): Promise<R[]> {
+		const basePath = path.includes("?") ? path.split("?")[0] : path;
+		let nextPage: string | undefined = path;
+		const values: R[] = [];
+		while (nextPage !== undefined) {
+			const response: JiraPaginateValues<R> = await this._getJira<R>(nextPage);
+			if (response.values && response.values.length > 0) {
+				values.push(...response.values);
+			}
+			Logger.debug(`Jira server paged: is last page? ${response.isLast}`);
+			if (!response.isLast) {
+				const existingParams = path.includes("?") ? qs.parse(path.split("?")[1]) : {};
+				nextPage = `${basePath}?${qs.stringify({
+					...existingParams,
+					startAt: (response.startAt + response.maxResults).toString(10)
+				})}`;
+			} else {
+				Logger.debug("Jira: there are no more pages");
+				nextPage = undefined;
+			}
+		}
+		return values;
 	}
 
 	async _getJira<R extends object>(path: string): Promise<any> {
@@ -261,6 +262,7 @@ export class JiraServerProvider extends ThirdPartyIssueProviderBase<CSJiraServer
 			this.boards = [];
 			const response: JiraProject[] = await this._getJira<JiraProject[]>("/rest/api/2/project");
 			this.boards.push(...(await this.filterBoards(response)));
+			Logger.debug(`Jira Server: got ${this.boards.length} projects`);
 			return { boards: this.boards };
 		} catch (error) {
 			debugger;
@@ -275,16 +277,39 @@ export class JiraServerProvider extends ThirdPartyIssueProviderBase<CSJiraServer
 		}
 	}
 
+	private async gatherProjectMetadata(projects: JiraProject[]): Promise<JiraProjectsMetaResponse> {
+		const jiraProjectsFieldDetails: JiraProjectsMetaResponse = { projects: [] };
+		for (const project of projects) {
+			const issueTypesResponse: IssueType[] = await this._getJiraPaged(
+				`/rest/api/2/issue/createmeta/${project.id}/issuetypes`
+			);
+
+			const issuetypes: IssueTypeDescriptor[] = [];
+
+			jiraProjectsFieldDetails.projects.push({
+				...project,
+				issuetypes
+			});
+
+			for (const issueType of issueTypesResponse) {
+				const issueTypeDetails: IssueTypeDetails[] = await this._getJiraPaged(
+					`/rest/api/2/issue/createmeta/${project.id}/issuetypes/${issueType.id}`
+				);
+				const fields: IssueTypeFields = {};
+				for (const field of issueTypeDetails) {
+					fields[field.name] = { ...field };
+				}
+
+				issuetypes.push({ ...issueType, fields });
+			}
+		}
+		return jiraProjectsFieldDetails;
+	}
+
 	private async filterBoards(projects: JiraProject[]): Promise<JiraBoard[]> {
 		Logger.debug("Jira Server: Filtering for compatible projects");
 		try {
-			const response = await this._getJira(
-				`/rest/api/2/issue/createmeta?${qs.stringify({
-					projectIds: projects.map(p => p.id).join(","),
-					expand: "projects.issuetypes.fields"
-				})}`
-			);
-			return this.getCompatibleBoards(response);
+			return this.getCompatibleBoards(await this.gatherProjectMetadata(projects));
 		} catch (error) {
 			Container.instance().errorReporter.reportMessage({
 				type: ReportingMessageType.Error,

--- a/shared/agent/src/providers/jiraserver.types.ts
+++ b/shared/agent/src/providers/jiraserver.types.ts
@@ -1,0 +1,77 @@
+import { JiraCard } from "../protocol/agent.protocol.jira";
+
+export interface JiraPaginate {
+	maxResults: number;
+	startAt: number;
+	total: number;
+	isLast: boolean;
+}
+
+export interface JiraPaginateValues<T> extends JiraPaginate {
+	values: T[];
+}
+
+export interface JiraServerOauthParams {
+	consumerKey: string;
+	privateKey: string;
+}
+
+export interface JiraProject {
+	id: string;
+	name: string;
+	key: string;
+}
+
+export interface IssueTypeFields {
+	[name: string]: { required: boolean; hasDefaultValue: boolean };
+}
+
+export interface IssueTypeDescriptor {
+	name: string;
+	iconUrl: string;
+	fields: IssueTypeFields;
+}
+
+export interface JiraProjectMeta extends JiraProject {
+	issuetypes: IssueTypeDescriptor[];
+}
+
+export interface JiraProjectsMetaResponse {
+	projects: JiraProjectMeta[];
+}
+
+export interface CreateJiraIssueResponse {
+	id: string;
+	key: string;
+	self: string;
+}
+
+export interface CardSearchResponse {
+	issues: JiraCard[];
+	nextPage?: string;
+	isLast: boolean;
+	total: number;
+}
+
+export interface IssueType {
+	self: string;
+	id: string;
+	description: string;
+	iconUrl: string;
+	name: string;
+	subtask: boolean;
+}
+
+export interface IssueTypeDetails {
+	required: boolean;
+	schema: {
+		items: string;
+		type: string;
+		system: string;
+	};
+	name: string;
+	fieldId: string;
+	autocompleteUrl: string;
+	hasDefaultValue: boolean;
+	operations: string[];
+}


### PR DESCRIPTION


**This PR Addresses:**  
[NR-439 Remove dependence on createmeta for Jira and Jira Server](https://issues.newrelic.com/browse/NR-439)  


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>