### PR TITLE
[NR-79482] Error sharing an existing codemark to Slack resolved

### DIFF
--- a/shared/ui/Stream/SharingModal.tsx
+++ b/shared/ui/Stream/SharingModal.tsx
@@ -168,6 +168,7 @@ export function SharingModal(props: SharingModalProps) {
 					review: props.review,
 					codeError: props.codeError,
 					mentionedUserIds,
+					providerServerTokenUserId: valuesRef.current.botUserId,
 				}
 			);
 			if (props.post && ts) {


### PR DESCRIPTION
[NR-79482](https://issues.newrelic.com/browse/NR-79482)
Error sharing an existing codemark to Slack

Successfully shares an existing codemark to a DM.