### PR TITLE
pr conversation endpoint being requested without ids

### DIFF
--- a/shared/ui/Stream/OpenPullRequests.tsx
+++ b/shared/ui/Stream/OpenPullRequests.tsx
@@ -801,13 +801,15 @@ export const OpenPullRequests = React.memo((props: Props) => {
 	};
 
 	const fetchOnePR = async (providerId: string, pullRequestId: string, message?: string) => {
-		//GL ids can be a stringified object, order of parameters can fluctuate.  So a
-		//simple string comparison is not sufficent, we have to convert to an object if possible
-		//and extract the id param.  For everything else that is not GL, we just use the standard pr.id
-		let prId = expandedPrIdObject(pullRequestId);
-		setIndividualLoadingPR(prId);
-		(await dispatch(getPullRequestConversationsFromProvider(providerId, pullRequestId))) as any;
-		setIndividualLoadingPR("");
+		if (providerId && pullRequestId) {
+			//GL ids can be a stringified object, order of parameters can fluctuate.  So a
+			//simple string comparison is not sufficent, we have to convert to an object if possible
+			//and extract the id param.  For everything else that is not GL, we just use the standard pr.id
+			let prId = expandedPrIdObject(pullRequestId);
+			setIndividualLoadingPR(prId);
+			(await dispatch(getPullRequestConversationsFromProvider(providerId, pullRequestId))) as any;
+			setIndividualLoadingPR("");
+		}
 	};
 
 	const checkout = async (event, prToCheckout, cantCheckoutReason) => {
@@ -1442,13 +1444,7 @@ export const OpenPullRequests = React.memo((props: Props) => {
 							{!query.hidden &&
 								prGroup &&
 								prGroup.map((pr: any, index) => {
-									return renderPrGroup(
-										providerId || query?.providerId,
-										pr,
-										index,
-										groupIndex,
-										query?.name
-									);
+									return renderPrGroup(providerId, pr, index, groupIndex, query?.name);
 								})}
 						</PaneNode>
 					);

--- a/shared/ui/Stream/OpenPullRequests.tsx
+++ b/shared/ui/Stream/OpenPullRequests.tsx
@@ -760,6 +760,7 @@ export const OpenPullRequests = React.memo((props: Props) => {
 		if (!derivedState.maximized) {
 			dispatch(setPaneMaximized("open-pull-requests", !derivedState.maximized));
 		}
+
 		// if we have an expanded PR diffs in the sidebar, collapse it
 		if (pr.id === derivedState.expandedPullRequestId) {
 			dispatch(clearCurrentPullRequest());
@@ -779,8 +780,13 @@ export const OpenPullRequests = React.memo((props: Props) => {
 				setCurrentGroupIndex(groupIndex);
 				fetchOnePR(pr.providerId, prId);
 
-
-				const nonCustomQueries = ["Waiting on my Review", "Assigned to Me", "Created by Me", "Recent", "From URL"];
+				const nonCustomQueries = [
+					"Waiting on my Review",
+					"Assigned to Me",
+					"Created by Me",
+					"Recent",
+					"From URL"
+				];
 				let telemetryQueryName = queryName;
 				if (!nonCustomQueries.includes(queryName)) {
 					telemetryQueryName = "Custom";
@@ -1215,7 +1221,13 @@ export const OpenPullRequests = React.memo((props: Props) => {
 			if (data) {
 				return;
 			}
-		} else {
+		}
+
+		if (
+			!providerPullRequests &&
+			derivedState.currentPullRequestProviderId! &&
+			derivedState.currentPullRequestId
+		) {
 			fetchOnePR(derivedState.currentPullRequestProviderId!, derivedState.currentPullRequestId);
 			console.warn(`could not find match for idExact=${derivedState.currentPullRequestIdExact}`);
 		}
@@ -1430,7 +1442,13 @@ export const OpenPullRequests = React.memo((props: Props) => {
 							{!query.hidden &&
 								prGroup &&
 								prGroup.map((pr: any, index) => {
-									return renderPrGroup(providerId, pr, index, groupIndex, query?.name);
+									return renderPrGroup(
+										providerId || query?.providerId,
+										pr,
+										index,
+										groupIndex,
+										query?.name
+									);
 								})}
 						</PaneNode>
 					);
@@ -1548,11 +1566,17 @@ export const OpenPullRequests = React.memo((props: Props) => {
 												count={0}
 												isLoading={isLoadingPRs || index === isLoadingPRGroup}
 											></PaneNodeName>
-											{!collapsed && renderQueryGroup(provider.id)}
+											{!collapsed && provider?.id && renderQueryGroup(provider.id)}
 										</PaneNode>
 									);
 							  })
-							: PRConnectedProviders.map(provider => renderQueryGroup(provider.id))}
+							: PRConnectedProviders.map(provider => {
+									if (provider?.id) {
+										return renderQueryGroup(provider.id);
+									} else {
+										return null;
+									}
+							  })}
 					</PaneBody>
 				)}
 			</>

--- a/shared/ui/Stream/OpenPullRequests.tsx
+++ b/shared/ui/Stream/OpenPullRequests.tsx
@@ -1566,17 +1566,11 @@ export const OpenPullRequests = React.memo((props: Props) => {
 												count={0}
 												isLoading={isLoadingPRs || index === isLoadingPRGroup}
 											></PaneNodeName>
-											{!collapsed && provider?.id && renderQueryGroup(provider.id)}
+											{!collapsed && renderQueryGroup(provider.id)}
 										</PaneNode>
 									);
 							  })
-							: PRConnectedProviders.map(provider => {
-									if (provider?.id) {
-										return renderQueryGroup(provider.id);
-									} else {
-										return null;
-									}
-							  })}
+							: PRConnectedProviders.map(provider => renderQueryGroup(provider.id))}
 					</PaneBody>
 				)}
 			</>

--- a/shared/ui/Stream/PullRequestExpandedSidebar.tsx
+++ b/shared/ui/Stream/PullRequestExpandedSidebar.tsx
@@ -75,6 +75,8 @@ export const PullRequestExpandedSidebar = (props: PullRequestExpandedSidebarProp
 		);
 		setSubmittingReview(false);
 	};
+	console.warn("eric props.pullRequest", props.pullRequest);
+	console.warn("eric props.thirdPartyPrObject", props.thirdPartyPrObject);
 
 	return (
 		<>
@@ -133,7 +135,10 @@ export const PullRequestExpandedSidebar = (props: PullRequestExpandedSidebarProp
 						key="files-changed"
 						pr={props.thirdPartyPrObject as FetchThirdPartyPullRequestPullRequest}
 						fetch={() => {
-							props.fetchOnePR(props.thirdPartyPrObject.providerId, props.thirdPartyPrObject.id);
+							props.fetchOnePR(
+								props.thirdPartyPrObject.providerId || props.pullRequest?.providerId,
+								props.thirdPartyPrObject.id || props.pullRequest?.id
+							);
 						}}
 						setIsLoadingMessage={() => {}}
 						sidebarView={true}

--- a/shared/ui/Stream/PullRequestExpandedSidebar.tsx
+++ b/shared/ui/Stream/PullRequestExpandedSidebar.tsx
@@ -75,8 +75,6 @@ export const PullRequestExpandedSidebar = (props: PullRequestExpandedSidebarProp
 		);
 		setSubmittingReview(false);
 	};
-	console.warn("eric props.pullRequest", props.pullRequest);
-	console.warn("eric props.thirdPartyPrObject", props.thirdPartyPrObject);
 
 	return (
 		<>
@@ -135,10 +133,7 @@ export const PullRequestExpandedSidebar = (props: PullRequestExpandedSidebarProp
 						key="files-changed"
 						pr={props.thirdPartyPrObject as FetchThirdPartyPullRequestPullRequest}
 						fetch={() => {
-							props.fetchOnePR(
-								props.thirdPartyPrObject.providerId || props.pullRequest?.providerId,
-								props.thirdPartyPrObject.id || props.pullRequest?.id
-							);
+							props.fetchOnePR(props.thirdPartyPrObject.providerId, props.thirdPartyPrObject.id);
 						}}
 						setIsLoadingMessage={() => {}}
 						sidebarView={true}


### PR DESCRIPTION
The main culprit was the useEffect hook that was calling the fetch pr convo endpoint in scenarios where there was no currentPR id/providerId in redux.




[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/ggHePtmiQyGA34K2RUW3lQ?src=GitHub) by bcanzanella on Jun 8, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>