### PR TITLE
GH #1109 Observability throughput incorrect

### DIFF
--- a/shared/ui/Stream/Observability.tsx
+++ b/shared/ui/Stream/Observability.tsx
@@ -22,9 +22,9 @@ import {
 	ObservabilityErrorCore,
 	ObservabilityRepo,
 	ObservabilityRepoError,
-	GetMethodLevelTelemetryRequestType,
-	GetReposScmRequestType,
-	ERROR_GENERIC_USE_ERROR_MESSAGE
+	ERROR_GENERIC_USE_ERROR_MESSAGE,
+	GetServiceLevelTelemetryRequestType,
+	GoldenMetricsResult
 } from "@codestream/protocols/agent";
 import {
 	HostDidChangeWorkspaceFoldersNotificationType,
@@ -63,8 +63,6 @@ import { ALERT_SEVERITY_COLORS } from "./CodeError/index";
 import { ObservabilityCurrentRepo } from "./ObservabilityCurrentRepo";
 import { ObservabilityGoldenMetricDropdown } from "./ObservabilityGoldenMetricDropdown";
 import { ObservabilityErrorWrapper } from "./ObservabilityErrorWrapper";
-import { GetReposScmResponse } from "../../../protocols/agent/agent.protocol";
-import { offline } from "../store/connectivity/actions";
 
 interface Props {
 	paneState: PaneState;
@@ -246,7 +244,7 @@ export const Observability = React.memo((props: Props) => {
 	const [observabilityErrors, setObservabilityErrors] = useState<ObservabilityRepoError[]>([]);
 	const [observabilityRepos, setObservabilityRepos] = useState<ObservabilityRepo[]>([]);
 	const [loadingPane, setLoadingPane] = useState<string | null>("");
-	const [goldenMetrics, setGoldenMetrics] = useState<any>([]);
+	const [goldenMetrics, setGoldenMetrics] = useState<GoldenMetricsResult[]>([]);
 	const [newRelicUrl, setNewRelicUrl] = useState<string | undefined>("");
 	const [expandedEntity, setExpandedEntity] = useState<string | null>(null);
 	const [currentEntityAccountIndex, setCurrentEntityAccountIndex] = useState<string | null>(null);
@@ -539,7 +537,7 @@ export const Observability = React.memo((props: Props) => {
 			if (!noLoadingSpinner) {
 				setLoadingGoldenMetrics(true);
 			}
-			const response = await HostApi.instance.send(GetMethodLevelTelemetryRequestType, {
+			const response = await HostApi.instance.send(GetServiceLevelTelemetryRequestType, {
 				newRelicEntityGuid: entityGuid,
 				repoId: currentRepoId
 			});

--- a/shared/ui/Stream/ObservabilityGoldenMetricDropdown.tsx
+++ b/shared/ui/Stream/ObservabilityGoldenMetricDropdown.tsx
@@ -1,3 +1,4 @@
+import { GoldenMetricsResult } from "@codestream/protocols/agent";
 import { forEach as _forEach, isNil as _isNil } from "lodash-es";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
@@ -6,7 +7,7 @@ import Icon from "./Icon";
 import Tooltip from "./Tooltip";
 
 interface Props {
-	goldenMetrics: any;
+	goldenMetrics: GoldenMetricsResult[];
 	loadingGoldenMetrics?: boolean;
 }
 
@@ -24,24 +25,53 @@ const StyledMetric = styled.div`
 	}
 `;
 
+interface GoldenMetricTitleMapping {
+	responseTimeMs: {
+		name: "responseTimeMs";
+		title: string;
+		units: "ms";
+		tooltip: string;
+	};
+	throughput: {
+		name: "throughput";
+		title: string;
+		units: "rpm";
+		tooltip: string;
+	};
+	errorRate: {
+		name: "errorRate";
+		title: string;
+		units: "avg";
+		tooltip: string;
+	};
+}
 export const ObservabilityGoldenMetricDropdown = React.memo((props: Props) => {
 	const [expanded, setExpanded] = useState<boolean>(true);
 	const [updatedAt, setUpdatedAt] = useState<string>("");
 	const { goldenMetrics } = props;
-	const goldenMetricTitleMapping = {
+	const goldenMetricTitleMapping: GoldenMetricTitleMapping = {
 		responseTimeMs: {
-			title: "Response Time Ms",
+			// this matches the "name" from the goldenMetrics in the agent and the key here
+			name: "responseTimeMs",
+
+			title: "Response time (ms)",
 			units: "ms",
 			tooltip: "This shows the average time this service spends processing web requests."
 		},
 		throughput: {
+			// this matches the "name" from the goldenMetrics in the agent and the key here
+			name: "throughput",
+
 			title: "Throughput",
 			units: "rpm",
 			tooltip:
 				"Throughput measures how many requests this service processes per minute. It will help you find your busiest service"
 		},
 		errorRate: {
-			title: "Error Rate",
+			// this matches the "name" from the goldenMetrics in the agent and the key here
+			name: "errorRate",
+
+			title: "Error rate",
 			units: "avg",
 			tooltip:
 				"Error rate is the percentage of transactions that result in an error during a particular time range."
@@ -106,7 +136,7 @@ export const ObservabilityGoldenMetricDropdown = React.memo((props: Props) => {
 						const goldenMetricTooltip = goldenMetricTitleMapping[gm?.name]?.tooltip;
 						let goldenMetricValueTrue =
 							gm?.result && gm.result.length > 0
-								? gm?.result[0][goldenMetricTitleMapping[gm?.name]?.title]
+								? gm?.result[0][goldenMetricTitleMapping[gm?.name]?.name]
 								: "";
 						let goldenMetricValue = goldenMetricValueTrue;
 
@@ -150,7 +180,9 @@ export const ObservabilityGoldenMetricDropdown = React.memo((props: Props) => {
 								className={"pr-row"}
 							>
 								<div>
-									<span style={{ marginRight: "5px" }}>{gm.title}</span>
+									<span style={{ marginRight: "5px" }}>
+										{goldenMetricTitleMapping[gm?.name]?.title}
+									</span>
 									{goldenMetricTooltip && (
 										<Icon
 											style={{ transform: "scale(0.9)" }}


### PR DESCRIPTION
a lot of these changes are in typings, but one thing I tried to re-work is using "name" as a query key, rather than "title" (from the agent). Any calling code should find queries/queryData using "name" and set the title themselves (as we do with `goldenMetricTitleMapping`)

Also, we're changing the queries we use for service level golden metrics to use the queries used in the NR1 UI.