### PR TITLE
NEWRELIC-4935 Investigate use of VM's api to query of vulnerability details

### DIFF
--- a/shared/agent/src/protocol/agent.protocol.providers.ts
+++ b/shared/agent/src/protocol/agent.protocol.providers.ts
@@ -1853,6 +1853,10 @@ export const riskSeverityList = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN",
 
 export type RiskSeverity = typeof riskSeverityList[number];
 
+export const criticalityList = ["CRITICAL", "HIGH", "MODERATE", "LOW"] as const;
+
+export type CriticalityType = typeof criticalityList[number];
+
 // /v1/issues/ response
 // https://source.datanerd.us/incubator/nrsec-workflow-api/blob/dacb63f32aa836a4b90f6345a83e0ae95f7d3463/src/main/java/com/newrelic/nrsecworkflowapi/api/SecurityIssueSummary.java
 export type SecurityIssueSummary = {
@@ -1910,7 +1914,7 @@ export type Vuln = {
 	vector: string;
 	description: string;
 	score: number;
-	criticality: string; // TODO mebe enum
+	criticality: CriticalityType;
 };
 
 export type LibraryDetails = {
@@ -1918,6 +1922,7 @@ export type LibraryDetails = {
 	version: string;
 	suggestedVersion?: string;
 	highestScore: number;
+	highestCriticality: CriticalityType;
 	language?: string;
 	vulns: Array<Vuln>;
 };

--- a/shared/agent/src/providers/newrelic/vuln/nrVulnerability.ts
+++ b/shared/agent/src/providers/newrelic/vuln/nrVulnerability.ts
@@ -1,7 +1,7 @@
 import { URLSearchParams } from "url";
 
 import { Response } from "node-fetch";
-import { isEmpty } from "lodash";
+import { chunk, isEmpty } from "lodash";
 import Cache from "timed-cache";
 import { ResponseError } from "vscode-jsonrpc/lib/messages";
 import * as semver from "semver";
@@ -13,6 +13,8 @@ import {
 	ERROR_VM_NOT_SETUP,
 } from "../../../protocol/agent.protocol.errors";
 import {
+	criticalityList,
+	CriticalityType,
 	GetLibraryDetailsRequest,
 	GetLibraryDetailsResponse,
 	GetLibraryDetailsType,
@@ -29,7 +31,7 @@ import {
 import { CodeStreamSession } from "../../../session";
 import { log, lspHandler, lspProvider } from "../../../system";
 import { ThirdPartyProviderBase } from "../../thirdPartyProviderBase";
-import { EntityLibraries, LibraryUsage, VulnerabililityDetails } from "./types";
+import { EntityLibraries, LibraryUsage, VulnerabililityDetails, VulnerableLibrary } from "./types";
 
 const API_TIMEOUT = 5000;
 
@@ -54,6 +56,28 @@ export function isNrSecError(obj: unknown): obj is NrSecError {
 		!isEmpty(maybe.message) &&
 		!isEmpty(maybe.path)
 	);
+}
+
+const critScore: Record<CriticalityType, number> = {
+	CRITICAL: 5,
+	HIGH: 4,
+	MODERATE: 3,
+	LOW: 2,
+};
+
+function isCriticalityType(maybe: unknown): maybe is CriticalityType {
+	return criticalityList.includes(maybe as CriticalityType);
+}
+
+function maxCriticalicy(highestCriticality: CriticalityType, criticality: string): CriticalityType {
+	if (!isCriticalityType(criticality)) {
+		return highestCriticality;
+	}
+	if (critScore[highestCriticality] < critScore[criticality]) {
+		return criticality;
+	} else {
+		return highestCriticality;
+	}
 }
 
 @lspProvider("newrelic-vulnerabilities")
@@ -197,7 +221,7 @@ export class NewRelicVulnerabilitiesProvider extends ThirdPartyProviderBase {
 		};
 	}
 
-	riskSeverityToCriticality(riskSeverity: RiskSeverity): string {
+	riskSeverityToCriticality(riskSeverity: RiskSeverity): CriticalityType {
 		switch (riskSeverity) {
 			case "CRITICAL":
 				return "CRITICAL";
@@ -264,8 +288,38 @@ export class NewRelicVulnerabilitiesProvider extends ThirdPartyProviderBase {
 			}
 			return count > 0;
 		});
+
+		// Parallel processing - split into 4 lists, process each chunk
+		const chunks = chunk(filteredLibraries, Math.max(filteredLibraries.length / 4, 1));
+		const libraryDetailsCombined = new Array<LibraryDetails>();
+		const promises = chunks.map(chunk =>
+			this.processLibraryChunk(accountId, chunk, request.severityFilter)
+		);
+		for (const promise of promises) {
+			const result = await promise;
+			libraryDetailsCombined.push(...result);
+		}
+
+		// API result comes in sorted (filteredLibraries) by weighted score (but weighted score not returned by api)
+		// so we have to re-sort libraryDetailsCombined since the parallel processing could have changed the order
+
+		libraryDetailsCombined.sort((a, b) => {
+			return (
+				filteredLibraries.findIndex(i => a.name === i.name) -
+				filteredLibraries.findIndex(i => b.name === i.name)
+			);
+		});
+
+		return libraryDetailsCombined;
+	}
+
+	private async processLibraryChunk(
+		accountId: number,
+		libraryChunk: Array<VulnerableLibrary>,
+		severityFilter?: RiskSeverity[]
+	): Promise<Array<LibraryDetails>> {
 		const libraryDetails = new Array<LibraryDetails>();
-		for (const library of filteredLibraries) {
+		for (const library of libraryChunk) {
 			const libraryVulnerabilities = await this.fetchLibraryVulnerabilities(
 				accountId,
 				library.name,
@@ -284,16 +338,19 @@ export class NewRelicVulnerabilitiesProvider extends ThirdPartyProviderBase {
 			if (!vulnerabilities) {
 				continue;
 			}
-			const vulnResponse = new Array<Vuln>();
+
 			let highestScore = 0;
+			let highestCriticality: CriticalityType = "LOW";
+			const vulnResponse = new Array<Vuln>();
 			for (const finding of vulnerabilities) {
-				const filterValues = request.severityFilter?.map(this.riskSeverityToCriticality);
+				const filterValues = severityFilter?.map(this.riskSeverityToCriticality);
 				if (filterValues && !isEmpty(filterValues)) {
 					if (!filterValues.includes(finding.criticality)) {
 						continue;
 					}
 				}
 				highestScore = Math.max(highestScore, finding.score);
+				highestCriticality = maxCriticalicy(highestCriticality, finding.criticality);
 				vulnResponse.push({
 					criticality: finding.criticality,
 					description: finding.description,
@@ -316,13 +373,11 @@ export class NewRelicVulnerabilitiesProvider extends ThirdPartyProviderBase {
 					suggestedVersion: library.suggestedVersion?.version,
 					language: library.language,
 					highestScore,
+					highestCriticality,
 					vulns: vulnResponse,
 				});
 			}
 		}
-		// Currently comes in sorted by weighted score (but weighted score not returned by api) so no need to sort
-		// libraryDetails.sort((a, b) => b.highestScore - a.highestScore);
-		// this.libraryDetailsCache.put(JSON.stringify(request), libraryDetails);
 		return libraryDetails;
 	}
 

--- a/shared/agent/src/providers/newrelic/vuln/types.d.ts
+++ b/shared/agent/src/providers/newrelic/vuln/types.d.ts
@@ -1,3 +1,5 @@
+import { CriticalityType } from "../../../protocol/agent.protocol.providers";
+
 export type VersionDetails = {
 	version?: string;
 	criticalVulnerabilities: number;
@@ -29,7 +31,7 @@ export type VulnerabililityDetails = {
 	source?: string;
 	cveJson: string;
 	language: string;
-	criticality: string;
+	criticality: CriticalityType;
 	packages: {
 		remediation: string;
 		artifact: string;

--- a/shared/ui/Stream/SecurityIssuesWrapper.tsx
+++ b/shared/ui/Stream/SecurityIssuesWrapper.tsx
@@ -1,4 +1,5 @@
 import {
+	CriticalityType,
 	ERROR_VM_NOT_SETUP,
 	GetLibraryDetailsType,
 	LibraryDetails,
@@ -83,23 +84,19 @@ const severityColorMap: Record<RiskSeverity, string> = {
 	UNKNOWN: "#ee8608",
 };
 
-function calculateRisk(score: number): RiskSeverity {
-	if (score > 9) {
-		return "CRITICAL";
+function criticalityToRiskSeverity(riskSeverity: CriticalityType): RiskSeverity {
+	switch (riskSeverity) {
+		case "CRITICAL":
+			return "CRITICAL";
+		case "HIGH":
+			return "HIGH";
+		case "MODERATE":
+			return "MEDIUM";
+		case "LOW":
+			return "LOW";
+		default:
+			return "LOW";
 	}
-	if (score > 7) {
-		return "HIGH";
-	}
-	if (score > 4) {
-		return "MEDIUM";
-	}
-	// if (score > 5) {
-	//     return "INFO";
-	// }
-	if (score > 0.1) {
-		return "LOW";
-	}
-	return "UNKNOWN";
 }
 
 function Severity(props: { severity: RiskSeverity }) {
@@ -200,7 +197,7 @@ function VulnRow(props: { vuln: Vuln }) {
 					<Icon style={{ transform: "scale(0.9)" }} name="lock" />
 				</div>
 				<div>{props.vuln.title}</div>
-				<Severity severity={calculateRisk(props.vuln.score)} />
+				<Severity severity={criticalityToRiskSeverity(props.vuln.criticality)} />
 			</Row>
 			{expanded && (
 				<Modal
@@ -245,7 +242,7 @@ function LibraryRow(props: { library: LibraryDetails }) {
 						<span className="subtle">{subtleText}</span>
 					</Tooltip>
 				</div>
-				<Severity severity={calculateRisk(library.highestScore)} />
+				<Severity severity={criticalityToRiskSeverity(library.highestCriticality)} />
 			</Row>
 			{expanded && library.vulns.map(vuln => <VulnRow vuln={vuln} />)}
 		</>


### PR DESCRIPTION
 - Parallel processing of library details api to reduce load time from 12 seconds to 2 seconds
 - Fix severity showing up as unknown instead of null by mapping criticality instead of riskscore
