### PR TITLE
Lock PR fails if user doesn't select a reason …

### DIFF
--- a/shared/ui/Stream/PullRequestConversationTab.tsx
+++ b/shared/ui/Stream/PullRequestConversationTab.tsx
@@ -356,7 +356,7 @@ export const PullRequestConversationTab = (props: {
 			case "Spam":
 				reason = "SPAM";
 				break;
-			case "RESOLVED":
+			case "Resolved":
 				reason = "RESOLVED";
 				break;
 		}
@@ -960,7 +960,12 @@ export const PullRequestConversationTab = (props: {
 								</Link>
 								.
 							</div>
-							<Button fillParent onClick={() => lockPullRequest()} isLoading={isLoadingLocking}>
+							<Button
+								fillParent
+								disabled={!isLockingReason || isLockingReason === "Choose a reason"}
+								onClick={() => lockPullRequest()}
+								isLoading={isLoadingLocking}
+							>
 								Lock conversation on this pull request
 							</Button>
 						</Dialog>


### PR DESCRIPTION


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>