### PR TITLE
NR-115329 & NR-115352 & NR-115332 Bitbucket disabled buttons

### DIFF
--- a/shared/ui/Stream/PullRequests/Bitbucket/PullRequest.tsx
+++ b/shared/ui/Stream/PullRequests/Bitbucket/PullRequest.tsx
@@ -492,7 +492,7 @@ export const PullRequest = () => {
 	};
 
 	const isMergeable = () => {
-		if (pr?.viewerCanUpdate && pr?.state !== "MERGED") {
+		if (pr?.viewerCanUpdate && pr?.state === "OPEN") {
 			return true;
 		} else {
 			return false;
@@ -685,11 +685,16 @@ export const PullRequest = () => {
 													</>
 												}
 												trigger={["hover"]}
+												className="clickable"
 												delay={1}
 												placement="bottom"
-												onClick={e => {
-													setIsOpen(true);
-												}}
+												{...(isMergeable()
+													? {
+															onClick: e => {
+																setIsOpen(true);
+															},
+													  }
+													: {})}
 											/>
 										</span>
 									</>

--- a/shared/ui/Stream/PullRequests/Bitbucket/PullRequestReviewButton.tsx
+++ b/shared/ui/Stream/PullRequests/Bitbucket/PullRequestReviewButton.tsx
@@ -274,9 +274,16 @@ export const PullRequestReviewButton = (props: Props) => {
 						}
 						trigger={["hover"]}
 						delay={1}
-						onClick={checkout}
+						{...(!cantCheckoutReason
+							? {
+									onClick: () => {
+										checkout();
+									},
+							  }
+							: {})}
 						placement="bottom"
 						name="git-branch"
+						className="clickable"
 					/>
 				</span>
 			)}
@@ -314,10 +321,15 @@ export const PullRequestReviewButton = (props: Props) => {
 					} //text that shows to user when they hover, can be either Approve of Unapprove
 					trigger={["hover"]}
 					delay={1}
-					onClick={e => {
-						submitReview(approvalStatus.requestedState);
-					}}
+					{...(!props.pullRequest.viewerDidAuthor
+						? {
+								onClick: e => {
+									submitReview(approvalStatus.requestedState);
+								},
+						  }
+						: {})}
 					placement="bottom"
+					className="clickable"
 				/>
 			</span>
 			<span className={props.pullRequest.viewerDidAuthor ? "disabled" : ""}>
@@ -336,9 +348,14 @@ export const PullRequestReviewButton = (props: Props) => {
 					trigger={["hover"]}
 					delay={1}
 					placement="bottom"
-					onClick={e => {
-						submitReview(requestStatus.requestedState);
-					}}
+					{...(!props.pullRequest.viewerDidAuthor
+						? {
+								onClick: e => {
+									submitReview(requestStatus.requestedState);
+								},
+						  }
+						: {})}
+					className="clickable"
 				/>
 			</span>
 		</>


### PR DESCRIPTION
Bitbucket - If the user authored the PR they can't click the approve unapprove request changes changes requested buttons, and if the PR is already merged or declined user can't click on the merge button