### PR TITLE
Provide useful GHE connection errors when disconnecting from VPN

### DIFF
--- a/shared/ui/Stream/OpenPullRequests.tsx
+++ b/shared/ui/Stream/OpenPullRequests.tsx
@@ -139,8 +139,8 @@ const Root = styled.div`
 `;
 
 const PrErrorText = styled.small`
-	text-align: right;
 	display: block;
+	padding-left: 16px;
 `;
 
 interface ReposScmPlusName extends ReposScm {


### PR DESCRIPTION
This adds a cache timeout for the version check on GHE so that we avoid making the same request repeatedly for a single refresh, but we recheck the version after a minute so we can provide timely and relevant error messages after disconnecting from a VPN. Otherwise, it can take upwards of 5 minutes to show an error message if you were previously able to connect to GHE.