### PR TITLE
NR-41711 / NR-41712

### DIFF
--- a/vs/src/CodeStream.VisualStudio.Shared/Services/AuthenticationService.cs
+++ b/vs/src/CodeStream.VisualStudio.Shared/Services/AuthenticationService.cs
@@ -78,12 +78,14 @@ namespace CodeStream.VisualStudio.Shared.Services {
 					}
 				}
 
-				try {
-					await CodeStreamAgentService.LogoutAsync(newServerUrl);
-				}
-				catch (Exception ex) {
-					Log.Error(ex, $"{nameof(LogoutAsync)} - agent");
-				}
+				#if X86
+					try {
+						await CodeStreamAgentService.LogoutAsync(newServerUrl);
+					}
+					catch (Exception ex) {
+						Log.Error(ex, $"{nameof(LogoutAsync)} - agent");
+					}
+				#endif 
 
 				if (reason == SessionSignedOutReason.UserSignedOutFromWebview ||
 					reason == SessionSignedOutReason.UserSignedOutFromExtension

--- a/vs/src/CodeStream.VisualStudio.Shared/Services/CodeLevelMetricsCallbackService.cs
+++ b/vs/src/CodeStream.VisualStudio.Shared/Services/CodeLevelMetricsCallbackService.cs
@@ -74,6 +74,11 @@ namespace CodeStream.VisualStudio.Shared.Services {
 		}
 
 		public async Task<CodeLevelMetricsTelemetry> GetTelemetryAsync(string codeNamespace, string functionName) {
+			if (!_sessionService.IsReady)
+			{
+				return new CodeLevelMetricsTelemetry();
+			}
+		
 			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 			var solution = _vsSolution.GetSolutionFile();
 


### PR DESCRIPTION
In 2022, we no longer need to call the Logout method - logout was explicitly adding for 2019.

If CodeLens / CLM is turned on, and you log out of CodeStream, CodeLens still tries to make its calls to the agent.  Block it if not ready.