### PR TITLE
non-pasted code login is unreliable

### DIFF
--- a/shared/ui/Authentication/TextInput.tsx
+++ b/shared/ui/Authentication/TextInput.tsx
@@ -13,6 +13,7 @@ interface TextInputProps extends Pick<React.HTMLAttributes<HTMLInputElement>, "o
 	nativeProps?: AnyObject;
 	autoFocus?: boolean;
 	hasError?: boolean;
+	disabled?: boolean;
 }
 
 export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(function (
@@ -45,6 +46,7 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(func
 
 	return (
 		<input
+			disabled={props?.disabled}
 			ref={ref}
 			className={"input-text" + (props.hasError ? " has-error" : "")}
 			type={props.type}


### PR DESCRIPTION
The main problem was we were not disabling text input when submitting authentication digits AND not showing loading spinner/disabling submit button.  Since we attempt to submit when we have 6 digits in text input AND the user can still edit the text field during submit without knowing an API authentication is happening, this lead to a bunch of wonky behavior.

Also, I moved onChange and onPaste into their own handle functions just for my own sanity of stepping through the code, but the logic (minus disable + loading) is the same.


[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/lb0K2JVrR2C-dTA-W8wxLg?src=GitHub) by bcanzanella on Mar 28, 2023

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>