### PR TITLE
NR-864 Ruby symbol lookup in JetBrains

### DIFF
--- a/shared/agent/src/providers/newrelic/methodAverageDurationQuery.ts
+++ b/shared/agent/src/providers/newrelic/methodAverageDurationQuery.ts
@@ -1,3 +1,5 @@
+import { LanguageId } from "../newrelic";
+
 function mapRubyTimesliceName(name: string): string {
 	if (name.startsWith("Nested/Controller")) {
 		return name.replace("Nested/", "");
@@ -7,7 +9,7 @@ function mapRubyTimesliceName(name: string): string {
 }
 
 export function generateMethodAverageDurationQuery(
-	languageId: string,
+	languageId: LanguageId,
 	newRelicEntityGuid: string,
 	metricTimesliceNames?: string[],
 	codeNamespace?: string


### PR DESCRIPTION
- Per slack discussion filter out MessageBroker/ spans for now
- Refactor for better typing / future special casing for other languages


**This PR Addresses:**  
[NR-5862 Investigate how to refresh CLM in JB IDEs](https://issues.newrelic.com/browse/NR-5862)  


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>