### PR TITLE
NR-12086 Occasional Jira error on startup

### DIFF
--- a/shared/agent/src/providers/jira.ts
+++ b/shared/agent/src/providers/jira.ts
@@ -137,14 +137,22 @@ export class JiraProvider extends ThirdPartyIssueProviderBase<CSJiraProviderInfo
 	}
 
 	async onConnected(providerInfo?: CSJiraProviderInfo) {
-		super.onConnected(providerInfo);
-		this._urlAddon = "";
+		await super.onConnected(providerInfo);
 		if (this._providerInfo?.isApiToken) {
 			this._webUrl = this._providerInfo?.data?.baseUrl || "";
+			Logger.log("jira using api token with webUrl", this._webUrl);
 			return;
 		}
+		if (this._urlAddon?.length > 0) {
+			return;
+		}
+
+		// Infinite loop if get also does ensureConnected() so pass flag to disable check
 		const response = await this.get<AccessibleResourcesResponse>(
-			"/oauth/token/accessible-resources"
+			"/oauth/token/accessible-resources",
+			undefined,
+			undefined,
+			false
 		);
 
 		Logger.debug("Jira: Accessible Resources are", response.body);

--- a/shared/agent/src/providers/jira.ts
+++ b/shared/agent/src/providers/jira.ts
@@ -182,7 +182,6 @@ export class JiraProvider extends ThirdPartyIssueProviderBase<CSJiraProviderInfo
 	@log()
 	async getBoards(request: FetchThirdPartyBoardsRequest): Promise<FetchThirdPartyBoardsResponse> {
 		if (this.boards.length > 0) return { boards: this.boards };
-		await this.ensureConnected();
 		try {
 			Logger.debug("Jira: fetching projects");
 			const jiraBoards: JiraBoard[] = [];
@@ -328,7 +327,6 @@ export class JiraProvider extends ThirdPartyIssueProviderBase<CSJiraProviderInfo
 
 	@log()
 	async getCards(request: FetchThirdPartyCardsRequest): Promise<FetchThirdPartyCardsResponse> {
-		await this.ensureConnected();
 		// /rest/api/2/search?jql=assignee=currentuser()
 		// https://developer.atlassian.com/server/jira/platform/jira-rest-api-examples/
 		// why don't we get assignees for subtasks?
@@ -413,7 +411,6 @@ export class JiraProvider extends ThirdPartyIssueProviderBase<CSJiraProviderInfo
 
 	@log()
 	async createCard(request: CreateThirdPartyCardRequest) {
-		await this.ensureConnected();
 		const data = request.data as CreateJiraCardRequest;
 		// using /api/2 because 3 returns nonsense errors for the same request
 		const body: { [k: string]: any } = {
@@ -444,7 +441,6 @@ export class JiraProvider extends ThirdPartyIssueProviderBase<CSJiraProviderInfo
 
 	@log()
 	async moveCard(request: MoveThirdPartyCardRequest) {
-		await this.ensureConnected();
 		try {
 			Logger.debug("Jira: moving card");
 			const response = await this.post(`/rest/api/2/issue/${request.cardId}/transitions`, {

--- a/shared/agent/src/providers/provider.ts
+++ b/shared/agent/src/providers/provider.ts
@@ -346,7 +346,6 @@ export abstract class ThirdPartyProviderBase<
 
 		this._readyPromise = this.onConnected(this._providerInfo);
 		await this._readyPromise;
-		this.resetReady();
 	}
 
 	protected async onConnected(providerInfo?: TProviderInfo) {
@@ -445,7 +444,9 @@ export abstract class ThirdPartyProviderBase<
 	protected async onDisconnected(request?: ThirdPartyDisconnect) {}
 
 	async ensureConnected(request?: { providerTeamId?: string }) {
-		if (this._readyPromise !== undefined) return this._readyPromise;
+		if (this._readyPromise !== undefined) {
+			await this._readyPromise;
+		}
 
 		if (this._providerInfo !== undefined) {
 			await this.refreshToken(request);
@@ -488,7 +489,6 @@ export abstract class ThirdPartyProviderBase<
 		await this.refreshToken(request);
 		this._readyPromise = this.onConnected(this._providerInfo);
 		await this._readyPromise;
-		this.resetReady();
 		this._ensuringConnection = undefined;
 	}
 


### PR DESCRIPTION
NR-12086 Occasional Jira error on startup
- Don't discard _readyPromise - always await it (except for disconnect)
- Remove duplicate ensureConnected in jira.ts (this.get / this.post call it)

**This PR Addresses:**  
[NR-12086 Occasional Jira error on startup](https://issues.newrelic.com/browse/NR-12086)  


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>