### PR TITLE
NEWRELIC-6353 Node symbol lookup - support next.js framework

### DIFF
--- a/jb/src/main/kotlin/clm/CLMEditorManager.kt
+++ b/jb/src/main/kotlin/clm/CLMEditorManager.kt
@@ -178,9 +178,11 @@ abstract class CLMEditorManager(
                             return@launch
                         }
                         // logger.info("=== Calling fileLevelTelemetry for ${editor.document.uri} resetCache: $resetCache")
+                        // next.js file path is like posts/[id].tsx - IntelliJ won't create an uri for this file name!
+                        val uri = editor.document.uri ?: "file://${editor.document.file?.path}"
                         val result = project.agentService?.fileLevelTelemetry(
                             FileLevelTelemetryParams(
-                                editor.document.uri,
+                                uri,
                                 languageId,
                                 FunctionLocator(classNames, null),
                                 null,

--- a/jb/src/main/kotlin/clm/CLMLanguageComponent.kt
+++ b/jb/src/main/kotlin/clm/CLMLanguageComponent.kt
@@ -55,7 +55,9 @@ abstract class CLMLanguageComponent<T : CLMEditorManager>(
             if (reviewFile != null) {
                 if (!reviewFile.canCreateMarker) return
             } else {
-                if (event.editor.document.uri?.startsWith("file://") != true) return
+                // next.js file path is like posts/[id].tsx - IntelliJ won't create an uri for this file name!
+                if (event.editor.document.uri != null &&
+                    event.editor.document.uri?.startsWith("file://") != true) return
             }
         }
         managersByEditor[event.editor] = editorFactory(event.editor)

--- a/shared/agent/src/providers/newrelic.ts
+++ b/shared/agent/src/providers/newrelic.ts
@@ -161,6 +161,9 @@ const supportedLanguages = [
 	"go",
 	"php",
 	"javascript",
+	"javascriptreact",
+	"typescript",
+	"typescriptreact",
 ] as const;
 export type LanguageId = typeof supportedLanguages[number];
 
@@ -1877,6 +1880,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 					request.newRelicEntityGuid,
 					request.resolutionMethod,
 					queryType,
+					request.languageId,
 					bestMatchingCodeFilePath || request.codeFilePath,
 					bestMatchingCodeFilePath ? undefined : request.locator
 				);
@@ -2149,6 +2153,9 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 				case "go":
 				case "php":
 				case "javascript":
+				case "typescript":
+				case "typescriptreact":
+				case "javascriptreact":
 					functionInfo = {
 						functionName: additionalMetadata["code.function"],
 						className: additionalMetadata["code.namespace"],
@@ -2275,6 +2282,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 			// get a list of file-based method telemetry
 			const spanResponse =
 				(await this.getSpans({
+					languageId,
 					newRelicAccountId,
 					newRelicEntityGuid,
 					codeFilePath: relativeFilePath,
@@ -3089,7 +3097,8 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 			const sliResults = await this.query<ServiceLevelIndicatorQueryResult>(sliQuery);
 			const indicators = sliResults?.actor?.entity?.serviceLevel?.indicators;
 
-			if (indicators?.length === 0) {
+			if (!indicators || indicators?.length === 0) {
+				Logger.log("getServiceLevelObjectives No indicators found");
 				return undefined;
 			}
 
@@ -3145,6 +3154,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 		} catch (ex) {
 			ContextLogger.warn("getServiceLevelObjectives failure", {
 				request,
+				error: ex,
 			});
 		}
 
@@ -3338,6 +3348,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 		} catch (ex) {
 			ContextLogger.warn("fetchErrorGroupDataById failure", {
 				errorGroupGuid,
+				error: ex,
 			});
 			const accessTokenError = ex as {
 				message: string;
@@ -3544,6 +3555,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 				ContextLogger.warn("fetchErrorGroup (stack trace missing)", {
 					entityGuid: entityGuid,
 					occurrenceId: occurrenceId,
+					error: ex,
 				});
 				stackTracePromise = undefined;
 			}
@@ -3582,6 +3594,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 			ContextLogger.warn("fetchErrorGroup (stack trace missing upon waiting)", {
 				entityGuid: entityGuid,
 				occurrenceId: occurrenceId,
+				error: ex,
 			});
 		}
 
@@ -4050,6 +4063,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 			ContextLogger.warn("getErrorsInboxAssignments", {
 				userId: userId,
 				usingEmailAddress: emailAddress != null,
+				error: ex,
 			});
 			return undefined;
 		}
@@ -4326,6 +4340,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 		} catch (e) {
 			ContextLogger.warn("" + e.message, {
 				idLike,
+				error: e,
 			});
 		}
 		return undefined;
@@ -4383,6 +4398,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 			ContextLogger.warn("generateTimestampRange failed", {
 				timestampInMilliseconds: timestampInMilliseconds,
 				plusOrMinusInMinutes: plusOrMinusInMinutes,
+				error: ex,
 			});
 		}
 		return undefined;

--- a/shared/agent/src/providers/newrelic/newrelic.types.ts
+++ b/shared/agent/src/providers/newrelic/newrelic.types.ts
@@ -1,4 +1,5 @@
 import { FunctionLocator } from "@codestream/protocols/agent";
+import { LanguageId } from "../newrelic";
 
 export interface Directive {
 	type: "assignRepository" | "removeAssignee" | "setAssignee" | "setState";
@@ -64,6 +65,7 @@ export interface SpanRequest {
 	newRelicAccountId: number;
 	newRelicEntityGuid: string;
 	resolutionMethod: ResolutionMethod;
+	languageId: LanguageId;
 	codeFilePath?: string;
 	locator?: FunctionLocator;
 }

--- a/shared/agent/test/unit/providers/newrelic/newrelic.clm.queries.spec.ts
+++ b/shared/agent/test/unit/providers/newrelic/newrelic.clm.queries.spec.ts
@@ -35,7 +35,7 @@ describe("clm query generation", () => {
 	});
 	describe("generateSpanQuery", () => {
 		it("generates filePath locator query using equals", () => {
-			const response = generateSpanQuery("nrGuid", "filePath", "equals", "my/file.py");
+			const response = generateSpanQuery("nrGuid", "filePath", "equals", "python", "my/file.py");
 			// console.log(response);
 			expect(response).toContain(
 				"nrql(query: \"SELECT name,`transaction.name`,code.lineno,code.namespace,code.function,traceId,transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.filepath='my/file.py'  SINCE 30 minutes AGO LIMIT 250\")"
@@ -43,7 +43,7 @@ describe("clm query generation", () => {
 		});
 
 		it("generates filePath locator query using like", () => {
-			const response = generateSpanQuery("nrGuid", "filePath", "like", "my/file.py");
+			const response = generateSpanQuery("nrGuid", "filePath", "like", "python", "my/file.py");
 			// console.log(response);
 			expect(response).toContain(
 				"nrql(query: \"SELECT name,`transaction.name`,code.lineno,code.namespace,code.function,traceId,transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.filepath like '%my/file.py'  SINCE 30 minutes AGO LIMIT 250\""
@@ -51,15 +51,15 @@ describe("clm query generation", () => {
 		});
 
 		it("generates filePath locator query using fuzzy", () => {
-			const response = generateSpanQuery("nrGuid", "filePath", "fuzzy", "my/file.py");
+			const response = generateSpanQuery("nrGuid", "filePath", "fuzzy", "python", "my/file.py");
 			// console.log(response);
 			expect(response).toContain(
-				"nrql(query: \"SELECT name, `transaction.name`, code.lineno, code.namespace, code.function, traceId, transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.filepath like '%/my/file.py%' SINCE 30 minutes AGO LIMIT 250\")"
+				"nrql(query: \"SELECT name, `transaction.name`, code.lineno, code.namespace, code.function, traceId, transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.filepath like '%my/file.py%' SINCE 30 minutes AGO LIMIT 250\")"
 			);
 		});
 
 		it("generates namespace only locator query using equals", () => {
-			const response = generateSpanQuery("nrGuid", "locator", "equals", undefined, {
+			const response = generateSpanQuery("nrGuid", "locator", "equals", "python", undefined, {
 				namespace: "blah",
 			});
 			// console.log(response);
@@ -69,7 +69,7 @@ describe("clm query generation", () => {
 		});
 
 		it("generates namespace only locator query using like", () => {
-			const response = generateSpanQuery("nrGuid", "locator", "like", undefined, {
+			const response = generateSpanQuery("nrGuid", "locator", "like", "python", undefined, {
 				namespace: "blah",
 			});
 			// console.log(response);
@@ -79,7 +79,7 @@ describe("clm query generation", () => {
 		});
 
 		it("generates namespace and function locator query using equals", () => {
-			const response = generateSpanQuery("nrGuid", "locator", "equals", undefined, {
+			const response = generateSpanQuery("nrGuid", "locator", "equals", "python", undefined, {
 				namespace: "blah",
 				functionName: "foo",
 			});
@@ -90,7 +90,7 @@ describe("clm query generation", () => {
 		});
 
 		it("generates namespace and function locator query using like", () => {
-			const response = generateSpanQuery("nrGuid", "locator", "like", undefined, {
+			const response = generateSpanQuery("nrGuid", "locator", "like", "python", undefined, {
 				namespace: "blah",
 				functionName: "foo",
 			});

--- a/vscode/src/controllers/instrumentableCodeLensController.ts
+++ b/vscode/src/controllers/instrumentableCodeLensController.ts
@@ -104,6 +104,9 @@ export class InstrumentableCodeLensController implements Disposable {
 					{ language: "go" },
 					{ language: "php" },
 					{ language: "javascript" },
+					{ language: "javascriptreact" },
+					{ language: "typescript" },
+					{ language: "typescriptreact" },
 					{ scheme: "codestream-diff" }
 				],
 				this._provider

--- a/vscode/src/providers/instrumentationCodeLensProvider.ts
+++ b/vscode/src/providers/instrumentationCodeLensProvider.ts
@@ -138,7 +138,6 @@ export class InstrumentationCodeLensProvider implements vscode.CodeLensProvider 
 			const useLanguageServer = config.get("useLanguageServer");
 			if (!useLanguageServer) {
 				return this.rubyPluginConfigCodelens();
-			} else {
 			}
 			return;
 		}

--- a/vscode/src/providers/symbolLocator.ts
+++ b/vscode/src/providers/symbolLocator.ts
@@ -23,6 +23,15 @@ export interface ISymbolLocator {
 	locate(document: TextDocument, token: vscode.CancellationToken): Promise<SymboslLocated>;
 }
 
+function isJavascriptIsh(languageId: string) {
+	return (
+		languageId === "javascript" ||
+		languageId === "typescript" ||
+		languageId === "javascriptreact" ||
+		languageId === "tyspescriptreact"
+	);
+}
+
 export class SymbolLocator implements ISymbolLocator {
 	async locate(
 		document: TextDocument,
@@ -123,7 +132,7 @@ export class SymbolLocator implements ISymbolLocator {
 	}
 
 	public isJavascriptFunctionVariable(document: TextDocument, symbol: DocumentSymbol): boolean {
-		if (document.languageId === "javascript" && symbol.kind === vscode.SymbolKind.Variable) {
+		if (isJavascriptIsh(document.languageId) && symbol.kind === vscode.SymbolKind.Variable) {
 			// Look for variables assigned to functions i.e. myVar = functiion {}
 			const symbolText = document.getText(symbol.range);
 			const functionKeywordRegex = new RegExp(`${symbol.name}\\s*=\\s*function`, "s");


### PR DESCRIPTION
Also fix error logging (or at least make it more consistent)

**This PR Addresses:**  
[NEWRELIC-6353 Node symbol lookup - support next.js framework](https://issues.newrelic.com/browse/NEWRELIC-6353)  


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>