### PR TITLE
Hide Mention of Keybindings / Shortcuts in VS

### DIFF
--- a/vs/src/CodeStream.VisualStudio.Shared/UI/WebViews/theme.css
+++ b/vs/src/CodeStream.VisualStudio.Shared/UI/WebViews/theme.css
@@ -43,6 +43,14 @@
     --list-inactive-foreground: --cs--list-inactive-foreground--;
 }
 
+.menu-popup .menu-popup-body .compact .menu-item span.shortcut {
+	display: none;
+}
+
+.no-codemarks-container .no-codemarks .keybindings {
+	display: none;
+}
+
 .codestream #app .stream nav.inline {
 	padding-top: 6px;
 }


### PR DESCRIPTION
Since they don't work, hide the necessary mentions.


[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/GCKov2XATv2SapAVIto5bw?src=GitHub) by bcanzanella on Aug 15, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>