### PR TITLE
fixes issue related to unsupported clients

### DIFF
--- a/vscode/src/agent/agentConnection.ts
+++ b/vscode/src/agent/agentConnection.ts
@@ -452,8 +452,12 @@ export class CodeStreamAgentConnection implements Disposable {
 		return options;
 	}
 
-	async logout(newServerUrl?: string) {
+	async logout(reason: SessionSignedOutReason, newServerUrl?: string) {
 		await this.stop();
+		if (reason === SessionSignedOutReason.UnsupportedVersion) {
+			// don't restart the extension if the version is unsupported
+			return;
+		}
 		await Container.agent.start(newServerUrl);
 	}
 
@@ -1077,7 +1081,11 @@ export class CodeStreamAgentConnection implements Disposable {
 		if (e.reason === LogoutReason.Token) {
 			void Container.session.logout();
 		} else {
-			void Container.session.goOffline(e.reason !== LogoutReason.UnsupportedVersion);
+			if (e.reason === LogoutReason.UnsupportedVersion) {
+				void Container.session.logout(SessionSignedOutReason.UnsupportedVersion);
+			} else {
+				void Container.session.goOffline(true);
+			}
 		}
 	}
 

--- a/vscode/src/api/session.ts
+++ b/vscode/src/api/session.ts
@@ -93,7 +93,8 @@ export enum SessionSignedOutReason {
 	UserSignedOutFromWebview = "userSignedOutFromWebview",
 	UserSignedOutFromExtension = "userSignedOutFromExtension",
 	UserWentOffline = "userWentOffline",
-	MaintenanceMode = "maintenanceMode"
+	MaintenanceMode = "maintenanceMode",
+	UnsupportedVersion = "unsupportedVersion"
 }
 
 export enum SessionStatus {
@@ -616,7 +617,7 @@ export class CodeStreamSession implements Disposable {
 			}
 
 			if (Container.agent !== undefined) {
-				void (await Container.agent.logout(newServerUrl));
+				void (await Container.agent.logout(reason, newServerUrl));
 			}
 
 			if (this._disposableAuthenticated !== undefined) {

--- a/vscode/src/controllers/webviewController.ts
+++ b/vscode/src/controllers/webviewController.ts
@@ -152,6 +152,7 @@ export class WebviewController implements Disposable {
 	private _apiVersionCompatibility: ApiVersionCompatibility | undefined;
 	private _missingCapabilities: CSApiCapabilities | undefined;
 	private _providerSessionIds: { [key: string]: string } = {};
+	private _hasShownAfterOnVersionChanged: boolean = false;
 
 	private readonly _notifyActiveEditorChangedDebounced: (e: TextEditor | undefined) => void;
 
@@ -638,8 +639,9 @@ export class WebviewController implements Disposable {
 			this._versionCompatibility = e.compatibility;
 		}
 
-		if (!this.visible) {
+		if (!this.visible && !this._hasShownAfterOnVersionChanged) {
 			await this.show();
+			this._hasShownAfterOnVersionChanged = true;
 		}
 		this._webview!.notify(DidChangeVersionCompatibilityNotificationType, e);
 	}


### PR DESCRIPTION
related to https://github.com/TeamCodeStream/codestream/commit/d59ac75eab5b8356fdfc43dadb035cb60db8271a  though this will only fix new clients if it happens again

This change will prevent VSC from restarting the agent if it's found that the client is out of date (preventing an infinite loop)