### PR TITLE
mutli repo fix and better logging

### DIFF
--- a/shared/agent/src/providers/newrelic.ts
+++ b/shared/agent/src/providers/newrelic.ts
@@ -4,6 +4,7 @@ import { sep } from "path";
 
 import {
 	BuiltFromResult,
+	RelatedRepoData,
 	CrashOrException,
 	Entity,
 	EntityAccount,
@@ -3519,18 +3520,41 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 
 	private async findMappedRemoteByEntity(
 		entityGuid: string
-	): Promise<BuiltFromResult[] | undefined> {
+	): Promise<RelatedRepoData[] | undefined> {
 		if (!entityGuid) return undefined;
 
 		const relatedEntityResponse = await this.findRelatedEntityByRepositoryGuid(entityGuid);
 		if (relatedEntityResponse) {
-			const remotes = this.findRelatedReposFromServiceEntity(
+			let relatedRepoData = this.findRelatedReposFromServiceEntity(
 				relatedEntityResponse.actor.entity.relatedEntities.results
 			);
-			if (!_isEmpty(remotes)) {
-				return remotes;
+
+			let relatedRepoDataWithRemotes;
+
+			if (relatedRepoData) {
+				relatedRepoDataWithRemotes = await Promise.all(
+					relatedRepoData.map(
+						async (
+							_
+						): Promise<{ url?: string; remotes?: string[]; error?: any; name?: string }> => {
+							let remotes = await this._memoizedBuildRepoRemoteVariants([_.url]);
+							if (!_isEmpty(remotes)) {
+								return { ..._, remotes };
+							}
+							return { ..._ };
+						}
+					)
+				);
+			}
+			Logger.log("findMappedRemoteByEntity", { entityGuid, relatedRepoDataWithRemotes });
+			if (!_isEmpty(relatedRepoDataWithRemotes)) {
+				return relatedRepoDataWithRemotes;
 			}
 		}
+		Logger.warn(
+			"findMappedRemoteByEntity: no response data from findRelatedEntityByRepositoryGuid",
+			entityGuid
+		);
 		return undefined;
 	}
 

--- a/shared/agent/src/providers/newrelic.ts
+++ b/shared/agent/src/providers/newrelic.ts
@@ -4,7 +4,7 @@ import { sep } from "path";
 
 import {
 	BuiltFromResult,
-	RelatedRepoData,
+	RelatedRepoWithRemotes,
 	CrashOrException,
 	Entity,
 	EntityAccount,
@@ -3520,7 +3520,7 @@ export class NewRelicProvider extends ThirdPartyIssueProviderBase<CSNewRelicProv
 
 	private async findMappedRemoteByEntity(
 		entityGuid: string
-	): Promise<RelatedRepoData[] | undefined> {
+	): Promise<RelatedRepoWithRemotes[] | undefined> {
 		if (!entityGuid) return undefined;
 
 		const relatedEntityResponse = await this.findRelatedEntityByRepositoryGuid(entityGuid);

--- a/shared/ui/Stream/CodeError/RepositoryAssociator.tsx
+++ b/shared/ui/Stream/CodeError/RepositoryAssociator.tsx
@@ -112,7 +112,6 @@ export function RepositoryAssociator(props: {
 				if (!_isEmpty(derivedState.relatedRepos)) {
 					filteredResults = results.filter(_ => {
 						return derivedState.relatedRepos?.some(repo => {
-							// return repo.url === _.remote;
 							return repo.remotes.includes(_.remote);
 						});
 					});
@@ -123,6 +122,7 @@ export function RepositoryAssociator(props: {
 				}
 				if (filteredResults.length === 1) {
 					setSelected(filteredResults[0]);
+					//no dropdown required, just go to error and auto select the single result
 					handleOnSubmitWithOneItemInDropdown(filteredResults[0]);
 				} else {
 					setOpenRepositories(filteredResults);

--- a/shared/ui/Stream/CodeError/RepositoryAssociator.tsx
+++ b/shared/ui/Stream/CodeError/RepositoryAssociator.tsx
@@ -18,6 +18,7 @@ import Dismissable from "../Dismissable";
 import { DropdownButton } from "../DropdownButton";
 import { DelayedRender } from "../../Container/DelayedRender";
 import { LoadingMessage } from "../../src/components/LoadingMessage";
+import { isEmpty as _isEmpty } from "lodash-es";
 
 const Ellipsize = styled.div`
 	button {
@@ -107,11 +108,19 @@ export function RepositoryAssociator(props: {
 				}
 				//take repos in users IDE, and filter them with a list of
 				//related repos to service entity the error originates from
-				const filteredResults = results.filter(_ => {
-					return derivedState.relatedRepos?.some(repo => {
-						return repo.name === _.name;
+				let filteredResults;
+				if (!_isEmpty(derivedState.relatedRepos)) {
+					filteredResults = results.filter(_ => {
+						return derivedState.relatedRepos?.some(repo => {
+							// return repo.url === _.remote;
+							return repo.remotes.includes(_.remote);
+						});
 					});
-				});
+				} else {
+					// no related repo data for whatever reason, just show repos
+					// instead of "repo not found" error
+					filteredResults = results;
+				}
 				if (filteredResults.length === 1) {
 					setSelected(filteredResults[0]);
 					handleOnSubmitWithOneItemInDropdown(filteredResults[0]);

--- a/shared/ui/index.tsx
+++ b/shared/ui/index.tsx
@@ -639,7 +639,7 @@ function listenForEvents(store) {
 								...definedQuery.query,
 								// cache the sessionStart here in case the IDE is restarted
 								sessionStart: state.context.sessionStart,
-								relatedRepos: response.relatedRepos,
+								relatedRepos: response?.relatedRepos,
 								pendingEntityId: definedQuery.query.entityId,
 								pendingErrorGroupGuid: definedQuery.query.errorGroupGuid,
 								pendingRequiresConnection: !isConnected(state, {

--- a/shared/ui/index.tsx
+++ b/shared/ui/index.tsx
@@ -23,6 +23,8 @@ import {
 	PollForMaintenanceModeRequestType,
 	VersionCompatibility,
 	VerifyConnectivityResponse,
+	GetObservabilityErrorGroupMetadataRequestType,
+	GetObservabilityErrorGroupMetadataResponse,
 } from "@codestream/protocols/agent";
 import { CodemarkType, CSApiCapabilities, CSCodeError, CSMe } from "@codestream/protocols/api";
 import React from "react";
@@ -117,7 +119,6 @@ import { confirmPopup } from "./Stream/Confirm";
 import translations from "./translations/en";
 import { parseProtocol } from "./utilities/urls";
 import { HostApi } from "./webview-api";
-
 // import translationsEs from "./translations/es";
 
 export function setupCommunication(host: { postMessage: (message: any) => void }) {
@@ -628,11 +629,17 @@ function listenForEvents(store) {
 						}
 						const state = store.getState();
 
+						const response = (await HostApi.instance.send(
+							GetObservabilityErrorGroupMetadataRequestType,
+							{ errorGroupGuid: definedQuery.query.errorGroupGuid }
+						)) as GetObservabilityErrorGroupMetadataResponse;
+
 						store.dispatch(
 							openErrorGroup(definedQuery.query.errorGroupGuid, definedQuery.query.occurrenceId, {
 								...definedQuery.query,
 								// cache the sessionStart here in case the IDE is restarted
 								sessionStart: state.context.sessionStart,
+								relatedRepos: response.relatedRepos,
 								pendingEntityId: definedQuery.query.entityId,
 								pendingErrorGroupGuid: definedQuery.query.errorGroupGuid,
 								pendingRequiresConnection: !isConnected(state, {

--- a/shared/util/src/protocol/agent/agent.protocol.providers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.providers.ts
@@ -1718,6 +1718,15 @@ export interface BuiltFromResult {
 	};
 }
 
+export interface RelatedRepoData {
+	name?: string;
+	url?: string;
+	remotes?: any[];
+	error?: {
+		message?: string;
+	};
+}
+
 export interface RelatedRepository {
 	length: number;
 	url?: string;

--- a/shared/util/src/protocol/agent/agent.protocol.providers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.providers.ts
@@ -1721,7 +1721,7 @@ export interface BuiltFromResult {
 export interface RelatedRepoWithRemotes {
 	name?: string;
 	url?: string;
-	remotes?: any[];
+	remotes?: string[];
 	error?: {
 		message?: string;
 	};

--- a/shared/util/src/protocol/agent/agent.protocol.providers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.providers.ts
@@ -1718,7 +1718,7 @@ export interface BuiltFromResult {
 	};
 }
 
-export interface RelatedRepoData {
+export interface RelatedRepoWithRemotes {
 	name?: string;
 	url?: string;
 	remotes?: any[];


### PR DESCRIPTION
- Logging so we know what was fetched when getting related repos to a service entity
- Compare remote variants to scm repo call to find a possible match to use in repository associator dropdown list.  Before we were doing a name comparison, which I am guessing was not sufficient.  Also fetch relatedRepos prior to open-in-ide so we have remotes to compare against.  The url doesn't have them available.