### PR TITLE
NR-90464 Codestream does not load on Rider IDE …

### DIFF
--- a/jb/build.gradle
+++ b/jb/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group "com.codestream"
-version "14.15.0"
+version "14.15.1"
 
 sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
@@ -198,6 +198,7 @@ copyDebugAgent.dependsOn buildDebugDeps
 
 task buildDebugDependencies {}
 buildDebugDependencies.dependsOn buildDebugDeps, copyDebugAgent, copyProtobuf
+
 
 
 

--- a/jb/docs/change-notes.html
+++ b/jb/docs/change-notes.html
@@ -1,3 +1,8 @@
+<h4 id="14_15_1">14.15.1</h4>
+<h5>Fixed</h5>
+<ul>
+	<li>Fixes an issue with CodeStream for Rider</li>
+</ul>
 <h4 id="14_15_0">14.15.0</h4>
 <h5>Fixed</h5>
 <ul>

--- a/jb/src/main/resources/META-INF/plugin.xml
+++ b/jb/src/main/resources/META-INF/plugin.xml
@@ -190,5 +190,6 @@
         </action>
     </actions>
 
+    <depends>Git4Idea</depends>
     <idea-version since-build="221.5591.52"/>
 </idea-plugin>

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "codestream",
 	"displayName": "New Relic CodeStream: GitHub, GitLab, Bitbucket PRs and Code Review",
 	"description": "GitHub pull requests, GitLab merge requests, and code reviews in your IDE. Eliminate context-switching. Integrates with New Relic observability, Bitbucket, Slack, MS Teams, Jira, Trello and more.",
-	"version": "14.15.0",
+	"version": "14.15.1",
 	"author": "CodeStream",
 	"publisher": "CodeStream",
 	"license": "UNLICENSED",


### PR DESCRIPTION


**This PR Addresses:**  
[NR-85041 C# CLM not working in IDE Rider](https://issues.newrelic.com/browse/NR-85041)  


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>