### PR TITLE
Duplicate getObservabilityErrors requests

### DIFF
--- a/shared/ui/Stream/Observability.tsx
+++ b/shared/ui/Stream/Observability.tsx
@@ -577,10 +577,8 @@ export const Observability = React.memo((props: Props) => {
 				filters: [{ repoId: repoId, entityGuid: entityGuid }],
 			})
 			.then(response => {
-				if (response?.repos) {
-					if (response.repos) {
-						setObservabilityErrors(response.repos);
-					}
+				if (response.repos) {
+					setObservabilityErrors(response.repos);
 				}
 				loading(repoId, false);
 				setLoadingPane(undefined);


### PR DESCRIPTION
Remove duplicate useEffect on `currentRepoId` for fetching observability errors - useEffect with dependency on `expandedEntity` already handles it.