### PR TITLE
hasRepoAssociation OR empty entity accounts should be part of the log…

### DIFF
--- a/shared/ui/Stream/Observability.tsx
+++ b/shared/ui/Stream/Observability.tsx
@@ -738,7 +738,7 @@ export const Observability = React.memo((props: Props) => {
 			// Show repo entity associator UI if needed
 			if (
 				currentRepo &&
-				!currentRepo.hasRepoAssociation &&
+				(!currentRepo.hasRepoAssociation || currentRepo.entityAccounts.length < 1) &&
 				!observabilityErrors?.find(
 					oe => oe?.repoId === currentRepo?.repoId && oe?.errors.length > 0
 				)


### PR DESCRIPTION
…ic that triggers EntityAssociator