### PR TITLE


Small cleanup based on discussion that we probably shouldn't add an "empty string" to node certs

### DIFF
--- a/vs/src/CodeStream.VisualStudio.Shared/LanguageServer/LanguageServerClientProcess.cs
+++ b/vs/src/CodeStream.VisualStudio.Shared/LanguageServer/LanguageServerClientProcess.cs
@@ -29,12 +29,16 @@ namespace CodeStream.VisualStudio.Shared.LanguageServer {
 
 			var nrSettings = httpClient.GetNREnvironmentSettings();
 
-			StringDictionary additionalEnv = new StringDictionary {
-				{ "NODE_EXTRA_CA_CERTS", codeStreamSettingsManager.ExtraCertificates },
+			var additionalEnv = new StringDictionary {
 				{ "NODE_TLS_REJECT_UNAUTHORIZED", codeStreamSettingsManager.DisableStrictSSL ? "0" : "1" },
 				// do not want to release with NEW_RELIC_LOG_ENABLED=true
 				{ "NEW_RELIC_LOG_ENABLED", "false"}
 			};
+
+			if (!string.IsNullOrEmpty(codeStreamSettingsManager.ExtraCertificates))
+			{
+				additionalEnv.Add("NODE_EXTRA_CA_CERTS", codeStreamSettingsManager.ExtraCertificates);
+			}
 
 			if (nrSettings.HasValidSettings) {
 				additionalEnv.Add("NEW_RELIC_HOST", nrSettings.Host);


### PR DESCRIPTION



[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/fw4yrpX-QoKZ0U4QwAsTug?src=GitHub) by bcanzanella on Aug 22, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>