### PR TITLE
Resolve Visual Studio plugin crash if New Relic env vars were already set

### DIFF
--- a/vs/src/CodeStream.VisualStudio.Core/Process/ProcessFactory.cs
+++ b/vs/src/CodeStream.VisualStudio.Core/Process/ProcessFactory.cs
@@ -33,7 +33,12 @@ namespace CodeStream.VisualStudio.Core.Process {
 
 			if (additionalEnv != null) {
 				foreach (string key in additionalEnv.Keys) {
-					info.EnvironmentVariables.Add(key, additionalEnv[key]);
+					try {
+						info.EnvironmentVariables[key] = additionalEnv[key];
+					}
+					catch (Exception ex) {
+						Log.Error(ex, $"Error setting environment variable: {key}");
+					}
 				}
 			}
 


### PR DESCRIPTION
Override any existing New Relic environment variables when launching node child process in Visual Studio plugin.