### PR TITLE
NEWRELIC-5914 User getting disconnected from Jira cloud

### DIFF
--- a/shared/agent/src/api/apiProvider.ts
+++ b/shared/agent/src/api/apiProvider.ts
@@ -1,3 +1,7 @@
+import { RequestInit, Response } from "node-fetch";
+import { Disposable, Event } from "vscode-languageserver";
+
+import { HistoryFetchInfo } from "broadcaster/broadcaster";
 import {
 	AccessToken,
 	AddEnterpriseProviderHostRequest,
@@ -208,10 +212,6 @@ import {
 	TriggerMsTeamsProactiveMessageRequest,
 	TriggerMsTeamsProactiveMessageResponse,
 } from "@codestream/protocols/api";
-import { RequestInit, Response } from "node-fetch";
-import { Disposable, Event } from "vscode-languageserver";
-
-import { HistoryFetchInfo } from "broadcaster/broadcaster";
 
 export type ApiProviderLoginResponse = CSLoginResponse & { token: AccessToken };
 
@@ -548,7 +548,6 @@ export interface ApiProvider {
 	removeEnterpriseProviderHost(request: RemoveEnterpriseProviderHostRequest): Promise<void>;
 	refreshThirdPartyProvider(request: {
 		providerId: string;
-		refreshToken: string;
 		sharing?: boolean;
 		subId?: string;
 	}): Promise<CSMe>;

--- a/shared/agent/src/api/codestream/codestreamApi.ts
+++ b/shared/agent/src/api/codestream/codestreamApi.ts
@@ -2375,7 +2375,6 @@ export class CodeStreamApiProvider implements ApiProvider {
 	})
 	async refreshThirdPartyProvider(request: {
 		providerId: string;
-		refreshToken: string;
 		sharing?: boolean;
 		subId?: string;
 	}): Promise<CSMe> {
@@ -2387,20 +2386,18 @@ export class CodeStreamApiProvider implements ApiProvider {
 
 			const params: { [key: string]: string } = {
 				teamId: this.teamId,
-				token: request.refreshToken,
 			};
 			if (providerConfig.isEnterprise) {
 				params.host = providerConfig.host;
 			}
 
 			const team = `teamId=${this.teamId}`;
-			const token = `refreshToken=${request.refreshToken}`;
 			const host = providerConfig.isEnterprise
 				? `&host=${encodeURIComponent(providerConfig.host!)}`
 				: "";
 			const sharing = request.sharing ? "&sharing=true" : "";
 			const subId = request.subId ? `&subId=${request.subId}` : "";
-			const url = `/provider-refresh/${providerConfig.name}?${team}&${token}${host}${sharing}${subId}`;
+			const url = `/provider-refresh/${providerConfig.name}?${team}${host}${sharing}${subId}`;
 			const response = await this.get<{ user: any }>(url, this._token);
 
 			const user = await SessionContainer.instance().session.resolveUserAndNotify(response.user);

--- a/shared/agent/src/managers/cache/baseCache.ts
+++ b/shared/agent/src/managers/cache/baseCache.ts
@@ -122,6 +122,27 @@ export class BaseCache<T> {
 		return entity;
 	}
 
+	// Non-promise version
+	getFromCache(criteria: KeyValue<T>[]): T | undefined {
+		const cc = Logger.getCorrelationContext();
+
+		const keys = getKeys(criteria);
+		const index = this.getIndex<UniqueIndex<T>>(keys);
+		const values = getValues(criteria);
+		if (!index || index.type !== IndexType.Unique) {
+			throw new Error(`No unique index declared for fields ${keys}`);
+		}
+
+		let entity = index.get(values);
+		if (!entity) {
+			if (cc !== undefined) {
+				cc.exitDetails = "(cache miss)";
+			}
+		}
+
+		return entity;
+	}
+
 	/**
 	 * Add or update an entity. All initialized indexes are updated. In order to dissociate an
 	 * updated entity from its old indexed values, #oldEntity must be specified.

--- a/shared/agent/src/managers/usersManager.ts
+++ b/shared/agent/src/managers/usersManager.ts
@@ -140,6 +140,15 @@ export class UsersManager extends CachedEntityManagerBase<CSUser> {
 		return cachedMe as CSMe;
 	}
 
+	// Non-promise version from cache
+	getMeCached(): CSMe {
+		const cachedMe = this.cache.getFromCache([["id", this.session.userId]]);
+		if (!cachedMe) {
+			throw new Error(`User's own object (${this.session.userId}) not found in cache`);
+		}
+		return cachedMe as CSMe;
+	}
+
 	@lspHandler(GetUnreadsRequestType)
 	getUnreads(request: GetUnreadsRequest): Promise<GetUnreadsResponse> {
 		return this.session.api.getUnreads(request);


### PR DESCRIPTION
NEWRELIC-5914 User getting disconnected from Jira cloud
- Don't send refresh token from client - server more likely to have valid refresh token. 
- Don't use separate this_providerInfo for each provider class - always refer to up-to date single source of truth in usersManager. 
- Note: server changes required before merging

**This PR Addresses:**  
[NEWRELIC-5914 User getting disconnected from Jira cloud](https://issues.newrelic.com/browse/NEWRELIC-5914)  


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>