### PR TITLE
Add "since X" for golden metrics tooltip

### DIFF
--- a/shared/agent/src/protocol/agent.protocol.providers.ts
+++ b/shared/agent/src/protocol/agent.protocol.providers.ts
@@ -1781,6 +1781,10 @@ export const GoldenMetricUnitMappings: UnitMappings = {
 
 export interface EntityGoldenMetrics {
 	lastUpdated: string;
+	/**
+	 * Adds a timeframe value for the UI to show (30 minutes, 2 days, etc.)
+	 */
+	since: string;
 	metrics: {
 		name: string;
 		title: string;

--- a/shared/agent/src/providers/newrelic.ts
+++ b/shared/agent/src/providers/newrelic.ts
@@ -2824,10 +2824,11 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 						entity(guid: "${entityGuid}") {
 	    	`;
 
+			const since = "30 MINUTES";
 			metricDefinitions.forEach(md => {
 				const whereClause = md.definition.where ? `WHERE ${md.definition.where}` : "";
 				gmQuery += `
-					${md.name}: nrdbQuery(nrql: "SELECT ${md.definition.select} AS 'result' FROM ${md.definition.from} ${whereClause} SINCE 30 MINUTES AGO", timeout: 10, async: true) {
+					${md.name}: nrdbQuery(nrql: "SELECT ${md.definition.select} AS 'result' FROM ${md.definition.from} ${whereClause} SINCE ${since} AGO", timeout: 10, async: true) {
 						results
 					}
 				`;
@@ -2872,6 +2873,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 
 			return {
 				lastUpdated: new Date().toLocaleString(),
+				since: since.toLowerCase().replace("minutes", "min"),
 				metrics: metrics,
 			};
 		} catch (ex) {

--- a/shared/ui/Stream/ObservabilityGoldenMetricDropdown.tsx
+++ b/shared/ui/Stream/ObservabilityGoldenMetricDropdown.tsx
@@ -72,7 +72,11 @@ export const ObservabilityGoldenMetricDropdown = React.memo((props: Props) => {
 								style={{ transform: "scale(0.8)" }}
 								name="clock"
 								className="clickable"
-								title={"Updated at " + entityGoldenMetrics.lastUpdated}
+								placement="bottom"
+								title={
+									`Since ${entityGoldenMetrics.since} ago. Updated at ` +
+									entityGoldenMetrics.lastUpdated
+								}
 								delay={1}
 							/>
 						)}


### PR DESCRIPTION
Currently, users don't know the timespan for Golden Metrics in the o11y panel.

Add "Since X units ago. " to the existing golden metrics tooltip.