### PR TITLE
Add new top-level menu for CodeStream actions

### DIFF
--- a/vs/src/CodeStream.VisualStudio.Shared/Commands/WebViewToggleCommand.cs
+++ b/vs/src/CodeStream.VisualStudio.Shared/Commands/WebViewToggleCommand.cs
@@ -3,6 +3,8 @@ using CodeStream.VisualStudio.Core.Logging;
 using Microsoft.VisualStudio.Shell;
 using Serilog;
 using System;
+using System.ComponentModel.Design;
+
 using CodeStream.VisualStudio.Shared.Packages;
 
 #if X86
@@ -12,21 +14,37 @@ using CodeStream.VisualStudio.Shared.Packages;
 #endif
 
 namespace CodeStream.VisualStudio.Shared.Commands {
-	internal sealed class WebViewToggleCommand : VsCommandBase {
-		private static readonly ILogger Log = LogManager.ForContext<WebViewToggleCommand>();
-		public WebViewToggleCommand() : base(PackageGuids.guidWebViewPackageCmdSet, PackageIds.WebViewToggleCommandId) { }
+	internal abstract class WebViewToggleCommandBase : VsCommandBase
+	{
+		private static readonly ILogger Log = LogManager.ForContext<WebViewToggleCommandBase>();
 
-		protected override void ExecuteUntyped(object parameter) {
+		protected WebViewToggleCommandBase(Guid commandSet, int commandId) : base(commandSet, commandId) {}
+
+		protected override void ExecuteUntyped(object parameter)
+		{
 			ThreadHelper.ThrowIfNotOnUIThread();
-			try {
+			try
+			{
 				Log.Verbose(nameof(WebViewToggleCommand) + " " + nameof(ExecuteUntyped));
 
 				var toolWindowProvider = Package.GetGlobalService(typeof(SToolWindowProvider)) as IToolWindowProvider;
 				var result = toolWindowProvider?.ToggleToolWindowVisibility(Guids.WebViewToolWindowGuid);
 			}
-			catch (Exception ex) {
+			catch (Exception ex)
+			{
 				Log.Error(ex, nameof(WebViewToggleCommand));
 			}
 		}
+	}
+
+
+	internal sealed class WebViewToggleCommand : WebViewToggleCommandBase
+	{
+		public WebViewToggleCommand() : base(PackageGuids.guidWebViewPackageCmdSet, PackageIds.WebViewToggleCommandId) { }
+	}
+
+	internal sealed class WebViewToggleTopLevelMenuCommand : WebViewToggleCommandBase
+	{
+		public WebViewToggleTopLevelMenuCommand() : base(PackageGuids.guidVSPackageCommandTopMenuCmdSet, PackageIds.CodeStreamTopLevelMenuToggleCommand) { }
 	}
 }

--- a/vs/src/CodeStream.VisualStudio.Shared/Packages/CommandsPackage.cs
+++ b/vs/src/CodeStream.VisualStudio.Shared/Packages/CommandsPackage.cs
@@ -89,7 +89,9 @@ namespace CodeStream.VisualStudio.Shared.Packages {
 
 						new WebViewReloadCommand(_sessionService),
 						new WebViewToggleCommand(),
+						new WebViewToggleTopLevelMenuCommand(),
 						new AuthenticationCommand(_componentModel, _sessionService),
+						new AuthenticationTopLevelCommand(_componentModel, _sessionService),
 						userCommand
 					};
 					await JoinableTaskFactory.SwitchToMainThreadAsync();

--- a/vs/src/CodeStream.VisualStudio.Vsix.x64/CodeStreamPackage.cs
+++ b/vs/src/CodeStream.VisualStudio.Vsix.x64/CodeStreamPackage.cs
@@ -15,6 +15,9 @@ namespace CodeStream.VisualStudio.Vsix.x64
         public const string guidCodeStreamPackageString = "5498f07e-2ca1-4d3b-bcfb-5e8a8a082eed";
         public static Guid guidCodeStreamPackage = new Guid(guidCodeStreamPackageString);
 
+        public const string guidVSPackageCommandTopMenuCmdSetString = "acf32b59-19bf-4492-b19b-2d359e74a69a";
+        public static Guid guidVSPackageCommandTopMenuCmdSet = new Guid(guidVSPackageCommandTopMenuCmdSetString);
+
         public const string guidWebViewPackageCmdSetString = "8f66deb0-240b-4137-8550-723344e49722";
         public static Guid guidWebViewPackageCmdSet = new Guid(guidWebViewPackageCmdSetString);
 
@@ -38,6 +41,10 @@ namespace CodeStream.VisualStudio.Vsix.x64
     /// </summary>
     internal sealed partial class PackageIds
     {
+        public const int CodeStreamTopLevelMenu = 0x1020;
+        public const int CodeStreamTopLevelMenuCommandGroup = 0x1021;
+        public const int CodeStreamTopLevelMenuToggleCommand = 0x0101;
+        public const int CodeStreamTopLevelMenuSignOutCommand = 0x0102;
         public const int Toolbar = 0x1000;
         public const int ToolbarGroup = 0x1050;
         public const int ToolbarGroup100 = 0x1060;

--- a/vs/src/CodeStream.VisualStudio.Vsix.x64/CodeStreamPackage.vsct
+++ b/vs/src/CodeStream.VisualStudio.Vsix.x64/CodeStreamPackage.vsct
@@ -13,6 +13,7 @@
 					<LocCanonicalName>CodeStream</LocCanonicalName>
 				</Strings>
 			</Menu>
+
 			<Menu guid="guidWebViewPackageCmdSet" id="CodeStreamMenuController200" priority="0x0200" type="MenuController">
 				<Parent guid="guidWebViewPackageCmdSet" id="ToolbarGroup" />
 				<CommandFlag>IconAndText</CommandFlag>
@@ -26,12 +27,21 @@
 					<LocCanonicalName>CodeStream.ToggleCodeStream</LocCanonicalName>
 				</Strings>
 			</Menu>
+
 			<Menu guid="guidWebViewPackageCodeWindowContextMenuCmdSet" id="CodeWindowContextSubMenu" priority="0x0110" type="Menu">		
 				<Strings>
 					<ButtonText>CodeStream</ButtonText>
 				</Strings>
 			</Menu>
+
+			<Menu guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenu" type="Menu">
+				<Strings>
+					<ButtonText>CodeStream</ButtonText>
+				</Strings>
+			</Menu>
+
 		</Menus>
+
 		<Groups>
 			<Group guid="guidWebViewPackageCodeWindowContextMenuCmdSet" id="CodeWindowContextSubMenuGroup" />
 			<Group guid="guidWebViewPackageCodeWindowContextMenuCmdSet" id="CodeWindowContextCommandGroup" />			
@@ -51,7 +61,9 @@
 				<Parent guid="guidWebViewPackageCmdSet" id="CodeStreamMenuController200" />
 			</Group>
 			<Group guid="guidWebViewPackageShortcutCmdSet" id="CodeStreamShortcutCommands" />
+			<Group guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenuCommandGroup"/>
 		</Groups>
+
 		<Buttons>
 			<Button guid="guidWebViewPackageCmdSet" id="WebViewToggleCommandId" priority="0x0101" type="Button">
 				<Parent guid="guidWebViewPackageCmdSet" id="ToolbarGroup100" />
@@ -180,7 +192,31 @@
 					<LocCanonicalName>CodeStream.GetPermalinkShortcut</LocCanonicalName>
 				</Strings>
 			</Button>
+
+
+			<Button guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenuToggleCommand" type="Button">
+				<Icon guid="guidImages" id="logo" />
+				<CommandFlag>DontCache</CommandFlag>
+				<CommandFlag>IconAndText</CommandFlag>
+				<CommandFlag>TextChanges</CommandFlag>
+				<Strings>
+					<ButtonText>Toggle CodeStream</ButtonText>
+				</Strings>
+			</Button>
+
+			<Button guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenuSignOutCommand" type="Button">
+				<Icon guid="guidImages" id="auth" />
+				<CommandFlag>IconAndText</CommandFlag>
+				<CommandFlag>DontCache</CommandFlag>
+				<CommandFlag>TextChanges</CommandFlag>
+				<CommandFlag>DynamicVisibility</CommandFlag>
+				<CommandFlag>DefaultInvisible</CommandFlag>
+				<Strings>
+					<ButtonText>Sign Out</ButtonText>
+				</Strings>
+			</Button>
 		</Buttons>
+
 		<Bitmaps>
 			<Bitmap guid="guidImages" href="..\resources\Sprites.png" usedList="logo, auth, user, empty4, empty5, empty6" />
 			<Bitmap guid="guidImagesCommands" href="..\resources\CommandsSprites.png" usedList="comment, issue, bookmark, permalink" />
@@ -225,6 +261,22 @@
 		<CommandPlacement guid="guidWebViewPackageCodeWindowContextMenuCmdSet" id="AddCodemarkPermalinkCommandId" priority="0x0004" >
 			<Parent guid="guidWebViewPackageCodeWindowContextMenuCmdSet" id="CodeWindowContextCommandGroup"/>
 		</CommandPlacement>
+
+
+		<CommandPlacement guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenu" priority="775">
+			<Parent guid="guidSHLMainMenu" id="IDG_VS_MM_TOOLSADDINS"/>
+		</CommandPlacement>
+
+		<CommandPlacement guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenuCommandGroup" priority="0x0001">
+			<Parent guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenu"/>
+		</CommandPlacement>
+
+		<CommandPlacement guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenuToggleCommand" priority="0x0001" >
+			<Parent guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenuCommandGroup"/>
+		</CommandPlacement>
+		<CommandPlacement guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenuSignOutCommand" priority="0x0002" >
+			<Parent guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenuCommandGroup"/>
+		</CommandPlacement>
 	</CommandPlacements>
 
 	<VisibilityConstraints>
@@ -237,6 +289,13 @@
 
 	<Symbols>
 		<GuidSymbol name="guidCodeStreamPackage" value="{5498f07e-2ca1-4d3b-bcfb-5e8a8a082eed}" />
+
+		<GuidSymbol name="guidVSPackageCommandTopMenuCmdSet" value="{acf32b59-19bf-4492-b19b-2d359e74a69a}">
+			<IDSymbol name="CodeStreamTopLevelMenu" value="0x1020" />
+			<IDSymbol name="CodeStreamTopLevelMenuCommandGroup" value="0x1021" />
+			<IDSymbol name="CodeStreamTopLevelMenuToggleCommand" value="0x0101" />
+			<IDSymbol name="CodeStreamTopLevelMenuSignOutCommand" value="0x0102" />
+		</GuidSymbol>
 
 		<GuidSymbol name="guidWebViewPackageCmdSet" value="{8f66deb0-240b-4137-8550-723344e49722}">
 			<IDSymbol name="Toolbar" value="0x1000" />

--- a/vs/src/CodeStream.VisualStudio.Vsix.x86/CodeStreamPackage.cs
+++ b/vs/src/CodeStream.VisualStudio.Vsix.x86/CodeStreamPackage.cs
@@ -15,6 +15,9 @@ namespace CodeStream.VisualStudio.Vsix.x86
         public const string guidCodeStreamPackageString = "5498f07e-2ca1-4d3b-bcfb-5e8a8a082eed";
         public static Guid guidCodeStreamPackage = new Guid(guidCodeStreamPackageString);
 
+        public const string guidVSPackageCommandTopMenuCmdSetString = "acf32b59-19bf-4492-b19b-2d359e74a69a";
+        public static Guid guidVSPackageCommandTopMenuCmdSet = new Guid(guidVSPackageCommandTopMenuCmdSetString);
+
         public const string guidWebViewPackageCmdSetString = "8f66deb0-240b-4137-8550-723344e49722";
         public static Guid guidWebViewPackageCmdSet = new Guid(guidWebViewPackageCmdSetString);
 
@@ -38,6 +41,10 @@ namespace CodeStream.VisualStudio.Vsix.x86
     /// </summary>
     internal sealed partial class PackageIds
     {
+        public const int CodeStreamTopLevelMenu = 0x1020;
+        public const int CodeStreamTopLevelMenuCommandGroup = 0x1021;
+        public const int CodeStreamTopLevelMenuToggleCommand = 0x0101;
+        public const int CodeStreamTopLevelMenuSignOutCommand = 0x0102;
         public const int Toolbar = 0x1000;
         public const int ToolbarGroup = 0x1050;
         public const int ToolbarGroup100 = 0x1060;

--- a/vs/src/CodeStream.VisualStudio.Vsix.x86/CodeStreamPackage.vsct
+++ b/vs/src/CodeStream.VisualStudio.Vsix.x86/CodeStreamPackage.vsct
@@ -13,6 +13,7 @@
 					<LocCanonicalName>CodeStream</LocCanonicalName>
 				</Strings>
 			</Menu>
+
 			<Menu guid="guidWebViewPackageCmdSet" id="CodeStreamMenuController200" priority="0x0200" type="MenuController">
 				<Parent guid="guidWebViewPackageCmdSet" id="ToolbarGroup" />
 				<CommandFlag>IconAndText</CommandFlag>
@@ -26,16 +27,25 @@
 					<LocCanonicalName>CodeStream.ToggleCodeStream</LocCanonicalName>
 				</Strings>
 			</Menu>
-			<Menu guid="guidWebViewPackageCodeWindowContextMenuCmdSet" id="CodeWindowContextSubMenu" priority="0x0110" type="Menu">		
+
+			<Menu guid="guidWebViewPackageCodeWindowContextMenuCmdSet" id="CodeWindowContextSubMenu" priority="0x0110" type="Menu">
 				<Strings>
 					<ButtonText>CodeStream</ButtonText>
 				</Strings>
 			</Menu>
+
+			<Menu guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenu" type="Menu">
+				<Strings>
+					<ButtonText>CodeStream</ButtonText>
+				</Strings>
+			</Menu>
+
 		</Menus>
+
 		<Groups>
 			<Group guid="guidWebViewPackageCodeWindowContextMenuCmdSet" id="CodeWindowContextSubMenuGroup" />
-			<Group guid="guidWebViewPackageCodeWindowContextMenuCmdSet" id="CodeWindowContextCommandGroup" />			
-			
+			<Group guid="guidWebViewPackageCodeWindowContextMenuCmdSet" id="CodeWindowContextCommandGroup" />
+
 			<Group guid="guidWebViewPackageCmdSet" id="ToolbarGroup" priority="0x0600">
 				<Parent guid="guidWebViewPackageCmdSet" id="Toolbar" />
 			</Group>
@@ -51,7 +61,9 @@
 				<Parent guid="guidWebViewPackageCmdSet" id="CodeStreamMenuController200" />
 			</Group>
 			<Group guid="guidWebViewPackageShortcutCmdSet" id="CodeStreamShortcutCommands" />
+			<Group guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenuCommandGroup"/>
 		</Groups>
+
 		<Buttons>
 			<Button guid="guidWebViewPackageCmdSet" id="WebViewToggleCommandId" priority="0x0101" type="Button">
 				<Parent guid="guidWebViewPackageCmdSet" id="ToolbarGroup100" />
@@ -180,7 +192,31 @@
 					<LocCanonicalName>CodeStream.GetPermalinkShortcut</LocCanonicalName>
 				</Strings>
 			</Button>
+
+
+			<Button guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenuToggleCommand" type="Button">
+				<Icon guid="guidImages" id="logo" />
+				<CommandFlag>DontCache</CommandFlag>
+				<CommandFlag>IconAndText</CommandFlag>
+				<CommandFlag>TextChanges</CommandFlag>
+				<Strings>
+					<ButtonText>Toggle CodeStream</ButtonText>
+				</Strings>
+			</Button>
+
+			<Button guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenuSignOutCommand" type="Button">
+				<Icon guid="guidImages" id="auth" />
+				<CommandFlag>IconAndText</CommandFlag>
+				<CommandFlag>DontCache</CommandFlag>
+				<CommandFlag>TextChanges</CommandFlag>
+				<CommandFlag>DynamicVisibility</CommandFlag>
+				<CommandFlag>DefaultInvisible</CommandFlag>
+				<Strings>
+					<ButtonText>Sign Out</ButtonText>
+				</Strings>
+			</Button>
 		</Buttons>
+
 		<Bitmaps>
 			<Bitmap guid="guidImages" href="..\resources\Sprites.png" usedList="logo, auth, user, empty4, empty5, empty6" />
 			<Bitmap guid="guidImagesCommands" href="..\resources\CommandsSprites.png" usedList="comment, issue, bookmark, permalink" />
@@ -215,7 +251,7 @@
 		<CommandPlacement guid="guidWebViewPackageCodeWindowContextMenuCmdSet" id="CodeWindowContextCommandGroup" priority="0x0110">
 			<Parent guid="guidWebViewPackageCodeWindowContextMenuCmdSet" id="CodeWindowContextSubMenu"/>
 		</CommandPlacement>
-		
+
 		<CommandPlacement guid="guidWebViewPackageCodeWindowContextMenuCmdSet" id="AddCodemarkCommentCommandId" priority="0x0001" >
 			<Parent guid="guidWebViewPackageCodeWindowContextMenuCmdSet" id="CodeWindowContextCommandGroup"/>
 		</CommandPlacement>
@@ -224,6 +260,22 @@
 		</CommandPlacement>
 		<CommandPlacement guid="guidWebViewPackageCodeWindowContextMenuCmdSet" id="AddCodemarkPermalinkCommandId" priority="0x0004" >
 			<Parent guid="guidWebViewPackageCodeWindowContextMenuCmdSet" id="CodeWindowContextCommandGroup"/>
+		</CommandPlacement>
+
+
+		<CommandPlacement guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenu" priority="775">
+			<Parent guid="guidSHLMainMenu" id="IDG_VS_MM_TOOLSADDINS"/>
+		</CommandPlacement>
+
+		<CommandPlacement guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenuCommandGroup" priority="0x0001">
+			<Parent guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenu"/>
+		</CommandPlacement>
+
+		<CommandPlacement guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenuToggleCommand" priority="0x0001" >
+			<Parent guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenuCommandGroup"/>
+		</CommandPlacement>
+		<CommandPlacement guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenuSignOutCommand" priority="0x0002" >
+			<Parent guid="guidVSPackageCommandTopMenuCmdSet" id="CodeStreamTopLevelMenuCommandGroup"/>
 		</CommandPlacement>
 	</CommandPlacements>
 
@@ -237,6 +289,13 @@
 
 	<Symbols>
 		<GuidSymbol name="guidCodeStreamPackage" value="{5498f07e-2ca1-4d3b-bcfb-5e8a8a082eed}" />
+
+		<GuidSymbol name="guidVSPackageCommandTopMenuCmdSet" value="{acf32b59-19bf-4492-b19b-2d359e74a69a}">
+			<IDSymbol name="CodeStreamTopLevelMenu" value="0x1020" />
+			<IDSymbol name="CodeStreamTopLevelMenuCommandGroup" value="0x1021" />
+			<IDSymbol name="CodeStreamTopLevelMenuToggleCommand" value="0x0101" />
+			<IDSymbol name="CodeStreamTopLevelMenuSignOutCommand" value="0x0102" />
+		</GuidSymbol>
 
 		<GuidSymbol name="guidWebViewPackageCmdSet" value="{8f66deb0-240b-4137-8550-723344e49722}">
 			<IDSymbol name="Toolbar" value="0x1000" />
@@ -260,23 +319,23 @@
 		<GuidSymbol name="guidHtmlCtxMenu" value="{78F03954-2FB8-4087-8CE7-59D71710B3BB}">
 			<IDSymbol name="IDM_HTMLCTXMENU" value="1" />
 		</GuidSymbol>
-		
+
 		<GuidSymbol name="guidWebViewPackageCodeWindowContextMenuCmdSet" value="{0f33235e-3a5c-42bc-b519-d888652f972c}">
 			<IDSymbol name="CodeWindowContextSubMenuGroup" value="0x9000" />
 			<IDSymbol name="CodeWindowContextCommandGroup" value="0x9001" />
-			
+
 			<IDSymbol name="CodeWindowContextSubMenu" value="0x9200" />
-			
+
 			<IDSymbol name="CodeStreamEditorCommands" value="0x1023" />
 			<IDSymbol name="AddCodemarkCommentCommandId" value="0x0400" />
 			<IDSymbol name="AddCodemarkIssueCommandId" value="0x0401" />
 			<IDSymbol name="AddCodemarkPermalinkCommandId" value="0x0403" />
 		</GuidSymbol>
-		 
+
 		<GuidSymbol name="guidWebViewPackageShortcutCmdSet" value="{A72BBF5D-23D2-4A8A-939E-12C4651DD341}">
 			<IDSymbol name="CodeStreamShortcutCommands" value="0x1023" />
 			<IDSymbol name="AddCodemarkCommentCommandId" value="0x0400" />
-			<IDSymbol name="AddCodemarkIssueCommandId" value="0x0401" />			
+			<IDSymbol name="AddCodemarkIssueCommandId" value="0x0401" />
 			<IDSymbol name="AddCodemarkPermalinkCommandId" value="0x0403" />
 		</GuidSymbol>
 


### PR DESCRIPTION
Appears beneath "Extensions", and has Toggle CodeStream and Sign Out (when necessary)

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>