### PR TITLE
Remove button to open spatial view

### DIFF
--- a/shared/ui/Stream/Codemarks.tsx
+++ b/shared/ui/Stream/Codemarks.tsx
@@ -737,17 +737,6 @@ export class SimpleCodemarksForFile extends Component<Props, State> {
 						delay={1}
 						tabIndex={1}
 					/>
-					<Icon
-						onClick={() => {
-							this.props.openPanel(WebviewPanels.CodemarksForFile);
-							HostApi.instance.track("Spatial View Opened");
-						}}
-						name="maximize"
-						title="Spatial View"
-						placement="bottom"
-						delay={1}
-						tabIndex={1}
-					/>
 					<InlineMenu
 						key="settings-menu"
 						className="subtle no-padding"


### PR DESCRIPTION



[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/2jdTkYpBTeqVuMHHZrnWxg?src=GitHub) by ericjones on Aug 26, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>