### PR TITLE
NR-84166 Refactor newrelic.ts & NRManager.ts …

### DIFF
--- a/shared/agent/package-lock.json
+++ b/shared/agent/package-lock.json
@@ -47,6 +47,7 @@
 				"timed-cache": "2.0.0",
 				"tiny-async-pool": "1.2.0",
 				"tmp": "0.1.0",
+				"typed-inject": "3.0.1",
 				"utf-8-validate": "5.0.8",
 				"uuid": "3.3.2",
 				"vscode-languageserver": "5.2.1",
@@ -15945,6 +15946,14 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/typed-inject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-3.0.1.tgz",
+			"integrity": "sha512-5yr8inrNos7uo/irp5PZ7WNwmYGfoa0w1NiDdCWW6hhIxYH2NCqYwX9BUOXpZgxk964rb1ElEfvBtftuvIPpvw==",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -28214,6 +28223,11 @@
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
 			"integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="
+		},
+		"typed-inject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-3.0.1.tgz",
+			"integrity": "sha512-5yr8inrNos7uo/irp5PZ7WNwmYGfoa0w1NiDdCWW6hhIxYH2NCqYwX9BUOXpZgxk964rb1ElEfvBtftuvIPpvw=="
 		},
 		"typedarray": {
 			"version": "0.0.6",

--- a/shared/agent/package.json
+++ b/shared/agent/package.json
@@ -89,6 +89,7 @@
 		"timed-cache": "2.0.0",
 		"tiny-async-pool": "1.2.0",
 		"tmp": "0.1.0",
+		"typed-inject": "3.0.1",
 		"utf-8-validate": "5.0.8",
 		"uuid": "3.3.2",
 		"vscode-languageserver": "5.2.1",

--- a/shared/agent/src/api/apiProvider.ts
+++ b/shared/agent/src/api/apiProvider.ts
@@ -1,5 +1,5 @@
 import { RequestInit, Response } from "node-fetch";
-import { Disposable, Event } from "vscode-languageserver";
+import { Event } from "vscode-languageserver";
 
 import { HistoryFetchInfo } from "broadcaster/broadcaster";
 import {
@@ -77,8 +77,6 @@ import {
 	FetchReviewsResponse,
 	FetchStreamsRequest,
 	FetchStreamsResponse,
-	FetchTeamsRequest,
-	FetchTeamsResponse,
 	FetchThirdPartyBuildsRequest,
 	FetchThirdPartyBuildsResponse,
 	FetchUnreadStreamsRequest,
@@ -113,8 +111,6 @@ import {
 	GetReviewResponse,
 	GetStreamRequest,
 	GetStreamResponse,
-	GetTeamRequest,
-	GetTeamResponse,
 	GetUnreadsRequest,
 	GetUnreadsResponse,
 	GetUserRequest,
@@ -382,8 +378,6 @@ export type RTMessage =
 
 export interface ApiProvider {
 	onDidReceiveMessage: Event<RTMessage>;
-
-	readonly baseUrl: string;
 	readonly teamId: string;
 	readonly userId: string;
 	readonly capabilities: Capabilities;
@@ -391,8 +385,6 @@ export interface ApiProvider {
 
 	providerType: ProviderType;
 
-	fetch<R extends object>(url: string, init?: RequestInit, token?: string): Promise<R>;
-	useMiddleware(middleware: CodeStreamApiMiddleware): Disposable;
 	dispose(): Promise<void>;
 
 	login(options: LoginOptions): Promise<ApiProviderLoginResponse>;
@@ -510,9 +502,6 @@ export interface ApiProvider {
 		request: UpdateStreamMembershipRequest
 	): Promise<UpdateStreamMembershipResponse>;
 
-	fetchTeams(request: FetchTeamsRequest): Promise<FetchTeamsResponse>;
-	getTeam(request: GetTeamRequest): Promise<GetTeamResponse>;
-
 	fetchCompanies(request: FetchCompaniesRequest): Promise<FetchCompaniesResponse>;
 	getCompany(request: GetCompanyRequest): Promise<GetCompanyResponse>;
 	deleteCompany(request: DeleteCompanyRequest): Promise<DeleteCompanyResponse>;
@@ -561,16 +550,10 @@ export interface ApiProvider {
 	): Promise<LookupNewRelicOrganizationsResponse>;
 
 	verifyConnectivity(): Promise<VerifyConnectivityResponse>;
-	setServerUrl(url: string): void;
 
 	announceHistoryFetch(info: HistoryFetchInfo): void;
 
 	fetchBuilds(request: FetchThirdPartyBuildsRequest): Promise<FetchThirdPartyBuildsResponse>;
-
-	get<R extends object>(url: string, token?: string): Promise<R>;
-	post<RQ extends object, R extends object>(url: string, body: any, token?: string): Promise<R>;
-	put<RQ extends object, R extends object>(url: string, body: RQ, token?: string): Promise<R>;
-	delete<R extends object>(url: string, token?: string): Promise<R>;
 }
 export interface CodeStreamApiMiddlewareContext {
 	url: string;

--- a/shared/agent/src/api/codestream/api/apiClient.ts
+++ b/shared/agent/src/api/codestream/api/apiClient.ts
@@ -1,0 +1,334 @@
+import { Headers, RequestInit, Response } from "node-fetch";
+import { CodeStreamApiMiddleware, CodeStreamApiMiddlewareContext } from "../../apiProvider";
+import { Logger } from "../../../logger";
+import { fetchCore } from "../../../system/fetchCore";
+import { Container } from "../../../container";
+import { promises as fs } from "fs";
+import { URLSearchParams } from "url";
+import { Objects, Strings } from "../../../system";
+import { VersionInfo } from "../../../types";
+import { Agent as HttpsAgent } from "https";
+import HttpsProxyAgent from "https-proxy-agent";
+import { Agent as HttpAgent } from "http";
+import { ReportingMessageType } from "@codestream/protocols/agent";
+import { ServerError } from "../../../agentError";
+
+export class ApiClient {
+	private _token: string | undefined;
+	private readonly _middleware: CodeStreamApiMiddleware[] = [];
+
+	constructor(
+		public baseUrl: string,
+		public readonly version: VersionInfo,
+		public readonly httpsAgent: HttpsAgent | HttpsProxyAgent | HttpAgent | undefined,
+		public readonly strictSSL: boolean
+	) {}
+
+	public get token(): string | undefined {
+		return this._token;
+	}
+
+	public set token(value: string | undefined) {
+		this._token = value;
+	}
+
+	useMiddleware(middleware: CodeStreamApiMiddleware) {
+		this._middleware.push(middleware);
+		return {
+			dispose: () => {
+				const i = this._middleware.indexOf(middleware);
+				this._middleware.splice(i, 1);
+			},
+		};
+	}
+
+	setServerUrl(serverUrl: string) {
+		this.baseUrl = serverUrl.trim();
+	}
+
+	async get<R extends object>(url: string, token?: string): Promise<R> {
+		if (!token && url.indexOf("/no-auth/") === -1) token = this._token;
+		return this.fetch<R>(url, { method: "GET" }, token) as Promise<R>;
+	}
+
+	async put<RQ extends object, R extends object>(
+		url: string,
+		body: RQ,
+		token?: string
+	): Promise<R> {
+		if (!token && url.indexOf("/no-auth/") === -1) token = this._token;
+		return this.fetch<R>(
+			url,
+			{
+				method: "PUT",
+				body: JSON.stringify(body),
+			},
+			token
+		);
+	}
+
+	async post<RQ extends object, R extends object>(
+		url: string,
+		body: RQ,
+		token?: string
+	): Promise<R> {
+		if (!token && url.indexOf("/no-auth/") === -1) token = this._token;
+		return this.fetch<R>(
+			url,
+			{
+				method: "POST",
+				body: JSON.stringify(body),
+			},
+			token
+		);
+	}
+
+	async delete<R extends object>(url: string, token?: string): Promise<R> {
+		if (!token && url.indexOf("/no-auth/") === -1) token = this._token;
+		let resp = undefined;
+		if (resp === undefined) {
+			resp = this.fetch<R>(url, { method: "DELETE" }, token) as Promise<R>;
+		}
+		return resp;
+	}
+
+	/*private*/
+	async fetch<R extends object>(url: string, init?: RequestInit, token?: string): Promise<R> {
+		const start = process.hrtime();
+
+		const sanitizedUrl = ApiClient.sanitizeUrl(url);
+		let traceResult;
+		try {
+			if (init !== undefined || token !== undefined) {
+				if (init === undefined) {
+					init = {};
+				}
+
+				if (init.headers === undefined) {
+					init.headers = new Headers();
+				}
+
+				if (init.headers instanceof Headers) {
+					init.headers.append("Accept", "application/json");
+					init.headers.append("Content-Type", "application/json");
+
+					if (token !== undefined) {
+						init.headers.append("Authorization", `Bearer ${token}`);
+					}
+
+					init.headers.append("X-CS-Plugin-IDE", this.version.ide.name);
+					init.headers.append("X-CS-Plugin-IDE-Detail", this.version.ide.detail);
+					init.headers.append(
+						"X-CS-Plugin-Version",
+						`${this.version.extension.version}+${this.version.extension.build}`
+					);
+					init.headers.append("X-CS-IDE-Version", this.version.ide.version);
+				}
+			}
+
+			if (this.httpsAgent !== undefined) {
+				if (init === undefined) {
+					init = {};
+				}
+
+				init.agent = this.httpsAgent;
+			}
+
+			const method = (init && init.method) || "GET";
+			const absoluteUrl = `${this.baseUrl}${url}`;
+
+			const context =
+				this._middleware.length > 0
+					? ({
+							url: absoluteUrl,
+							method: method,
+							request: init,
+					  } as CodeStreamApiMiddlewareContext)
+					: undefined;
+
+			if (context !== undefined) {
+				for (const mw of this._middleware) {
+					if (mw.onRequest === undefined) continue;
+
+					try {
+						await mw.onRequest(context);
+					} catch (ex) {
+						Logger.error(
+							ex,
+							`API: ${method} ${sanitizedUrl}: Middleware(${mw.name}).onRequest FAILED`
+						);
+					}
+				}
+			}
+
+			let json: Promise<R> | undefined;
+			if (context !== undefined) {
+				for (const mw of this._middleware) {
+					if (mw.onProvideResponse === undefined) continue;
+
+					try {
+						json = mw.onProvideResponse(context);
+						if (json !== undefined) break;
+					} catch (ex) {
+						Logger.error(
+							ex,
+							`API: ${method} ${sanitizedUrl}: Middleware(${mw.name}).onProvideResponse FAILED`
+						);
+					}
+				}
+			}
+
+			let id;
+			let resp;
+			let retryCount = 0;
+			if (json === undefined) {
+				[resp, retryCount] = await fetchCore(0, absoluteUrl, init);
+				if (context !== undefined) {
+					context.response = resp;
+				}
+
+				id = resp.headers.get("x-request-id");
+
+				if (resp.ok) {
+					traceResult = `API(${id}): Completed ${method} ${sanitizedUrl}`;
+					json = resp.json() as Promise<R>;
+				}
+			}
+
+			if (context !== undefined) {
+				for (const mw of this._middleware) {
+					if (mw.onResponse === undefined) continue;
+
+					try {
+						await mw.onResponse(context, json);
+					} catch (ex) {
+						Logger.error(
+							ex,
+							`API(${id}): ${method} ${sanitizedUrl}: Middleware(${mw.name}).onResponse FAILED`
+						);
+					}
+				}
+			}
+
+			if (resp !== undefined && !resp.ok) {
+				traceResult = `API(${id}): FAILED(${retryCount}x) ${method} ${sanitizedUrl}`;
+				Container.instance().errorReporter.reportBreadcrumb({
+					message: traceResult,
+					category: "apiErrorResponse",
+				});
+				throw await this.handleErrorResponse(resp);
+			}
+
+			const _json = await json;
+
+			if (Container.instance().agent.recordRequests && init) {
+				const now = Date.now();
+				const { method, body } = init;
+
+				const urlForFilename = ApiClient.sanitize(
+					sanitizedUrl.split("?")[0].replace(/\//g, "_").replace("_", "")
+				);
+				const filename = `/tmp/dump-${now}-csapi-${method}-${urlForFilename}.json`;
+
+				const out = {
+					url: url,
+					request: typeof body === "string" ? JSON.parse(body) : body,
+					response: _json,
+				};
+				const outString = JSON.stringify(out, null, 2);
+
+				await fs.writeFile(filename, outString, { encoding: "utf8" });
+				Logger.log(`Written ${filename}`);
+			}
+
+			return ApiClient.normalizeResponse(_json);
+		} finally {
+			Logger.log(
+				`${traceResult}${
+					init && init.body ? ` body=${ApiClient.sanitize(init && init.body)}` : ""
+				} \u2022 ${Strings.getDurationMilliseconds(start)} ms`
+			);
+		}
+	}
+
+	private async handleErrorResponse(response: Response): Promise<Error> {
+		let message = response.statusText;
+		let data;
+		if (response.status >= 400 && response.status < 500) {
+			try {
+				data = await response.json();
+				if (data.code) {
+					message += `(${data.code})`;
+				}
+				if (data.message) {
+					message += `: ${data.message}`;
+				}
+				if (data.info) {
+					if (data.info.name) {
+						message += `\n${data.info.name || data.info}`;
+					}
+					if (data.message === "Validation error") {
+						message += ` ${Array.from(Objects.values(data.info)).join(", ")}`;
+					}
+				}
+			} catch {}
+		}
+
+		Container.instance().errorReporter.reportMessage({
+			source: "agent",
+			type: ReportingMessageType.Error,
+			message: `[Server Error]: ${message}`,
+			extra: {
+				data,
+				responseStatus: response.status,
+				requestId: response.headers.get("x-request-id"),
+				requestUrl: response.url,
+			},
+		});
+
+		return new ServerError(message, data, response.status);
+	}
+
+	static normalizeResponse<R extends object>(obj?: { [key: string]: any }): R {
+		// FIXME maybe the api server should never return arrays with null elements?
+		if (obj != null) {
+			for (const [key, value] of Object.entries(obj)) {
+				if (key === "_id") {
+					obj["id"] = value;
+				}
+
+				if (Array.isArray(value)) {
+					obj[key] = value.map(v => this.normalizeResponse(v));
+				} else if (typeof value === "object") {
+					obj[key] = this.normalizeResponse(value);
+				}
+			}
+		}
+
+		return obj as R;
+	}
+
+	static sanitize(
+		body:
+			| string
+			| ArrayBuffer
+			| ArrayBufferView
+			| NodeJS.ReadableStream
+			| URLSearchParams
+			| undefined
+	) {
+		if (body === undefined || typeof body !== "string") return "";
+
+		return body.replace(
+			/("\w*?apikey\w*?":|"\w*?password\w*?":|"\w*?secret\w*?":|"\w*?token\w*?":)".*?"/gi,
+			'$1"<hidden>"'
+		);
+	}
+
+	static sanitizeUrl(url: string) {
+		return url.replace(
+			/(\b\w*?apikey\w*?=|\b\w*?password\w*?=|\b\w*?secret\w*?=|\b\w*?token\w*?=)(?:.+?)(?=&|$)/gi,
+			"$1<hidden>"
+		);
+	}
+}

--- a/shared/agent/src/api/codestream/api/teamsApi.ts
+++ b/shared/agent/src/api/codestream/api/teamsApi.ts
@@ -1,0 +1,32 @@
+import { log } from "../../../system/decorators/log";
+import { FetchTeamsRequest, GetTeamRequest } from "@codestream/protocols/agent";
+import { CSGetTeamResponse, CSGetTeamsResponse } from "@codestream/protocols/api";
+import { ApiClient } from "./apiClient";
+
+export class TeamsApi {
+	constructor(private apiClient: ApiClient) {}
+
+	public static inject = ["apiClient"] as const;
+
+	@log()
+	fetchTeams(request: FetchTeamsRequest) {
+		let params = "";
+		if (request.mine) {
+			params = `&mine`;
+		}
+
+		if (request.teamIds && request.teamIds.length) {
+			params += `&ids=${request.teamIds.join(",")}`;
+		}
+
+		return this.apiClient.get<CSGetTeamsResponse>(
+			`/teams${params ? `?${params.substring(1)}` : ""}`,
+			this.apiClient.token
+		);
+	}
+
+	@log()
+	getTeam(request: GetTeamRequest) {
+		return this.apiClient.get<CSGetTeamResponse>(`/teams/${request.teamId}`, this.apiClient.token);
+	}
+}

--- a/shared/agent/src/api/middleware/versionMiddleware.ts
+++ b/shared/agent/src/api/middleware/versionMiddleware.ts
@@ -6,11 +6,11 @@ import { Disposable, Emitter, Event } from "vscode-languageserver";
 import { Logger } from "../../logger";
 import { log, Versions } from "../../system";
 import {
-	ApiProvider,
 	CodeStreamApiMiddleware,
 	CodeStreamApiMiddlewareContext,
 } from "../apiProvider";
 import { APIServerVersionInfo } from "../codestream/apiServerVersionInfo";
+import { ApiClient } from "../codestream/api/apiClient";
 
 export interface VersionCompatibilityChangedEvent {
 	compatibility: VersionCompatibility;
@@ -39,8 +39,8 @@ export class VersionMiddlewareManager implements Disposable {
 	private _compatibility: VersionCompatibility | undefined;
 	private _apiVersion: string = "";
 
-	constructor(private readonly _api: ApiProvider) {
-		this._disposable = this._api.useMiddleware(new VersionMiddleware(this));
+	constructor(private readonly _apiClient: ApiClient) {
+		this._disposable = this._apiClient.useMiddleware(new VersionMiddleware(this));
 	}
 
 	dispose() {

--- a/shared/agent/src/managers/baseManager.ts
+++ b/shared/agent/src/managers/baseManager.ts
@@ -5,11 +5,11 @@ import { CSEntity, CSMarkerLocations } from "@codestream/protocols/api";
 import { RawRTMessage } from "../api/apiProvider";
 import { Container, SessionContainer } from "../container";
 import { Logger } from "../logger";
-import { CodeStreamSession } from "../session";
 import { debug, log } from "../system";
 import { IndexParams } from "./cache";
 import { BaseCache, KeyValue } from "./cache/baseCache";
 import { isDirective, resolve } from "./operations";
+import cacheReset from "./cache/cacheReset";
 
 function getCacheUpdateAction(
 	newOrDirective: any,
@@ -59,8 +59,8 @@ export abstract class ManagerBase<T> {
 
 	protected forceFetchToResolveOnCacheMiss = false;
 
-	constructor(public readonly session: CodeStreamSession) {
-		this.session.onDidRequestReset(() => {
+	constructor() {
+		cacheReset.onDidRequestReset(() => {
 			this.invalidateCache();
 		});
 

--- a/shared/agent/src/managers/cache/cacheReset.ts
+++ b/shared/agent/src/managers/cache/cacheReset.ts
@@ -1,0 +1,17 @@
+import { Emitter, Event } from "vscode-languageserver";
+import { log } from "../../system/decorators/log";
+
+class CacheReset {
+	private _onDidRequestReset = new Emitter<void>();
+	get onDidRequestReset(): Event<void> {
+		return this._onDidRequestReset.event;
+	}
+
+	@log()
+	reset() {
+		this._onDidRequestReset.fire(undefined);
+	}
+}
+
+const cacheReset = new CacheReset();
+export default cacheReset;

--- a/shared/agent/src/managers/codeErrorsManager.ts
+++ b/shared/agent/src/managers/codeErrorsManager.ts
@@ -20,9 +20,14 @@ import { CSCodeError } from "@codestream/protocols/api";
 import { MessageType } from "../api/apiProvider";
 import { log, lsp, lspHandler } from "../system";
 import { CachedEntityManagerBase, Id } from "./entityManager";
+import { CodeStreamSession } from "../session";
 
 @lsp
 export class CodeErrorsManager extends CachedEntityManagerBase<CSCodeError> {
+	constructor(private readonly session: CodeStreamSession) {
+		super();
+	}
+
 	@lspHandler(FetchCodeErrorsRequestType)
 	@log()
 	async get(request?: FetchCodeErrorsRequest): Promise<FetchCodeErrorsResponse> {

--- a/shared/agent/src/managers/codemarksManager.ts
+++ b/shared/agent/src/managers/codemarksManager.ts
@@ -51,10 +51,15 @@ import { Container, SessionContainer } from "../container";
 import { Logger } from "../logger";
 import { log, lsp, lspHandler, Strings } from "../system";
 import { CachedEntityManagerBase, Id } from "./entityManager";
+import { CodeStreamSession } from "../session";
 
 @lsp
 export class CodemarksManager extends CachedEntityManagerBase<CSCodemark> {
 	private _codemarkSha1Cache = new Map<string, GetCodemarkSha1Response>();
+
+	constructor(private readonly session: CodeStreamSession) {
+		super();
+	}
 
 	async cacheSet(entity: CSCodemark, oldEntity?: CSCodemark): Promise<CSCodemark | undefined> {
 		if (await this.canSeeCodemark(entity)) {

--- a/shared/agent/src/managers/companiesManager.ts
+++ b/shared/agent/src/managers/companiesManager.ts
@@ -8,9 +8,14 @@ import { CSCompany } from "@codestream/protocols/api";
 
 import { lsp, lspHandler } from "../system";
 import { CachedEntityManagerBase, Id } from "./entityManager";
+import { CodeStreamSession } from "../session";
 
 @lsp
 export class CompaniesManager extends CachedEntityManagerBase<CSCompany> {
+	constructor(private readonly session: CodeStreamSession) {
+		super();
+	}
+
 	@lspHandler(FetchCompaniesRequestType)
 	async get(request?: FetchCompaniesRequest): Promise<FetchCompaniesResponse> {
 		let companies = await this.getAllCached();

--- a/shared/agent/src/managers/entityManager.ts
+++ b/shared/agent/src/managers/entityManager.ts
@@ -2,7 +2,6 @@
 import { CSEntity } from "@codestream/protocols/api";
 
 import { RawRTMessage } from "../api/apiProvider";
-import { CodeStreamSession } from "../session";
 import { log } from "../system";
 import { ManagerBase } from "./baseManager";
 import { KeyValue } from "./cache/baseCache";
@@ -19,10 +18,6 @@ export abstract class EntityManagerBase<T extends CSEntity> extends ManagerBase<
 		fetchFn: this.fetch.bind(this),
 		entityName: this.getEntityName(),
 	});
-
-	constructor(session: CodeStreamSession) {
-		super(session);
-	}
 
 	getById(id: Id): Promise<T> {
 		return this.cache.getById(id);

--- a/shared/agent/src/managers/filesManager.ts
+++ b/shared/agent/src/managers/filesManager.ts
@@ -19,10 +19,15 @@ import { lsp, lspHandler } from "../system";
 import { IndexParams, IndexType } from "./cache";
 import { getValues, KeyValue } from "./cache/baseCache";
 import { EntityManagerBase, Id } from "./entityManager";
+import { CodeStreamSession } from "../session";
 
 @lsp
 export class FilesManager extends EntityManagerBase<CSFileStream> {
 	private idsByPath = new Map<string, Id>();
+
+	constructor(private readonly session: CodeStreamSession) {
+		super();
+	}
 
 	getIndexedFields(): IndexParams<CSFileStream>[] {
 		return [

--- a/shared/agent/src/managers/markerLocationManager.ts
+++ b/shared/agent/src/managers/markerLocationManager.ts
@@ -28,6 +28,7 @@ import { ManagerBase } from "./baseManager";
 import { IndexParams, IndexType } from "./cache";
 import { getValues, KeyValue } from "./cache/baseCache";
 import { Id } from "./entityManager";
+import { CodeStreamSession } from "../session";
 
 export interface Markerish {
 	id: string;
@@ -83,6 +84,10 @@ function compareReferenceLocations(a: CSReferenceLocation, b: CSReferenceLocatio
 
 export class MarkerLocationManager extends ManagerBase<CSMarkerLocations> {
 	protected forceFetchToResolveOnCacheMiss = true;
+
+	constructor(private readonly session: CodeStreamSession) {
+		super();
+	}
 
 	getIndexedFields(): IndexParams<CSMarkerLocations>[] {
 		return [

--- a/shared/agent/src/managers/markersManager.ts
+++ b/shared/agent/src/managers/markersManager.ts
@@ -21,9 +21,14 @@ import { IndexParams, IndexType } from "./cache";
 import { getValues, KeyValue } from "./cache/baseCache";
 import { EntityManagerBase, Id } from "./entityManager";
 import { MarkersBuilder } from "./markersBuilder";
+import { CodeStreamSession } from "../session";
 
 @lsp
 export class MarkersManager extends EntityManagerBase<CSMarker> {
+	constructor(private readonly session: CodeStreamSession) {
+		super();
+	}
+
 	async getByStreamId(streamId: Id, visibleOnly?: boolean): Promise<CSMarker[]> {
 		const markers = await this.cache.getGroup([["fileStreamId", streamId]]);
 		this.polyfill(markers);

--- a/shared/agent/src/managers/postsManager.ts
+++ b/shared/agent/src/managers/postsManager.ts
@@ -115,6 +115,7 @@ import { EntityManagerBase, Id } from "./entityManager";
 import { MarkersBuilder } from "./markersBuilder";
 
 import getProviderDisplayName = Marker.getProviderDisplayName;
+import { CodeStreamSession } from "../session";
 
 export type FetchPostsFn = (request: FetchPostsRequest) => Promise<FetchPostsResponse>;
 
@@ -735,6 +736,10 @@ export class PostsManager extends EntityManagerBase<CSPost> {
 		fetchPosts: this.fetchPosts.bind(this),
 		entityName: this.getEntityName(),
 	});
+
+	constructor(private readonly session: CodeStreamSession) {
+		super();
+	}
 
 	disableCache() {
 		this.cache.disable();

--- a/shared/agent/src/managers/reposManager.ts
+++ b/shared/agent/src/managers/reposManager.ts
@@ -14,9 +14,14 @@ import { CSRepository } from "@codestream/protocols/api";
 
 import { lsp, lspHandler } from "../system";
 import { CachedEntityManagerBase, Id } from "./entityManager";
+import { CodeStreamSession } from "../session";
 
 @lsp
 export class ReposManager extends CachedEntityManagerBase<CSRepository> {
+	constructor(private readonly session: CodeStreamSession) {
+		super();
+	}
+
 	@lspHandler(CreateRepoRequestType)
 	createRepo(request: CreateRepoRequest): Promise<CreateRepoResponse> {
 		return this.session.api.createRepo(request);

--- a/shared/agent/src/managers/serverManager.ts
+++ b/shared/agent/src/managers/serverManager.ts
@@ -9,12 +9,14 @@ import {
 } from "@codestream/protocols/agent";
 
 import { Logger } from "../logger";
-import { CodeStreamSession } from "../session";
 import { lsp, lspHandler } from "../system";
+import { ApiClient } from "../api/codestream/api/apiClient";
 
 @lsp
 export class ServerManager {
-	constructor(private readonly session: CodeStreamSession) {}
+	constructor(private apiClient: ApiClient) {}
+
+	public static inject = ["apiClient"] as const;
 
 	@lspHandler(CodeStreamApiGetRequestType)
 	async get(request: { url: string; queryData: ParsedUrlQueryInput }): Promise<any> {
@@ -22,7 +24,7 @@ export class ServerManager {
 			if (request.queryData) {
 				request.url += `?${qs.stringify(request.queryData)}`;
 			}
-			return this.session.api.get(request.url);
+			return this.apiClient.get(request.url);
 		} catch (e) {
 			Logger.error(e, "Could not GET", {
 				url: request.url,
@@ -33,7 +35,7 @@ export class ServerManager {
 	@lspHandler(CodeStreamApiPostRequestType)
 	async post(request: { url: string; body?: any }): Promise<any> {
 		try {
-			return this.session.api.post(request.url, request.body);
+			return this.apiClient.post(request.url, request.body);
 		} catch (e) {
 			Logger.error(e, "Could not POST", {
 				url: request.url,
@@ -44,7 +46,7 @@ export class ServerManager {
 	@lspHandler(CodeStreamApiPutRequestType)
 	async put(request: { url: string; body?: any }): Promise<any> {
 		try {
-			return this.session.api.put(request.url, request.body);
+			return this.apiClient.put(request.url, request.body);
 		} catch (e) {
 			Logger.error(e, "Could not PUT", {
 				url: request.url,
@@ -55,7 +57,7 @@ export class ServerManager {
 	@lspHandler(CodeStreamApiDeleteRequestType)
 	async delete(request: { url: string }): Promise<any> {
 		try {
-			return this.session.api.delete(request.url);
+			return this.apiClient.delete(request.url);
 		} catch (e) {
 			Logger.error(e, "Could not DELETE", {
 				url: request.url,

--- a/shared/agent/src/managers/streamsManager.ts
+++ b/shared/agent/src/managers/streamsManager.ts
@@ -63,11 +63,16 @@ import { Logger } from "../logger";
 import { lsp, lspHandler } from "../system";
 import { KeyValue } from "./cache/baseCache";
 import { CachedEntityManagerBase, Id } from "./entityManager";
+import { CodeStreamSession } from "../session";
 
 @lsp
 export class StreamsManager extends CachedEntityManagerBase<
 	CSChannelStream | CSDirectStream | CSObjectStream
 > {
+	constructor(private readonly session: CodeStreamSession) {
+		super();
+	}
+
 	@lspHandler(FetchStreamsRequestType)
 	async get(request?: FetchStreamsRequest): Promise<FetchStreamsResponse> {
 		let streams = await this.getAllCached();

--- a/shared/agent/src/managers/teamsManager.ts
+++ b/shared/agent/src/managers/teamsManager.ts
@@ -11,9 +11,16 @@ import { CSTeam } from "@codestream/protocols/api";
 
 import { lsp, lspHandler } from "../system";
 import { CachedEntityManagerBase, Id } from "./entityManager";
+import { TeamsApi } from "../api/codestream/api/teamsApi";
 
 @lsp
 export class TeamsManager extends CachedEntityManagerBase<CSTeam> {
+	constructor(private teamsApi: TeamsApi) {
+		super();
+	}
+
+	public static inject = ["teamsApi"] as const;
+
 	@lspHandler(FetchTeamsRequestType)
 	async get(request?: FetchTeamsRequest): Promise<FetchTeamsResponse> {
 		let teams = await this.getAllCached();
@@ -27,14 +34,14 @@ export class TeamsManager extends CachedEntityManagerBase<CSTeam> {
 	}
 
 	protected async loadCache() {
-		const response = await this.session.api.fetchTeams({ mine: true });
+		const response = await this.teamsApi.fetchTeams({ mine: true });
 		const { teams, ...rest } = response;
 		this.cache.reset(teams);
 		this.cacheResponse(rest);
 	}
 
 	protected async fetchById(teamId: Id): Promise<CSTeam> {
-		const response = await this.session.api.getTeam({ teamId: teamId });
+		const response = await this.teamsApi.getTeam({ teamId: teamId });
 		return response.team;
 	}
 

--- a/shared/agent/src/managers/usersManager.ts
+++ b/shared/agent/src/managers/usersManager.ts
@@ -35,9 +35,14 @@ import { CSMe, CSUser } from "@codestream/protocols/api";
 
 import { lsp, lspHandler } from "../system";
 import { CachedEntityManagerBase, Id } from "./entityManager";
+import { CodeStreamSession } from "../session";
 
 @lsp
 export class UsersManager extends CachedEntityManagerBase<CSUser> {
+	constructor(private readonly session: CodeStreamSession) {
+		super();
+	}
+
 	@lspHandler(FetchUsersRequestType)
 	async get(request?: FetchUsersRequest): Promise<FetchUsersResponse> {
 		let users = await this.getAllCached();

--- a/shared/agent/src/providers/newrelic.ts
+++ b/shared/agent/src/providers/newrelic.ts
@@ -144,6 +144,7 @@ import { generateClmSpanDataExistsQuery } from "./newrelic/spanQuery";
 import { ThirdPartyIssueProviderBase } from "./thirdPartyIssueProviderBase";
 import { ClmManager, EnhancedMetricTimeslice, LanguageId } from "./newrelic/clm/clmManager";
 import { Index } from "@codestream/utils/types";
+import { TeamsManager } from "../managers/teamsManager";
 
 const ignoredErrors = [GraphqlNrqlTimeoutError];
 
@@ -185,7 +186,11 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 		this.errorLogIfNotIgnored.bind(this)
 	);
 
-	constructor(session: CodeStreamSession, config: ThirdPartyProviderConfig) {
+	constructor(
+		session: CodeStreamSession,
+		config: ThirdPartyProviderConfig,
+		private teamsManager: TeamsManager
+	) {
 		super(session, config);
 		this._memoizedBuildRepoRemoteVariants = memoize(
 			this.buildRepoRemoteVariants,
@@ -369,7 +374,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 	@log()
 	async updateOrgId(request: UpdateNewRelicOrgIdRequest): Promise<UpdateNewRelicOrgIdResponse> {
 		const orgId = await this.getOrgId();
-		const team = await SessionContainer.instance().teams.getByIdFromCache(request.teamId);
+		const team = await this.teamsManager.getByIdFromCache(request.teamId);
 		const company =
 			team && (await SessionContainer.instance().companies.getByIdFromCache(team.companyId));
 		if (orgId && company) {

--- a/shared/agent/test/unit/managers/reviewsManager.spec.ts
+++ b/shared/agent/test/unit/managers/reviewsManager.spec.ts
@@ -4,7 +4,7 @@ import { ReviewsManager } from "../../../src/managers/reviewsManager";
 describe("ReviewsManager.spec.ts", () => {
 	describe("checkPullRequestPreconditions", () => {
 		it("REPO_NOT_FOUND", async () => {
-			const manager = new ReviewsManager({ onDidRequestReset: function () {} } as any);
+			const manager = new ReviewsManager({ onDidRequestReset: function () {} } as any, {} as any);
 			const response = await manager.checkPullRequestPreconditions({} as any, null, {
 				session: {} as any,
 				git: {},
@@ -16,7 +16,7 @@ describe("ReviewsManager.spec.ts", () => {
 
 		describe("with review", () => {
 			it("HAS_LOCAL_MODIFICATIONS", async () => {
-				const manager = new ReviewsManager({ onDidRequestReset: function () {} } as any);
+				const manager = new ReviewsManager({ onDidRequestReset: function () {} } as any, {} as any);
 				manager.getById = async function () {
 					return {
 						reviewChangesets: [
@@ -52,7 +52,7 @@ describe("ReviewsManager.spec.ts", () => {
 			});
 
 			it("HAS_LOCAL_COMMITS", async () => {
-				const manager = new ReviewsManager({ onDidRequestReset: function () {} } as any);
+				const manager = new ReviewsManager({ onDidRequestReset: function () {} } as any, {} as any);
 				manager.getById = async function () {
 					return {
 						reviewChangesets: [
@@ -90,7 +90,7 @@ describe("ReviewsManager.spec.ts", () => {
 
 		describe("without review", () => {
 			it("REQUIRES_PROVIDER", async () => {
-				const manager = new ReviewsManager({ onDidRequestReset: function () {} } as any);
+				const manager = new ReviewsManager({ onDidRequestReset: function () {} } as any, {} as any);
 
 				const response = await manager.checkPullRequestPreconditions(
 					{
@@ -146,7 +146,7 @@ describe("ReviewsManager.spec.ts", () => {
 			});
 
 			it("works", async () => {
-				const manager = new ReviewsManager({ onDidRequestReset: function () {} } as any);
+				const manager = new ReviewsManager({ onDidRequestReset: function () {} } as any, {} as any);
 
 				const response = await manager.checkPullRequestPreconditions(
 					{ headRefName: "develop", repoId: "123" } as any,

--- a/shared/agent/test/unit/providers/newrelic/newrelic.spec.ts
+++ b/shared/agent/test/unit/providers/newrelic/newrelic.spec.ts
@@ -122,7 +122,7 @@ describe("NewRelicProvider", () => {
 			name: "Thing for Android - Production",
 		};
 
-		const results = new NewRelicProvider({} as any, {} as any).tryFormatStack(
+		const results = new NewRelicProvider({} as any, {} as any, {} as any).tryFormatStack(
 			data.entityType,
 			data.exception
 		);
@@ -147,7 +147,7 @@ describe("NewRelicProvider", () => {
 
 	describe("addMethodName", () => {
 		it("parses python function name", async () => {
-			const provider = new NewRelicProviderStub({} as any, {} as any);
+			const provider = new NewRelicProviderStub({} as any, {} as any, {} as any);
 			const results = provider.addMethodName(
 				{
 					"Function/routes.app:hello_world": [
@@ -221,7 +221,7 @@ describe("NewRelicProvider", () => {
 		});
 
 		it("maps python code.namespace", async () => {
-			const provider = new NewRelicProviderStub({} as any, {} as any);
+			const provider = new NewRelicProviderStub({} as any, {} as any, {} as any);
 			const results = provider.addMethodName(
 				{
 					"Carrot/foo_bar.system.tasks.bill_credit_payment_item": [
@@ -266,7 +266,7 @@ describe("NewRelicProvider", () => {
 		});
 
 		it("handles ruby controller", () => {
-			const newrelic = new NewRelicProvider({} as any, {} as any);
+			const newrelic = new NewRelicProvider({} as any, {} as any, {} as any);
 			const groupedByTransactionName = {
 				"Controller/agents/show": [
 					{
@@ -380,7 +380,7 @@ describe("NewRelicProvider", () => {
 		});
 
 		it("handles ruby ActiveJob", () => {
-			const newrelic = new NewRelicProvider({} as any, {} as any);
+			const newrelic = new NewRelicProvider({} as any, {} as any, {} as any);
 			const groupedByTransactionName = {
 				"MessageBroker/ActiveJob::Async/Queue/Produce/Named/default": [
 					{
@@ -441,7 +441,7 @@ describe("NewRelicProvider", () => {
 		});
 
 		it("parses ruby modules:class:functions syntax", () => {
-			const newrelic = new NewRelicProvider({} as any, {} as any);
+			const newrelic = new NewRelicProvider({} as any, {} as any, {} as any);
 			const groupedByTransactionName: Dictionary<Span[]> = {
 				"Nested/OtherTransaction/Background/Custom::Helpers/custom_class_method": [
 					{
@@ -631,7 +631,7 @@ describe("NewRelicProvider", () => {
 		});
 
 		it("parses ruby class/function syntax", () => {
-			const newrelic = new NewRelicProvider({} as any, {} as any);
+			const newrelic = new NewRelicProvider({} as any, {} as any, {} as any);
 			const groupedByTransactionName: Dictionary<Span[]> = {
 				"Nested/OtherTransaction/Background/WhichIsWhich/samename": [
 					{
@@ -747,7 +747,7 @@ describe("NewRelicProvider", () => {
 				newRelicApiUrl: "",
 			},
 		} as any;
-		const provider = new NewRelicProviderStub({} as any, {} as any);
+		const provider = new NewRelicProviderStub({} as any, {} as any, {} as any);
 		provider.sessionServiceContainer = serviceLocatorStub;
 
 		const results = await provider.getFileLevelTelemetry({
@@ -802,7 +802,7 @@ describe("NewRelicProvider", () => {
 				newRelicApiUrl: "",
 			},
 		} as any;
-		const provider = new NewRelicProviderStub2({} as any, {} as any);
+		const provider = new NewRelicProviderStub2({} as any, {} as any, {} as any);
 		provider.sessionServiceContainer = serviceLocatorStub;
 
 		const results = await provider.getFileLevelTelemetry({
@@ -826,7 +826,7 @@ describe("NewRelicProvider", () => {
 	});
 
 	it("generateEntityQueryStatements", async () => {
-		const provider = new NewRelicProvider({} as any, {} as any);
+		const provider = new NewRelicProvider({} as any, {} as any, {} as any);
 		expect(provider.generateEntityQueryStatement("foo-bar_baz")).toEqual(
 			"name LIKE '%foo-bar_baz%'"
 		);
@@ -872,7 +872,7 @@ describe("NewRelicProvider", () => {
 			},
 		} as any;
 
-		const provider = new NewRelicProviderStub2({} as any, {} as any);
+		const provider = new NewRelicProviderStub2({} as any, {} as any, {} as any);
 		provider.sessionServiceContainer = serviceLocatorStub;
 
 		const results = await provider.getObservabilityRepos({});
@@ -885,7 +885,7 @@ describe("NewRelicProvider", () => {
 	});
 
 	it("getsSpansForFlask", async () => {
-		const provider = new NewRelicProviderStub2({} as any, {} as any);
+		const provider = new NewRelicProviderStub2({} as any, {} as any, {} as any);
 
 		const results = await provider.addMethodName(
 			{
@@ -915,7 +915,7 @@ describe("NewRelicProvider", () => {
 	});
 
 	it("throws GraphqlNrqlTimeoutError for matching response", () => {
-		const provider = new NewRelicProvider({} as any, {} as any);
+		const provider = new NewRelicProvider({} as any, {} as any, {} as any);
 		const responseBody: GraphqlNrqlErrorResponse = {
 			errors: [
 				{
@@ -943,7 +943,7 @@ describe("NewRelicProvider", () => {
 	});
 
 	it("throws GraphqlNrqlError for other gql errors", () => {
-		const provider = new NewRelicProvider({} as any, {} as any);
+		const provider = new NewRelicProvider({} as any, {} as any, {} as any);
 		const responseBody: GraphqlNrqlErrorResponse = {
 			errors: [
 				{

--- a/shared/agent/test/unit/providers/newrelic/newrelic2.spec.ts
+++ b/shared/agent/test/unit/providers/newrelic/newrelic2.spec.ts
@@ -6,7 +6,7 @@ import { NewRelicProvider } from "../../../../src/providers/newrelic";
 
 describe("newRelicProvider", () => {
 	it("getBestEntity-basedOnTag", () => {
-		const newrelic = new NewRelicProvider({} as any, {} as any);
+		const newrelic = new NewRelicProvider({} as any, {} as any, {} as any);
 		const asdf = newrelic.getGoldenSignalsEntity({} as any, {
 			repoId: "123",
 			repoName: "repo1",
@@ -26,7 +26,7 @@ describe("newRelicProvider", () => {
 	});
 
 	it("getBestEntity-basedOnName", () => {
-		const newrelic = new NewRelicProvider({} as any, {} as any);
+		const newrelic = new NewRelicProvider({} as any, {} as any, {} as any);
 		const asdf = newrelic.getGoldenSignalsEntity({} as any, {
 			repoId: "123",
 			repoName: "repo1",
@@ -53,7 +53,7 @@ describe("newRelicProvider", () => {
 	});
 
 	it("getBestEntity-default", () => {
-		const newrelic = new NewRelicProvider({} as any, {} as any);
+		const newrelic = new NewRelicProvider({} as any, {} as any, {} as any);
 		const asdf = newrelic.getGoldenSignalsEntity({} as any, {
 			repoId: "123",
 			repoName: "repo1",
@@ -86,7 +86,7 @@ describe("newRelicProvider", () => {
 		expect(asdf.entityGuid).toEqual("012");
 	});
 	it("getBestEntity-basedOnpreferences", () => {
-		const newrelic = new NewRelicProvider({} as any, {} as any);
+		const newrelic = new NewRelicProvider({} as any, {} as any, {} as any);
 		const asdf = newrelic.getGoldenSignalsEntity(
 			{
 				preferences: {


### PR DESCRIPTION
Start exploring dependency injection. Most DI frameworks are off the table since esbuild doesn't support emitDecoratorMetadata which is required for all the DI frameworks that use annotations (https://github.com/evanw/esbuild/issues/257)

Explored breaking up codestreamApi by separating the teams related apis to a separate class and factoring out the http parts to apiClient. 
