### PR TITLE
Disable sharing code errors to slack/teams

### DIFF
--- a/shared/ui/Stream/CodeError/index.tsx
+++ b/shared/ui/Stream/CodeError/index.tsx
@@ -917,14 +917,6 @@ export const BaseCodeErrorMenu = (props: BaseCodeErrorMenuProps) => {
 			});
 		}
 		if (props.codeError?.id?.indexOf(PENDING_CODE_ERROR_ID_PREFIX) === -1) {
-			// don't add the ability to share for pending codeErrors
-			items.push({
-				label: "Share",
-				icon: <Icon name="share" />,
-				key: "share",
-				action: () => setShareModalOpen(true)
-			});
-
 			items.push({
 				label: "Copy Link",
 				icon: <Icon name="copy" />,


### PR DESCRIPTION



[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/mSyRTn8NQAiNYIjgZPklFQ?src=GitHub) by bcanzanella on Aug 16, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>