### PR TITLE
Remove Grok From Org Screens

### DIFF
--- a/shared/ui/Stream/BlameMap.tsx
+++ b/shared/ui/Stream/BlameMap.tsx
@@ -57,7 +57,9 @@ export function BlameMap() {
 		const teammates = mapFilter(memberIds, id => {
 			const user = state.users[id as string];
 			if (!user || !user.isRegistered || user.deactivated || user.externalUserId) return;
-
+			if (user.username === "Grok") {
+				return;
+			}
 			if (!user.fullName) {
 				let email = user.email;
 				if (email) user.fullName = email.replace(/@.*/, "");
@@ -71,6 +73,9 @@ export function BlameMap() {
 		const invited = mapFilter(memberIds, id => {
 			const user = state.users[id as string];
 			if (!user || user.isRegistered || user.deactivated || user.externalUserId) return;
+			if (user.username === "Grok") {
+				return;
+			}
 			let email = user.email;
 			if (email) user.fullName = email.replace(/@.*/, "");
 			return user;

--- a/shared/ui/Stream/Invite.tsx
+++ b/shared/ui/Stream/Invite.tsx
@@ -686,7 +686,9 @@ const mapStateToProps = state => {
 	const teammates = mapFilter(memberIds, id => {
 		const user = users[id as string];
 		if (!user || !user.isRegistered || user.deactivated || user.externalUserId) return;
-
+		if (user.username === "Grok") {
+			return;
+		}
 		if (!user.fullName) {
 			let email = user.email;
 			if (email) user.fullName = email.replace(/@.*/, "");
@@ -706,6 +708,9 @@ const mapStateToProps = state => {
 	const invited = mapFilter(memberIds, id => {
 		const user = users[id as string];
 		if (!user || user.isRegistered || user.deactivated || user.externalUserId) return;
+		if (user.username === "Grok") {
+			return;
+		}
 		let email = user.email;
 		if (email) user.fullName = email.replace(/@.*/, "");
 		return user;

--- a/shared/ui/Stream/Team.tsx
+++ b/shared/ui/Stream/Team.tsx
@@ -774,7 +774,9 @@ const mapStateToProps = state => {
 	const teammates = mapFilter(memberIds, id => {
 		const user = users[id as string];
 		if (!user || !user.isRegistered || user.deactivated || user.externalUserId) return;
-
+		if (user.username === "Grok") {
+			return;
+		}
 		if (!user.fullName) {
 			let email = user.email;
 			if (email) user.fullName = email.replace(/@.*/, "");
@@ -794,6 +796,9 @@ const mapStateToProps = state => {
 	const invited = mapFilter(memberIds, id => {
 		const user = users[id as string];
 		if (!user || user.isRegistered || user.deactivated || user.externalUserId) return;
+		if (user.username === "Grok") {
+			return;
+		}
 		let email = user.email;
 		if (email) user.fullName = email.replace(/@.*/, "");
 		return user;

--- a/shared/ui/src/components/SelectPeople.tsx
+++ b/shared/ui/src/components/SelectPeople.tsx
@@ -110,7 +110,10 @@ class SelectPeople extends React.Component<Props, State> {
 }
 
 const mapStateToProps = (state: CodeStreamState): ConnectedProps => {
-	return { teamMembers: getTeamMembers(state) };
+	const allTeamMembers = getTeamMembers(state);
+
+	const teamMembers = allTeamMembers.filter(_ => _.username !== "Grok");
+	return { teamMembers };
 };
 
 const ConnectedSelectPeople = connect(mapStateToProps, {})(SelectPeople);


### PR DESCRIPTION
Not sure the best way to handle this because we DO want Grok to show in some places, but not others. Username is the only good piece of data to key from when filtering :/


[Changes reviewed on CodeStream](https://codestream-stg.staging-service.newrelic.com/r/Ya5We-trHA5di0uy/RIFim55lRxGS8v8WZfyRFg?src=GitHub) by bcanzanella on Jun 13, 2023

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>