### PR TITLE
adds retry logic to post-repo association

### DIFF
--- a/shared/agent/src/system/function.ts
+++ b/shared/agent/src/system/function.ts
@@ -401,7 +401,7 @@ export namespace Functions {
 			if (await fn()) {
 				return { success: true, count: i };
 			}
-			await new Promise(resolve => setTimeout(resolve, sleepIntervalInMilliseconds * i));
+			await wait(sleepIntervalInMilliseconds * i);
 		}
 		return { success: false, count: i };
 	}

--- a/shared/agent/src/system/function.ts
+++ b/shared/agent/src/system/function.ts
@@ -383,6 +383,29 @@ export namespace Functions {
 		}
 	}
 
+	/**
+	 * withExponentialRetryBackoff allows to re-run a function N times with a sleep of sleepIntervalInMilliseconds
+	 *
+	 * @export
+	 * @param {(...args: any[]) => Promise<boolean>} fn
+	 * @param {number} [tryCount=5]
+	 * @param {number} [sleepIntervalInMilliseconds=250]
+	 * @return {*}  {Promise<{ success: boolean; count: number }>}
+	 */
+	export async function withExponentialRetryBackoff(
+		fn: (...args: any[]) => Promise<boolean>,
+		tryCount: number = 5,
+		sleepIntervalInMilliseconds: number = 250
+	): Promise<{ success: boolean; count: number }> {
+		for (var i = 1; i < tryCount + 1; i++) {
+			if (await fn()) {
+				return { success: true, count: i };
+			}
+			await new Promise(resolve => setTimeout(resolve, sleepIntervalInMilliseconds * i));
+		}
+		return { success: false, count: i };
+	}
+
 	export function safe<T>(fn: () => T | undefined): T | undefined {
 		try {
 			return fn();


### PR DESCRIPTION
there's somewhat of a delay querying NR for the repo entity post association, this adds a bit of a buffer. 