### PR TITLE
Feature/newrelic 2804

### DIFF
--- a/shared/agent/src/providers/newrelic.ts
+++ b/shared/agent/src/providers/newrelic.ts
@@ -1011,7 +1011,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 				throw ex;
 			}
 		}
-		return response as any;
+		return response;
 	}
 
 	@log()


### PR DESCRIPTION
The original issue was that setting entities was a nested state set inside of a successful NR errors load. That might not happen for all users / user capabilities. This PR changes the order of those calls as well as:

- converts to async/await
- adds a generic error handler. the agent calls can now throw, and we need to be able to differentiate between truly no entities, and when querying for entities results in an error (which can happen for basic users)