### PR TITLE
NR-60240 Determine what the minimum version of GHE that codestream is compatible with …

### DIFF
--- a/shared/agent/src/providers/github.ts
+++ b/shared/agent/src/providers/github.ts
@@ -3042,6 +3042,15 @@ export class GitHubProvider
 		request: GetMyPullRequestsRequest
 	): Promise<GetMyPullRequestsResponse[][] | undefined> {
 		void (await this.ensureConnected());
+		if (!(await this.isPRApiCompatible())) {
+			const currentVersion = await this.getVersion();
+			// InternalErrors don't get sent to sentry
+			throw new InternalError(
+				`Pull requests are not available for ${this.displayName} ${
+					currentVersion.version
+				}. Please upgrade to ${this.minPRApiVersion()} or later.`
+			);
+		}
 		Logger.log(`github getMyPullRequests ${JSON.stringify(request)}`);
 		if (!this.isValidGetMyPullRequest(request)) {
 			Logger.warn(`Invalid GetMyPullRequestsRequest`);

--- a/shared/agent/src/providers/githubEnterprise.ts
+++ b/shared/agent/src/providers/githubEnterprise.ts
@@ -15,7 +15,7 @@ import { ProviderVersion } from "./types";
 
 /**
  * GitHub Enterprise
- * minimum supported version is 2.19.6 https://enterprise.github.com/releases/2.19.6/notes
+ * minimum supported version is 3.3.0
  */
 @lspProvider("github_enterprise")
 export class GitHubEnterpriseProvider extends GitHubProvider {
@@ -91,12 +91,15 @@ export class GitHubEnterpriseProvider extends GitHubProvider {
 		return (r: GitRemoteLike) => configDomain !== "" && r.domain === configDomain;
 	}
 
+	protected minPRApiVersion(): string {
+		return "3.3.0";
+	}
+
 	private _isPRApiCompatible: boolean | undefined;
 	protected async isPRApiCompatible(): Promise<boolean> {
 		if (this._isPRApiCompatible == null) {
 			const version = await this.getVersion();
-			const [major, minor] = version.asArray;
-			this._isPRApiCompatible = major > 2 || (major === 2 && minor >= 15);
+			this._isPRApiCompatible = semver.gte(version.version, this.minPRApiVersion());
 		}
 
 		return this._isPRApiCompatible;

--- a/shared/agent/src/providers/thirdPartyIssueProviderBase.ts
+++ b/shared/agent/src/providers/thirdPartyIssueProviderBase.ts
@@ -210,6 +210,10 @@ export abstract class ThirdPartyIssueProviderBase<
 		return result;
 	}
 
+	protected minPRApiVersion(): string {
+		return "0.0.0";
+	}
+
 	protected async isPRApiCompatible(): Promise<boolean> {
 		return true;
 	}

--- a/shared/agent/test/unit/providers/github/githubEnterprise.spec.ts
+++ b/shared/agent/test/unit/providers/github/githubEnterprise.spec.ts
@@ -1,7 +1,9 @@
 "use strict";
 
 import { describe, expect, it } from "@jest/globals";
+import { InternalError } from "../../../../src/agentError";
 import { GitHubEnterpriseProvider } from "../../../../src/providers/githubEnterprise";
+import { ProviderVersion } from "../../../../src/providers/types";
 
 describe("getOwnerFromRemote", () => {
 	const provider = new GitHubEnterpriseProvider({} as any, {} as any);
@@ -9,5 +11,72 @@ describe("getOwnerFromRemote", () => {
 	it("generic", () => {
 		const owner = provider.getOwnerFromRemote("//github.acme.us/foo/bar");
 		expect(owner).toEqual({ name: "bar", owner: "foo" });
+	});
+});
+
+describe("myPullRequests", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+	afterAll(() => {
+		jest.clearAllMocks();
+	});
+
+	it("should throw InternalError for invalid version", async () => {
+		jest
+			.spyOn(GitHubEnterpriseProvider.prototype, "ensureConnected")
+			.mockImplementation(async () => {
+				return;
+			});
+		jest
+			.spyOn(GitHubEnterpriseProvider.prototype as any, "isPRApiCompatible")
+			.mockResolvedValueOnce(false);
+		const providerVersion: ProviderVersion = {
+			version: "2.2.7",
+			asArray: [2, 2, 7],
+		};
+		jest
+			.spyOn(GitHubEnterpriseProvider.prototype as any, "getVersion")
+			.mockResolvedValueOnce(providerVersion);
+		const provider = new GitHubEnterpriseProvider({} as any, {} as any) as any;
+		await expect(provider.getMyPullRequests()).rejects.toThrowError(
+			new InternalError(
+				`Pull requests are not available for GitHub Enterprise 2.2.7. Please upgrade to 3.3.0 or later.`
+			)
+		);
+	});
+});
+
+describe("isPRApiCompatible", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+	it("should return false for version 2.9.99", async () => {
+		const providerVersion: ProviderVersion = {
+			version: "2.9.99",
+			asArray: [2, 9, 99],
+		};
+		jest
+			.spyOn(GitHubEnterpriseProvider.prototype as any, "getVersion")
+			.mockResolvedValueOnce(providerVersion);
+		const provider = new GitHubEnterpriseProvider({} as any, {} as any) as any;
+		const result: boolean = await provider.isPRApiCompatible();
+		expect(result).toBe(false);
+	});
+
+	it("should return true for version 3.3.0", async () => {
+		const providerVersion: ProviderVersion = {
+			version: "3.3.0",
+			asArray: [3, 3, 0],
+		};
+		jest
+			.spyOn(GitHubEnterpriseProvider.prototype as any, "getVersion")
+			.mockResolvedValueOnce(providerVersion);
+		const provider = new GitHubEnterpriseProvider({} as any, {} as any) as any;
+		const result: boolean = await provider.isPRApiCompatible();
+		expect(result).toBe(true);
 	});
 });

--- a/shared/ui/Stream/ConfigureEnterprisePanel.tsx
+++ b/shared/ui/Stream/ConfigureEnterprisePanel.tsx
@@ -1,5 +1,6 @@
 import { CSProviderInfo } from "@codestream/protocols/api";
 import { CodeStreamState } from "@codestream/webview/store";
+import Tooltip from "@codestream/webview/Stream/Tooltip";
 import UrlInputComponent from "@codestream/webview/Stream/UrlInputComponent";
 import { useAppDispatch, useAppSelector, useDidMount } from "@codestream/webview/utilities/hooks";
 import { normalizeUrl } from "@codestream/webview/utilities/urls";
@@ -132,6 +133,7 @@ export default function ConfigureEnterprisePanel(props: Props) {
 		directPAT,
 		versionMinimum,
 		checkVersionUrl,
+		checkVersionHover,
 		invalidHosts,
 		namePAT = "Personal Access Token",
 		supportsPRManagement,
@@ -159,10 +161,19 @@ export default function ConfigureEnterprisePanel(props: Props) {
 							Not a {displayName} customer yet? <Link href={getUrl}>Get {displayName}</Link>
 						</p>
 					)}
-					{versionMinimum && (
+					{versionMinimum && checkVersionUrl && (
 						<p style={{ textAlign: "center" }} className="explainer">
 							Requires {displayName} {versionMinimum} or later.{" "}
 							<Link href={checkVersionUrl}>Check your version</Link>.
+						</p>
+					)}
+					{versionMinimum && checkVersionHover && (
+						<p style={{ textAlign: "center" }} className="explainer">
+							Requires {displayName} {versionMinimum} or later.{" "}
+							<Tooltip title={checkVersionHover} placement="bottom">
+								<a href="#">Check your version</a>
+							</Tooltip>
+							.
 						</p>
 					)}
 					<br />

--- a/shared/ui/Stream/CrossPostIssueControls/types.ts
+++ b/shared/ui/Stream/CrossPostIssueControls/types.ts
@@ -27,6 +27,7 @@ export interface ProviderDisplay {
 	supportsPRManagement?: boolean;
 	versionMinimum?: string;
 	checkVersionUrl?: string;
+	checkVersionHover?: string;
 	invalidHosts?: Array<string>;
 
 	helpPATUrl?: string;
@@ -134,7 +135,8 @@ export const PROVIDER_MAPPINGS: { [provider: string]: ProviderDisplay } = {
 			scopesParam: "scopes",
 		},
 		versionMinimum: "3.3",
-		checkVersionUrl: "https://docs.newrelic.com/docs/codestream/troubleshooting/ghe-version/",
+		checkVersionHover:
+			"Open any page in GitHub Enterprise and scroll to the bottom of the page. The version number can be found in the footer.",
 	},
 	gitlab: {
 		displayName: "GitLab",

--- a/shared/ui/Stream/CrossPostIssueControls/types.ts
+++ b/shared/ui/Stream/CrossPostIssueControls/types.ts
@@ -133,6 +133,8 @@ export const PROVIDER_MAPPINGS: { [provider: string]: ProviderDisplay } = {
 			descriptionParam: "description",
 			scopesParam: "scopes",
 		},
+		versionMinimum: "3.3",
+		checkVersionUrl: "https://docs.newrelic.com/docs/codestream/troubleshooting/ghe-version/",
 	},
 	gitlab: {
 		displayName: "GitLab",


### PR DESCRIPTION
set ghe min version for PRs to 3.3 and add min version warning to ghe integration connect screen

**This PR Addresses:**  
[NR-60240 Determine what the minimum version of GHE that codestream is compatible with](https://issues.newrelic.com/browse/NR-60240)  


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>