### PR TITLE


NR-2590 -- ALWAYS enqueue the browser notification, regardless of what we did specifically with the type that came in before.

### DIFF
--- a/vs/src/CodeStream.VisualStudio.Shared/LanguageServer/CustomMessageHandler.cs
+++ b/vs/src/CodeStream.VisualStudio.Shared/LanguageServer/CustomMessageHandler.cs
@@ -111,8 +111,6 @@ namespace CodeStream.VisualStudio.Shared.LanguageServer {
 				if (preferences?.Data != null) {
 					_userPreferencesChangedSubject.OnNext(new UserPreferencesChangedSubjectArgs(preferences.Data));
 				}
-
-				BrowserService.EnqueueNotification(new DidChangeDataNotificationType(e));
 			}
 
 			if (type?.Value<string>() == "unreads") {
@@ -122,7 +120,7 @@ namespace CodeStream.VisualStudio.Shared.LanguageServer {
 				}
 			}
 
-			
+			BrowserService.EnqueueNotification(new DidChangeDataNotificationType(e));
 		}
 
 		/// <summary>


### PR DESCRIPTION
NR-2590 -- ALWAYS enqueue the browser notification, regardless of what we did specifically with the type that came in before.


[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/HRDdNW_VQFqvYeyo6vreSA?src=GitHub) by bcanzanella on Aug 17, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>