### PR TITLE
Reduce lag on diff click to line navigation

### DIFF
--- a/shared/ui/Stream/PullRequestFileCommentCard.tsx
+++ b/shared/ui/Stream/PullRequestFileCommentCard.tsx
@@ -116,8 +116,6 @@ export const PullRequestFileCommentCard = (props: PropsWithChildren<Props>) => {
 	const [pendingLineNavigationAndUriChange, setPendingLineNavigationAndUriChange] = useState(false);
 	const [commentRange, setCommentRange] = useState({});
 
-	console.warn("eric textEditorUri", derivedState.textEditorUri);
-
 	useDidMount(() => {
 		if (clickedComment) {
 			handleDiffClick();
@@ -141,6 +139,11 @@ export const PullRequestFileCommentCard = (props: PropsWithChildren<Props>) => {
 		}
 	}, [derivedState.documentMarkers]);
 
+	//This hook and the one below it are similar.  This one handles
+	//navigating to a new line after a diff click if the uri is already
+	//open/doesn't change in the IDE.  Will not hit the navigate-to-line endpoint
+	//unless all conditionals are met, and sets pendingLineNavigation to false
+	//regardless.
 	useEffect(() => {
 		async function navigateToLineNumber() {
 			const { textEditorUri } = derivedState;
@@ -161,6 +164,9 @@ export const PullRequestFileCommentCard = (props: PropsWithChildren<Props>) => {
 		}
 	}, [pendingLineNavigation]);
 
+	//This hook and the one above it are similar.  This one handles
+	//navigating to a new line after a diff click if the uri is not open/changes
+	//from a different one in the IDE
 	useEffect(() => {
 		async function navigateToLineNumber() {
 			const { textEditorUri } = derivedState;


### PR DESCRIPTION
Did some reorganizing/cleanup of this file. But the main thing is the removal of the timeout hack which was put in place to wait for the editorTextUri to change and prevent calling line navigation too early.  


We don't currently have a way to navigate to line number on a diff all in one call, so there is still a slight delay on the snap to line, but its better and less error prone now.


[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/m7DYpxqOQCuaZOJNtRO-cg?src=GitHub) by mfarias on Jun 10, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>