### PR TITLE
skeleton loaders and rounded buttons

### DIFF
--- a/shared/ui/Stream/CrossPostIssueControls/IssuesPane.tsx
+++ b/shared/ui/Stream/CrossPostIssueControls/IssuesPane.tsx
@@ -1210,8 +1210,9 @@ export const IssueList = React.memo((props: React.PropsWithChildren<IssueListPro
 						!props.loadingMessage &&
 						(props.activeProviders.length > 0 || derivedState.skipConnect) &&
 						cards.length == 0 &&
-						derivedState.initialLoadComplete &&
-						!firstLoad && <FilterMissing>There are no open issues assigned to you.</FilterMissing>
+						derivedState.initialLoadComplete && (
+							<FilterMissing>There are no open issues assigned to you.</FilterMissing>
+						)
 					)}
 					{(fetchCardErrors || []).map(fetchCardError => (
 						<IssueError>

--- a/shared/ui/Stream/CrossPostIssueControls/IssuesPane.tsx
+++ b/shared/ui/Stream/CrossPostIssueControls/IssuesPane.tsx
@@ -7,7 +7,6 @@ import {
 import { CSMe, CSTeamSettings } from "@codestream/protocols/api";
 import React, { useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
-
 import { OpenUrlRequestType } from "@codestream/protocols/webview";
 import { WebviewPanels } from "@codestream/webview/ipc/webview.protocol.common";
 import { Button } from "@codestream/webview/src/components/Button";
@@ -49,7 +48,7 @@ import { SmartFormattedList } from "../SmartFormattedList";
 import { EMPTY_STATUS, StartWork } from "../StartWork";
 import Tooltip from "../Tooltip";
 import { ProviderDisplay, PROVIDER_MAPPINGS } from "./types";
-
+import { IssuesLoading } from "@codestream/webview/Stream/IssuesLoading";
 interface FetchCardError {
 	provider: string;
 	error: string;
@@ -1200,7 +1199,7 @@ export const IssueList = React.memo((props: React.PropsWithChildren<IssueListPro
 							</IssueMissing>
 						</>
 					)}
-					{firstLoad && <LoadingMessage align="left">Loading...</LoadingMessage>}
+					{firstLoad && <IssuesLoading />}
 					{cards.length == 0 &&
 					selectedLabel !== "issues assigned to you" &&
 					!props.loadingMessage &&
@@ -1211,9 +1210,8 @@ export const IssueList = React.memo((props: React.PropsWithChildren<IssueListPro
 						!props.loadingMessage &&
 						(props.activeProviders.length > 0 || derivedState.skipConnect) &&
 						cards.length == 0 &&
-						derivedState.initialLoadComplete && (
-							<FilterMissing>There are no open issues assigned to you.</FilterMissing>
-						)
+						derivedState.initialLoadComplete &&
+						!firstLoad && <FilterMissing>There are no open issues assigned to you.</FilterMissing>
 					)}
 					{(fetchCardErrors || []).map(fetchCardError => (
 						<IssueError>

--- a/shared/ui/Stream/IssuesLoading.tsx
+++ b/shared/ui/Stream/IssuesLoading.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { SkeletonLoader, SkeletonFlexContainer } from "@codestream/webview/Stream/SkeletonLoader";
+
+export const IssuesLoading = () => {
+	return (
+		<>
+			<SkeletonFlexContainer>
+				<SkeletonLoader style={{ width: "75%", margin: "0px 10px 3px 20px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "0px 10px 3px 0px" }} />
+			</SkeletonFlexContainer>
+			<SkeletonFlexContainer>
+				<SkeletonLoader style={{ width: "65%", margin: "3px 10px 3px 20px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</SkeletonFlexContainer>
+			<SkeletonFlexContainer>
+				<SkeletonLoader style={{ width: "65%", margin: "3px 10px 3px 20px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</SkeletonFlexContainer>
+			<SkeletonFlexContainer>
+				<SkeletonLoader style={{ width: "55%", margin: "3px 10px 3px 20px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</SkeletonFlexContainer>
+		</>
+	);
+};

--- a/shared/ui/Stream/Observability.tsx
+++ b/shared/ui/Stream/Observability.tsx
@@ -262,7 +262,7 @@ export const Observability = React.memo((props: Props) => {
 			newRelicIsConnected,
 			activeO11y,
 			observabilityRepoEntities: preferences.observabilityRepoEntities || EMPTY_ARRAY,
-			showGoldenSignalsInEditor: state.configs.showGoldenSignalsInEditor,
+			showGoldenSignalsInEditor: state?.configs.showGoldenSignalsInEditor,
 			isVS: state.ide.name === "VS",
 			hideCodeLevelMetricsInstructions: state.preferences.hideCodeLevelMetricsInstructions,
 			currentMethodLevelTelemetry: (state.context.currentMethodLevelTelemetry ||
@@ -1186,7 +1186,7 @@ export const Observability = React.memo((props: Props) => {
 																		</PaneNodeName>
 																		{!collapsed && (
 																			<>
-																				{ea.entityGuid === loadingPane ? (
+																				{ea.entityGuid !== loadingPane ? (
 																					<>
 																						<ObservabilityLoadingServiceEntity />
 																					</>

--- a/shared/ui/Stream/Observability.tsx
+++ b/shared/ui/Stream/Observability.tsx
@@ -28,6 +28,10 @@ import styled from "styled-components";
 
 import { ObservabilityRelatedWrapper } from "@codestream/webview/Stream/ObservabilityRelatedWrapper";
 import { ObservabilityPreview } from "@codestream/webview/Stream/ObservabilityPreview";
+import {
+	ObservabilityLoadingServiceEntities,
+	ObservabilityLoadingServiceEntity,
+} from "@codestream/webview/Stream/ObservabilityLoading";
 import { CurrentMethodLevelTelemetry } from "@codestream/webview/store/context/types";
 import { setRefreshAnomalies } from "../store/context/actions";
 
@@ -1028,11 +1032,7 @@ export const Observability = React.memo((props: Props) => {
 						<>
 							<PaneNode>
 								{loadingEntities ? (
-									<ErrorRow
-										isLoading={true}
-										title="Loading..."
-										customPadding={"0 10px 0 20px"}
-									></ErrorRow>
+									<ObservabilityLoadingServiceEntities />
 								) : (
 									<>
 										{genericError && (
@@ -1188,10 +1188,7 @@ export const Observability = React.memo((props: Props) => {
 																			<>
 																				{ea.entityGuid === loadingPane ? (
 																					<>
-																						<ErrorRow
-																							isLoading={true}
-																							title="Loading..."
-																						></ErrorRow>
+																						<ObservabilityLoadingServiceEntity />
 																					</>
 																				) : (
 																					<>

--- a/shared/ui/Stream/Observability.tsx
+++ b/shared/ui/Stream/Observability.tsx
@@ -1186,7 +1186,7 @@ export const Observability = React.memo((props: Props) => {
 																		</PaneNodeName>
 																		{!collapsed && (
 																			<>
-																				{ea.entityGuid !== loadingPane ? (
+																				{ea.entityGuid === loadingPane ? (
 																					<>
 																						<ObservabilityLoadingServiceEntity />
 																					</>

--- a/shared/ui/Stream/ObservabilityGoldenMetricDropdown.tsx
+++ b/shared/ui/Stream/ObservabilityGoldenMetricDropdown.tsx
@@ -1,11 +1,11 @@
 import { EntityGoldenMetrics, GetAlertViolationsResponse } from "@codestream/protocols/agent";
 import { isEmpty as _isEmpty } from "lodash-es";
 import React, { useState } from "react";
-
 import { Row } from "./CrossPostIssueControls/IssuesPane";
 import Icon from "./Icon";
 import { ObservabilityAlertViolations } from "./ObservabilityAlertViolations";
 import Tooltip from "./Tooltip";
+import { ObservabilityLoadingGoldenMetrics } from "@codestream/webview/Stream/ObservabilityLoading";
 
 interface Props {
 	entityGoldenMetrics: EntityGoldenMetrics | undefined;
@@ -100,23 +100,7 @@ export const ObservabilityGoldenMetricDropdown = React.memo((props: Props) => {
 				</>
 			)}
 
-			{expanded && loadingGoldenMetrics && (
-				<Row
-					style={{
-						padding: noDropdown ? "0 10px 0 60px" : "0 10px 0 42px",
-					}}
-					className={"pr-row"}
-				>
-					<Icon
-						style={{
-							marginRight: "5px",
-						}}
-						className="spin"
-						name="sync"
-					/>{" "}
-					Loading...
-				</Row>
-			)}
+			{expanded && loadingGoldenMetrics && <ObservabilityLoadingGoldenMetrics />}
 			{(noDropdown || expanded) &&
 				!loadingGoldenMetrics &&
 				!_isEmpty(entityGoldenMetrics?.metrics) && (

--- a/shared/ui/Stream/ObservabilityGoldenMetricDropdown.tsx
+++ b/shared/ui/Stream/ObservabilityGoldenMetricDropdown.tsx
@@ -23,7 +23,6 @@ export const ObservabilityGoldenMetricDropdown = React.memo((props: Props) => {
 	const errorTitle: string | undefined =
 		errors.length === 0 ? undefined : `Last request failed:\n${errors.join("\n")}`;
 
-	console.warn("test");
 	const goldenMetricOutput = () => {
 		return (
 			<>

--- a/shared/ui/Stream/ObservabilityGoldenMetricDropdown.tsx
+++ b/shared/ui/Stream/ObservabilityGoldenMetricDropdown.tsx
@@ -23,6 +23,7 @@ export const ObservabilityGoldenMetricDropdown = React.memo((props: Props) => {
 	const errorTitle: string | undefined =
 		errors.length === 0 ? undefined : `Last request failed:\n${errors.join("\n")}`;
 
+	console.warn("test");
 	const goldenMetricOutput = () => {
 		return (
 			<>

--- a/shared/ui/Stream/ObservabilityLoading.tsx
+++ b/shared/ui/Stream/ObservabilityLoading.tsx
@@ -4,7 +4,7 @@ import { SkeletonLoader } from "@codestream/webview/Stream/SkeletonLoader";
 export const ObservabilityLoadingServiceEntity = () => {
 	return (
 		<>
-			<SkeletonLoader style={{ width: "30%", margin: "3px 10px 3px 40px" }} />
+			{/* <SkeletonLoader style={{ width: "30%", margin: "3px 10px 3px 40px" }} />
 			<div style={{ display: "flex", justifyContent: "space-between" }}>
 				<SkeletonLoader style={{ width: "20%", margin: "3px 10px 3px 50px" }} />
 				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
@@ -33,7 +33,38 @@ export const ObservabilityLoadingServiceEntity = () => {
 				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
 			</div>
 			<SkeletonLoader style={{ width: "25%", margin: "3px 10px 5px 40px" }} />
-			<SkeletonLoader style={{ width: "30%", margin: "3px 10px 3px 40px" }} />
+			<SkeletonLoader style={{ width: "30%", margin: "3px 10px 3px 40px" }} /> */}
+
+			<SkeletonLoader style={{ width: "30%", marginLeft: "40px" }} />
+			<div style={{ display: "flex", justifyContent: "space-between" }}>
+				<SkeletonLoader style={{ width: "20%", margin: "3px 10px 3px 50px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</div>
+			<div style={{ display: "flex", justifyContent: "space-between" }}>
+				<SkeletonLoader style={{ width: "25%", margin: "3px 10px 3px 50px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</div>
+			<div style={{ display: "flex", justifyContent: "space-between" }}>
+				<SkeletonLoader style={{ width: "20%", margin: "3px 10px 3px 50px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</div>
+			<SkeletonLoader style={{ width: "50%", marginLeft: "40px" }} />
+			<SkeletonLoader style={{ width: "20%", marginLeft: "40px" }} />
+			<SkeletonLoader style={{ width: "30%", marginLeft: "40px" }} />
+			<div style={{ display: "flex", justifyContent: "space-between" }}>
+				<SkeletonLoader style={{ width: "55%", margin: "3px 10px 3px 50px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</div>
+			<div style={{ display: "flex", justifyContent: "space-between" }}>
+				<SkeletonLoader style={{ width: "70%", margin: "3px 10px 3px 50px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</div>
+			<div style={{ display: "flex", justifyContent: "space-between" }}>
+				<SkeletonLoader style={{ width: "40%", margin: "3px 10px 3px 50px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</div>
+			<SkeletonLoader style={{ width: "25%", marginLeft: "40px" }} />
+			<SkeletonLoader style={{ width: "30%", marginLeft: "40px" }} />
 		</>
 	);
 };

--- a/shared/ui/Stream/ObservabilityLoading.tsx
+++ b/shared/ui/Stream/ObservabilityLoading.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { SkeletonLoader } from "@codestream/webview/Stream/SkeletonLoader";
+
+export const ObservabilityLoadingServiceEntity = () => {
+	return (
+		<>
+			<SkeletonLoader style={{ width: "30%", margin: "3px 10px 3px 40px" }} />
+			<div style={{ display: "flex", justifyContent: "space-between" }}>
+				<SkeletonLoader style={{ width: "20%", margin: "3px 10px 3px 50px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</div>
+			<div style={{ display: "flex", justifyContent: "space-between" }}>
+				<SkeletonLoader style={{ width: "25%", margin: "3px 10px 3px 50px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</div>
+			<div style={{ display: "flex", justifyContent: "space-between" }}>
+				<SkeletonLoader style={{ width: "20%", margin: "3px 10px 3px 50px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</div>
+			<SkeletonLoader style={{ width: "50%", margin: "3px 10px 5px 40px" }} />
+			<SkeletonLoader style={{ width: "20%", margin: "3px 10px 5px 40px" }} />
+			<SkeletonLoader style={{ width: "30%", margin: "3px 10px 3px 40px" }} />
+			<div style={{ display: "flex", justifyContent: "space-between" }}>
+				<SkeletonLoader style={{ width: "55%", margin: "3px 10px 3px 50px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</div>
+			<div style={{ display: "flex", justifyContent: "space-between" }}>
+				<SkeletonLoader style={{ width: "70%", margin: "3px 10px 3px 50px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</div>
+			<div style={{ display: "flex", justifyContent: "space-between" }}>
+				<SkeletonLoader style={{ width: "40%", margin: "3px 10px 3px 50px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</div>
+			<SkeletonLoader style={{ width: "25%", margin: "3px 10px 5px 40px" }} />
+			<SkeletonLoader style={{ width: "30%", margin: "3px 10px 3px 40px" }} />
+		</>
+	);
+};
+
+export const ObservabilityLoadingServiceEntities = () => {
+	return (
+		<>
+			<SkeletonLoader style={{ width: "45%", margin: "6px 10px 5px 20px" }} />
+			<SkeletonLoader style={{ width: "35%", margin: "3px 10px 5px 20px" }} />
+			<SkeletonLoader style={{ width: "60%", margin: "3px 10px 5px 20px" }} />
+			<SkeletonLoader style={{ width: "70%", margin: "3px 10px 5px 20px" }} />
+		</>
+	);
+};

--- a/shared/ui/Stream/ObservabilityLoading.tsx
+++ b/shared/ui/Stream/ObservabilityLoading.tsx
@@ -1,37 +1,37 @@
 import React from "react";
-import { SkeletonLoader } from "@codestream/webview/Stream/SkeletonLoader";
+import { SkeletonLoader, SkeletonFlexContainer } from "@codestream/webview/Stream/SkeletonLoader";
 
 export const ObservabilityLoadingServiceEntity = () => {
 	return (
 		<>
 			<SkeletonLoader style={{ width: "30%", marginLeft: "40px" }} />
-			<div style={{ display: "flex", justifyContent: "space-between" }}>
+			<SkeletonFlexContainer>
 				<SkeletonLoader style={{ width: "20%", margin: "0px 10px 3px 50px" }} />
 				<SkeletonLoader style={{ width: "6%", margin: "0px 10px 3px 0px" }} />
-			</div>
-			<div style={{ display: "flex", justifyContent: "space-between" }}>
+			</SkeletonFlexContainer>
+			<SkeletonFlexContainer>
 				<SkeletonLoader style={{ width: "25%", margin: "3px 10px 3px 50px" }} />
 				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
-			</div>
-			<div style={{ display: "flex", justifyContent: "space-between" }}>
+			</SkeletonFlexContainer>
+			<SkeletonFlexContainer>
 				<SkeletonLoader style={{ width: "20%", margin: "3px 10px 0px 50px" }} />
 				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 0px 0px" }} />
-			</div>
+			</SkeletonFlexContainer>
 			<SkeletonLoader style={{ width: "50%", marginLeft: "40px" }} />
 			<SkeletonLoader style={{ width: "20%", marginLeft: "40px" }} />
 			<SkeletonLoader style={{ width: "30%", marginLeft: "40px" }} />
-			<div style={{ display: "flex", justifyContent: "space-between" }}>
+			<SkeletonFlexContainer>
 				<SkeletonLoader style={{ width: "55%", margin: "0px 10px 3px 50px" }} />
 				<SkeletonLoader style={{ width: "6%", margin: "0px 10px 3px 0px" }} />
-			</div>
-			<div style={{ display: "flex", justifyContent: "space-between" }}>
+			</SkeletonFlexContainer>
+			<SkeletonFlexContainer>
 				<SkeletonLoader style={{ width: "70%", margin: "3px 10px 3px 50px" }} />
 				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
-			</div>
-			<div style={{ display: "flex", justifyContent: "space-between" }}>
+			</SkeletonFlexContainer>
+			<SkeletonFlexContainer>
 				<SkeletonLoader style={{ width: "40%", margin: "3px 10px 0px 50px" }} />
 				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 0px 0px" }} />
-			</div>
+			</SkeletonFlexContainer>
 			<SkeletonLoader style={{ width: "25%", marginLeft: "40px" }} />
 			<SkeletonLoader style={{ width: "30%", marginLeft: "40px" }} />
 		</>
@@ -45,6 +45,58 @@ export const ObservabilityLoadingServiceEntities = () => {
 			<SkeletonLoader style={{ width: "35%", marginLeft: "20px" }} />
 			<SkeletonLoader style={{ width: "60%", marginLeft: "20px" }} />
 			<SkeletonLoader style={{ width: "70%", marginLeft: "20px" }} />
+		</>
+	);
+};
+
+export const ObservabilityLoadingRelatedServiceEntities = () => {
+	return (
+		<>
+			<SkeletonLoader style={{ width: "45%", marginLeft: "50px" }} />
+			<SkeletonLoader style={{ width: "35%", marginLeft: "50px" }} />
+			<SkeletonLoader style={{ width: "60%", marginLeft: "50px" }} />
+		</>
+	);
+};
+
+export const ObservabilityLoadingGoldenMetrics = () => {
+	return (
+		<>
+			<SkeletonFlexContainer>
+				<SkeletonLoader style={{ width: "40%", margin: "0px 10px 3px 42px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "0px 10px 3px 0px" }} />
+			</SkeletonFlexContainer>
+			<SkeletonFlexContainer>
+				<SkeletonLoader style={{ width: "35%", margin: "3px 10px 3px 42px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</SkeletonFlexContainer>
+			<SkeletonFlexContainer>
+				<SkeletonLoader style={{ width: "30%", margin: "3px 10px 3px 42px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</SkeletonFlexContainer>
+		</>
+	);
+};
+
+export const ObservabilityLoadingVulnerabilities = () => {
+	return (
+		<>
+			<SkeletonFlexContainer>
+				<SkeletonLoader style={{ width: "65%", margin: "0px 10px 3px 40px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "0px 10px 3px 0px" }} />
+			</SkeletonFlexContainer>
+			<SkeletonFlexContainer>
+				<SkeletonLoader style={{ width: "45%", margin: "3px 10px 3px 40px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</SkeletonFlexContainer>
+			<SkeletonFlexContainer>
+				<SkeletonLoader style={{ width: "45%", margin: "3px 10px 3px 40px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</SkeletonFlexContainer>
+			<SkeletonFlexContainer>
+				<SkeletonLoader style={{ width: "55%", margin: "3px 10px 3px 40px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</SkeletonFlexContainer>
 		</>
 	);
 };

--- a/shared/ui/Stream/ObservabilityLoading.tsx
+++ b/shared/ui/Stream/ObservabilityLoading.tsx
@@ -4,64 +4,33 @@ import { SkeletonLoader } from "@codestream/webview/Stream/SkeletonLoader";
 export const ObservabilityLoadingServiceEntity = () => {
 	return (
 		<>
-			{/* <SkeletonLoader style={{ width: "30%", margin: "3px 10px 3px 40px" }} />
-			<div style={{ display: "flex", justifyContent: "space-between" }}>
-				<SkeletonLoader style={{ width: "20%", margin: "3px 10px 3px 50px" }} />
-				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
-			</div>
-			<div style={{ display: "flex", justifyContent: "space-between" }}>
-				<SkeletonLoader style={{ width: "25%", margin: "3px 10px 3px 50px" }} />
-				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
-			</div>
-			<div style={{ display: "flex", justifyContent: "space-between" }}>
-				<SkeletonLoader style={{ width: "20%", margin: "3px 10px 3px 50px" }} />
-				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
-			</div>
-			<SkeletonLoader style={{ width: "50%", margin: "3px 10px 5px 40px" }} />
-			<SkeletonLoader style={{ width: "20%", margin: "3px 10px 5px 40px" }} />
-			<SkeletonLoader style={{ width: "30%", margin: "3px 10px 3px 40px" }} />
-			<div style={{ display: "flex", justifyContent: "space-between" }}>
-				<SkeletonLoader style={{ width: "55%", margin: "3px 10px 3px 50px" }} />
-				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
-			</div>
-			<div style={{ display: "flex", justifyContent: "space-between" }}>
-				<SkeletonLoader style={{ width: "70%", margin: "3px 10px 3px 50px" }} />
-				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
-			</div>
-			<div style={{ display: "flex", justifyContent: "space-between" }}>
-				<SkeletonLoader style={{ width: "40%", margin: "3px 10px 3px 50px" }} />
-				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
-			</div>
-			<SkeletonLoader style={{ width: "25%", margin: "3px 10px 5px 40px" }} />
-			<SkeletonLoader style={{ width: "30%", margin: "3px 10px 3px 40px" }} /> */}
-
 			<SkeletonLoader style={{ width: "30%", marginLeft: "40px" }} />
 			<div style={{ display: "flex", justifyContent: "space-between" }}>
-				<SkeletonLoader style={{ width: "20%", margin: "3px 10px 3px 50px" }} />
-				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+				<SkeletonLoader style={{ width: "20%", margin: "0px 10px 3px 50px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "0px 10px 3px 0px" }} />
 			</div>
 			<div style={{ display: "flex", justifyContent: "space-between" }}>
 				<SkeletonLoader style={{ width: "25%", margin: "3px 10px 3px 50px" }} />
 				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
 			</div>
 			<div style={{ display: "flex", justifyContent: "space-between" }}>
-				<SkeletonLoader style={{ width: "20%", margin: "3px 10px 3px 50px" }} />
-				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+				<SkeletonLoader style={{ width: "20%", margin: "3px 10px 0px 50px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 0px 0px" }} />
 			</div>
 			<SkeletonLoader style={{ width: "50%", marginLeft: "40px" }} />
 			<SkeletonLoader style={{ width: "20%", marginLeft: "40px" }} />
 			<SkeletonLoader style={{ width: "30%", marginLeft: "40px" }} />
 			<div style={{ display: "flex", justifyContent: "space-between" }}>
-				<SkeletonLoader style={{ width: "55%", margin: "3px 10px 3px 50px" }} />
-				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+				<SkeletonLoader style={{ width: "55%", margin: "0px 10px 3px 50px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "0px 10px 3px 0px" }} />
 			</div>
 			<div style={{ display: "flex", justifyContent: "space-between" }}>
 				<SkeletonLoader style={{ width: "70%", margin: "3px 10px 3px 50px" }} />
 				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
 			</div>
 			<div style={{ display: "flex", justifyContent: "space-between" }}>
-				<SkeletonLoader style={{ width: "40%", margin: "3px 10px 3px 50px" }} />
-				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+				<SkeletonLoader style={{ width: "40%", margin: "3px 10px 0px 50px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 0px 0px" }} />
 			</div>
 			<SkeletonLoader style={{ width: "25%", marginLeft: "40px" }} />
 			<SkeletonLoader style={{ width: "30%", marginLeft: "40px" }} />
@@ -72,10 +41,10 @@ export const ObservabilityLoadingServiceEntity = () => {
 export const ObservabilityLoadingServiceEntities = () => {
 	return (
 		<>
-			<SkeletonLoader style={{ width: "45%", margin: "6px 10px 5px 20px" }} />
-			<SkeletonLoader style={{ width: "35%", margin: "3px 10px 5px 20px" }} />
-			<SkeletonLoader style={{ width: "60%", margin: "3px 10px 5px 20px" }} />
-			<SkeletonLoader style={{ width: "70%", margin: "3px 10px 5px 20px" }} />
+			<SkeletonLoader style={{ width: "45%", marginLeft: "20px" }} />
+			<SkeletonLoader style={{ width: "35%", marginLeft: "20px" }} />
+			<SkeletonLoader style={{ width: "60%", marginLeft: "20px" }} />
+			<SkeletonLoader style={{ width: "70%", marginLeft: "20px" }} />
 		</>
 	);
 };

--- a/shared/ui/Stream/ObservabilityRelatedCalledBy.tsx
+++ b/shared/ui/Stream/ObservabilityRelatedCalledBy.tsx
@@ -10,6 +10,7 @@ import Icon from "./Icon";
 import { ErrorRow } from "./Observability";
 import { ObservabilityRelatedEntity } from "./ObservabilityRelatedEntity";
 import { ObservabilityRelatedSearch } from "./ObservabilityRelatedSearch";
+import { ObservabilityLoadingRelatedServiceEntities } from "@codestream/webview/Stream/ObservabilityLoading";
 
 interface Props {
 	currentRepoId: string;
@@ -69,23 +70,7 @@ export const ObservabilityRelatedCalledBy = React.memo((props: Props) => {
 					searchItems={relatedEntitiesForSearch || []}
 				/>
 			)}
-			{loading && expanded && (
-				<Row
-					style={{
-						padding: "0 10px 0 60px",
-					}}
-					className={"pr-row"}
-				>
-					<Icon
-						style={{
-							marginRight: "5px",
-						}}
-						className="spin"
-						name="sync"
-					/>{" "}
-					Loading...
-				</Row>
-			)}
+			{loading && expanded && <ObservabilityLoadingRelatedServiceEntities />}
 		</>
 	);
 });

--- a/shared/ui/Stream/ObservabilityRelatedCalls.tsx
+++ b/shared/ui/Stream/ObservabilityRelatedCalls.tsx
@@ -10,6 +10,7 @@ import Icon from "./Icon";
 import { ErrorRow } from "./Observability";
 import { ObservabilityRelatedEntity } from "./ObservabilityRelatedEntity";
 import { ObservabilityRelatedSearch } from "./ObservabilityRelatedSearch";
+import { ObservabilityLoadingRelatedServiceEntities } from "@codestream/webview/Stream/ObservabilityLoading";
 
 interface Props {
 	currentRepoId: string;
@@ -71,23 +72,7 @@ export const ObservabilityRelatedCalls = React.memo((props: Props) => {
 					searchItems={relatedEntitiesForSearch || []}
 				/>
 			)}
-			{loading && expanded && (
-				<Row
-					style={{
-						padding: "0 10px 0 60px",
-					}}
-					className={"pr-row"}
-				>
-					<Icon
-						style={{
-							marginRight: "5px",
-						}}
-						className="spin"
-						name="sync"
-					/>{" "}
-					Loading...
-				</Row>
-			)}
+			{loading && expanded && <ObservabilityLoadingRelatedServiceEntities />}
 		</>
 	);
 });

--- a/shared/ui/Stream/OpenPullRequests.tsx
+++ b/shared/ui/Stream/OpenPullRequests.tsx
@@ -19,6 +19,7 @@ import { isEmpty, isEqual } from "lodash-es";
 import React, { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
 import { shallowEqual } from "react-redux";
 import styled from "styled-components";
+import { PullRequestDetailsLoading } from "@codestream/webview/Stream/PullRequestLoading";
 
 import { OpenUrlRequestType, ReviewCloseDiffRequestType } from "@codestream/protocols/webview";
 import { WebviewPanels } from "@codestream/webview/ipc/webview.protocol.common";
@@ -1559,9 +1560,7 @@ export const OpenPullRequests = React.memo((props: Props) => {
 							</Row>
 						)}
 						{prFromUrlLoading && prFromUrlProviderId === providerId && (
-							<div style={{ marginLeft: "30px" }}>
-								<Icon className={"spin"} name="refresh" /> Loading...
-							</div>
+							<PullRequestDetailsLoading />
 						)}
 						{!isEmpty(prFromUrl) && !prFromUrlLoading && prFromUrlProviderId === providerId && (
 							<>{renderPrGroup(prFromUrl?.providerId, prFromUrl, "-1", "-1", "From URL")}</>

--- a/shared/ui/Stream/OpenReviews.tsx
+++ b/shared/ui/Stream/OpenReviews.tsx
@@ -2,7 +2,7 @@ import { DEFAULT_FR_QUERIES } from "@codestream/webview/store/preferences/reduce
 import { bootstrapReviews } from "@codestream/webview/store/reviews/thunks";
 import { setUserPreference } from "@codestream/webview/Stream/actions";
 import React from "react";
-import { shallowEqual, useDispatch, useSelector } from "react-redux";
+import { shallowEqual, useSelector } from "react-redux";
 import * as reviewSelectors from "../store/reviews/reducer";
 import * as userSelectors from "../store/users/reducer";
 import { CodeStreamState } from "../store";
@@ -32,6 +32,7 @@ import {
 } from "../src/components/Pane";
 import { WebviewModals, WebviewPanels } from "../ipc/webview.protocol.common";
 import { Link } from "./Link";
+import { ReviewsLoading } from "@codestream/webview/Stream/ReviewsLoading";
 
 interface Props {
 	openRepos: ReposScm[];
@@ -134,12 +135,7 @@ export const OpenReviews = React.memo(function OpenReviews(props: Props) {
 			</PaneHeader>
 			{props.paneState !== PaneState.Collapsed && (
 				<PaneBody key={"openreviews"}>
-					{!bootstrapped && (
-						<Row>
-							<Icon name="sync" className="spin margin-right" />
-							<span>Loading...</span>
-						</Row>
-					)}
+					{!bootstrapped && <ReviewsLoading />}
 					{bootstrapped && totalReviews === 0 && (
 						<NoContent>
 							Lightweight, pre-PR code review. Get quick feedback on any code, even pre-commit.{" "}

--- a/shared/ui/Stream/PullRequestExpandedSidebar.tsx
+++ b/shared/ui/Stream/PullRequestExpandedSidebar.tsx
@@ -9,7 +9,7 @@ import { HostApi } from "../webview-api";
 import { Row } from "./CrossPostIssueControls/IssuesPane";
 import Icon from "./Icon";
 import { PullRequestFilesChangedTab } from "./PullRequestFilesChangedTab";
-
+import { PullRequestDetailsLoading } from "@codestream/webview/Stream/PullRequestLoading";
 export const ReviewButton = styled.div`
 	color: white;
 	background-color: #24a100;
@@ -141,9 +141,7 @@ export const PullRequestExpandedSidebar = (props: PullRequestExpandedSidebarProp
 				</div>
 			</Row>
 			{props.loadingThirdPartyPrObject && !props.thirdPartyPrObject && (
-				<div style={{ paddingLeft: "45px" }}>
-					Loading... <Icon className="spin" name="sync" />
-				</div>
+				<PullRequestDetailsLoading />
 			)}
 			{props.thirdPartyPrObject && (
 				<>

--- a/shared/ui/Stream/PullRequestFilesChangedTab.tsx
+++ b/shared/ui/Stream/PullRequestFilesChangedTab.tsx
@@ -18,6 +18,7 @@ import {
 	getPullRequestFiles,
 	getPullRequestFilesFromProvider,
 } from "../store/providerPullRequests/thunks";
+import { PullRequestDetailsLoading } from "@codestream/webview/Stream/PullRequestLoading";
 import { useAppDispatch, useAppSelector, useDidMount } from "../utilities/hooks";
 import { HostApi } from "../webview-api";
 import Icon from "./Icon";
@@ -254,12 +255,7 @@ export const PullRequestFilesChangedTab = (props: {
 			</div>
 		);
 
-	if (isLoading && props.sidebarView)
-		return (
-			<div style={{ marginLeft: "45px" }}>
-				Loading... <Icon name="sync" className="spin row-icon" />
-			</div>
-		);
+	if (isLoading && props.sidebarView) return <PullRequestDetailsLoading />;
 
 	if (!filesChanged || !filesChanged.length) return null;
 

--- a/shared/ui/Stream/PullRequestLoading.tsx
+++ b/shared/ui/Stream/PullRequestLoading.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { SkeletonLoader } from "@codestream/webview/Stream/SkeletonLoader";
+
+export const PullRequestDetailsLoading = () => {
+	return (
+		<>
+			<SkeletonLoader style={{ width: "35%", marginLeft: "45px" }} />
+			<SkeletonLoader style={{ width: "30%", marginLeft: "50px" }} />
+			<SkeletonLoader style={{ width: "35%", marginLeft: "50px" }} />
+			<SkeletonLoader style={{ width: "45%", marginLeft: "60px", marginBottom: "5px" }} />
+		</>
+	);
+};

--- a/shared/ui/Stream/ReviewsLoading.tsx
+++ b/shared/ui/Stream/ReviewsLoading.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { SkeletonLoader } from "@codestream/webview/Stream/SkeletonLoader";
+
+export const ReviewsLoading = () => {
+	return (
+		<>
+			<SkeletonLoader style={{ width: "15%", marginLeft: "20px" }} />
+			<SkeletonLoader style={{ width: "25%", marginLeft: "20px" }} />
+			<SkeletonLoader style={{ width: "30%", marginLeft: "20px" }} />
+			<div style={{ display: "flex", justifyContent: "space-between" }}>
+				<SkeletonLoader style={{ width: "45%", margin: "0px 10px 3px 40px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "0px 10px 3px 0px" }} />
+			</div>
+			<div style={{ display: "flex", justifyContent: "space-between" }}>
+				<SkeletonLoader style={{ width: "35%", margin: "3px 10px 3px 40px" }} />
+				<SkeletonLoader style={{ width: "6%", margin: "3px 10px 3px 0px" }} />
+			</div>
+		</>
+	);
+};

--- a/shared/ui/Stream/SecurityIssuesWrapper.tsx
+++ b/shared/ui/Stream/SecurityIssuesWrapper.tsx
@@ -24,6 +24,7 @@ import { ResponseError } from "vscode-jsonrpc";
 import { Row } from "./CrossPostIssueControls/IssuesPane";
 import Icon from "./Icon";
 import Tooltip from "./Tooltip";
+import { ObservabilityLoadingVulnerabilities } from "@codestream/webview/Stream/ObservabilityLoading";
 
 interface Props {
 	currentRepoId: string;
@@ -350,9 +351,7 @@ export const SecurityIssuesWrapper = React.memo((props: Props) => {
 					/>
 				</InlineMenu>
 			</Row>
-			{loading && expanded && (
-				<ErrorRow isLoading={loading} title="Loading..." customPadding={"0 10px 0 42px"}></ErrorRow>
-			)}
+			{loading && expanded && <ObservabilityLoadingVulnerabilities />}
 			{error && expanded && getErrorDetails(error)}
 			{expanded && !loading && data && data.totalRecords > 0 && (
 				<>

--- a/shared/ui/Stream/SkeletonLoader.tsx
+++ b/shared/ui/Stream/SkeletonLoader.tsx
@@ -14,8 +14,13 @@ const pulseAnimation = keyframes`
 `;
 
 // Skeleton Loader Bar component
+// margins are most common found to be used throughout the app
+// can be overwritten with style tag
 export const SkeletonLoader = styled.div`
 	height: 12px;
+  margin-top: 6px;
+  margin-bottom; 6px;
+  margin-right: 10px;
 	background-color: var(--base-background-color);
 	animation: ${pulseAnimation} 1.5s ease-in-out infinite;
 	border-radius: 3px;

--- a/shared/ui/Stream/SkeletonLoader.tsx
+++ b/shared/ui/Stream/SkeletonLoader.tsx
@@ -14,13 +14,13 @@ const pulseAnimation = keyframes`
 `;
 
 // Skeleton Loader Bar component
-// margins are most common found to be used throughout the app
+// margins here are the standard margins we have between text throughout the app
 // can be overwritten with style tag
 export const SkeletonLoader = styled.div`
 	height: 12px;
-  margin-top: 6px;
-  margin-bottom; 6px;
-  margin-right: 10px;
+	margin-top: 6px;
+	margin-bottom: 6px;
+	margin-right: 10px;
 	background-color: var(--base-background-color);
 	animation: ${pulseAnimation} 1.5s ease-in-out infinite;
 	border-radius: 3px;

--- a/shared/ui/Stream/SkeletonLoader.tsx
+++ b/shared/ui/Stream/SkeletonLoader.tsx
@@ -25,3 +25,8 @@ export const SkeletonLoader = styled.div`
 	animation: ${pulseAnimation} 1.5s ease-in-out infinite;
 	border-radius: 3px;
 `;
+
+export const SkeletonFlexContainer = styled.div`
+	display: flex;
+	justify-content: space-between;
+`;

--- a/shared/ui/Stream/SkeletonLoader.tsx
+++ b/shared/ui/Stream/SkeletonLoader.tsx
@@ -1,0 +1,22 @@
+import styled, { keyframes } from "styled-components";
+
+// Keyframes for pulsing animation
+const pulseAnimation = keyframes`
+  0% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 0.8;
+  }
+  100% {
+    opacity: 0.4;
+  }
+`;
+
+// Skeleton Loader Bar component
+export const SkeletonLoader = styled.div`
+	height: 12px;
+	background-color: var(--base-background-color);
+	animation: ${pulseAnimation} 1.5s ease-in-out infinite;
+	border-radius: 3px;
+`;

--- a/shared/ui/src/components/Button.tsx
+++ b/shared/ui/src/components/Button.tsx
@@ -198,7 +198,7 @@ export const ButtonRoot = styled.button<ButtonProps>(props => {
 	${getPadding(props.size, props.variant)}
 	${getLineHeight(props.size, props.variant)}
 	${props.narrow ? "padding-left: 3px; padding-right: 3px;" : ""}
-	border-radius: 0;
+	border-radius: 2px;
 	border: 1px solid transparent !important;
 	outline: none !important;
 

--- a/shared/ui/src/components/Pane.tsx
+++ b/shared/ui/src/components/Pane.tsx
@@ -81,7 +81,7 @@ export const PaneNodeName = styled((props: PropsWithChildren<PaneNodeNameProps>)
 	return (
 		<div className={props.className} onClick={props.onClick || toggleNode}>
 			<div style={{ display: props.labelIsFlex ? "flex" : "block" }} className="label">
-				{props.isLoading && <Icon name="sync" className="spin" />}
+				{props.isLoading && <Icon name="sync" className="spin" style={{ marginRight: "2px" }} />}
 				{!props.isLoading && (
 					<Icon
 						name={derivedState.collapsed ? "chevron-right-thin" : "chevron-down-thin"}

--- a/shared/ui/src/components/Pane.tsx
+++ b/shared/ui/src/components/Pane.tsx
@@ -81,7 +81,7 @@ export const PaneNodeName = styled((props: PropsWithChildren<PaneNodeNameProps>)
 	return (
 		<div className={props.className} onClick={props.onClick || toggleNode}>
 			<div style={{ display: props.labelIsFlex ? "flex" : "block" }} className="label">
-				{props.isLoading && <Icon name="sync" className="spin" style={{ marginRight: "2px" }} />}
+				{props.isLoading && <Icon name="sync" className="spin" />}
 				{!props.isLoading && (
 					<Icon
 						name={derivedState.collapsed ? "chevron-right-thin" : "chevron-down-thin"}

--- a/shared/ui/styles/stream.less
+++ b/shared/ui/styles/stream.less
@@ -1283,8 +1283,8 @@
 				// background: @base-border-color;
 				background: var(--panel-tool-background-color);
 				&.dropdown {
-					border-top-left-radius: 0;
-					border-top-right-radius: 0;
+					border-top-left-radius: 2px;
+					border-top-right-radius: 2px;
 				}
 				h3 {
 					margin: 0;
@@ -2008,6 +2008,7 @@
 				.btn {
 					padding-left: 10px;
 					padding-right: 10px;
+					border-radius: 2px;
 				}
 				text-align: right;
 				margin: 10px 0;


### PR DESCRIPTION


For the scope of this ticket, I've implemented skeleton screens in the areas you would see them in sidebar panes.  For example in o11y:

![image](https://github.com/TeamCodeStream/codestream/assets/10050393/f124e079-2156-40e9-ba7c-529376b249e6)


In this ticket, I have _not_ implemented them in modals.  For example, if you click an error, it will still bring up the "Loading error group..." text, or if you refresh a pr detail page, you will get this screen:

![image](https://github.com/TeamCodeStream/codestream/assets/10050393/5c32a558-9a6d-4418-90af-7e9474969897)
