### PR TITLE
NEWRELIC-3967 Unexpected error trying to delete codemarks/FRs

### DIFF
--- a/shared/ui/store/providerPullRequests/thunks.ts
+++ b/shared/ui/store/providerPullRequests/thunks.ts
@@ -305,9 +305,9 @@ export const getMyPullRequests = createAppAsyncThunk<
 		if (!options || !options.force) {
 			const state = getState();
 			const provider = state.providerPullRequests.myPullRequests[providerId];
-			if (provider && provider.data != null) {
+			if (provider) {
 				console.log(`fetched myPullRequest data from store providerId=${providerId}`);
-				return provider.data;
+				return provider;
 			}
 			// if the data was wiped... set force to get data from the provider api and
 			// bypass our cache
@@ -330,7 +330,7 @@ export const getMyPullRequests = createAppAsyncThunk<
 		});
 		if (index !== undefined) {
 			dispatch(updatePullRequestFilter({ providerId, data: response, index }));
-		} else if (!test) {
+		} else if (!test && response != null) {
 			dispatch(addMyPullRequests({ providerId, data: response }));
 		}
 

--- a/shared/ui/store/providerPullRequests/types.ts
+++ b/shared/ui/store/providerPullRequests/types.ts
@@ -63,7 +63,7 @@ export interface RepoPullRequest {
  * 	}
  */
 export type ProviderPullRequestsState = {
-	myPullRequests: Index<{ data?: GetMyPullRequestsResponse[][] }>;
+	myPullRequests: Index<GetMyPullRequestsResponse[][]>;
 	pullRequests: Index<Index<RepoPullRequest>>;
 };
 


### PR DESCRIPTION
NEWRELIC-3967 Unexpected error trying to delete codemarks/FRs

- Logs show this was not related to deleting codemark / feedback but from OpenPullRequests.tsx not handling empty results after sending bad query (fixed in recent release). But this error still result in showing empty PR list so ...

NEWRELIC-3626 Entire PR list disappears on transient network errors

- Robustify OpenPullRequests.tsx to not erase state on errors / empty response
- Remove duplicate state in pullRequestGroups useState and instead render from redux state for myPullRequests (was already kind of happening in a useHook)
- Remove unnecessary data attribute on myPullRequests in ProviderPullRequestsState

**This PR Addresses:**  
[NEWRELIC-3967 Unexpected error trying to delete codemarks/FRs](https://issues.newrelic.com/browse/NEWRELIC-3967)  


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>