### PR TITLE
fix: Azure Devops exclude additional states and limit work item count

### DIFF
--- a/shared/agent/src/providers/azuredevops.ts
+++ b/shared/agent/src/providers/azuredevops.ts
@@ -96,7 +96,7 @@ export class AzureDevOpsProvider extends ThirdPartyIssueProviderBase<CSAzureDevO
 			const wiql =
 				"Select ID, System.Title, System.Description, State, [Team Project] " +
 				"From WorkItems " +
-				"Where State <> 'Closed' " +
+				"Where State NOT IN ('Closed','Done','Completed','Inactive','Removed') " +
 				"And [Assigned To] = @Me " +
 				"Order By [Changed Date] Desc";
 			const { body } = (await this.post(
@@ -107,7 +107,7 @@ export class AzureDevOpsProvider extends ThirdPartyIssueProviderBase<CSAzureDevO
 				{ "Content-Type": "application/json" }
 			)) as { body: { workItems: AzureDevOpsWorkItem[] } };
 			if (body && body.workItems) {
-				const ids = body.workItems.map(workItem => workItem.id);
+				const ids = body.workItems.map(workItem => workItem.id).slice(0, 200);
 				const response = (await this.get(
 					`/_apis/wit/workitems?${qs.stringify({
 						ids: ids.join(","),


### PR DESCRIPTION
This PR fixes multiple things for the Azure DevOps issue integration:

- [x] It excludes additional states of work items
- [x] It limits the fetching of the work items to 200 as the API has a limit of 200 ([see docs](https://docs.microsoft.com/en-us/rest/api/azure/devops/wit/work-items/get-work-items-batch?view=azure-devops-rest-6.0&tabs=HTTP))

   ```
   Azure DevOps: FAILED(4x) GET https://dev.azure.com/plentymarkets/_apis/wit/workitems?ids=[...]&api-version=5.0 • 1897 ms
   [Error - 7:13:46 PM] [2022-07-22 17:13:46:067] AzureDevOpsProvider.handleErrorResponse
   Error: Internal Server Error
   ```
