### PR TITLE
NR-85804 Logged out switching between repos on JB and VSC

### DIFF
--- a/jb/src/main/kotlin/agent/CodeStreamLanguageClient.kt
+++ b/jb/src/main/kotlin/agent/CodeStreamLanguageClient.kt
@@ -3,6 +3,7 @@ package com.codestream.agent
 import com.codestream.agent.handlers.ResolveStackTraceHandler
 import com.codestream.agentService
 import com.codestream.appDispatcher
+import com.codestream.authentication.SaveTokenReason
 import com.codestream.authenticationService
 import com.codestream.clmService
 import com.codestream.codeStream
@@ -135,7 +136,7 @@ class CodeStreamLanguageClient(private val project: Project) : LanguageClient {
     fun didLogin(json: JsonElement) {
         val notification = gson.fromJson<DidLoginNotification>(json)
         project.agentService?.onDidStart {
-            project.authenticationService?.completeLogin(notification.data)
+            project.authenticationService?.completeLogin(SaveTokenReason.LOGIN_SUCCESS, notification.data)
         }
     }
 

--- a/jb/src/main/kotlin/authentication/AuthenticationService.kt
+++ b/jb/src/main/kotlin/authentication/AuthenticationService.kt
@@ -15,6 +15,7 @@ import com.codestream.protocols.webview.DidChangeApiVersionCompatibility
 import com.codestream.protocols.webview.UserSession
 import com.codestream.sessionService
 import com.codestream.settings.ApplicationSettingsService
+import com.codestream.settings.SettingsService
 import com.codestream.settingsService
 import com.codestream.webViewService
 import com.github.salomonbrys.kotson.fromJson
@@ -29,6 +30,14 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.future.await
 
+enum class SaveTokenReason {
+    COPY,
+    LOGIN_SUCCESS,
+    LOGOUT,
+    LOGIN_ERROR,
+    AUTO_SIGN_IN,
+}
+
 class AuthenticationService(val project: Project) {
 
     private val extensionCapabilities: JsonElement get() = gson.toJsonTree(Capabilities())
@@ -39,9 +48,9 @@ class AuthenticationService(val project: Project) {
     private var apiVersionCompatibility: ApiVersionCompatibility? = null
     private var missingCapabilities: JsonObject? = null
 
-    fun bootstrap(): Any? {
-        val settings = project.settingsService ?: return Unit
-        val session = project.sessionService ?: return Unit
+    fun bootstrap(): BootstrapResponse? {
+        val settings = project.settingsService ?: return null
+        val session = project.sessionService ?: return null
 
         return BootstrapResponse(
             UserSession(session.userLoggedIn?.userId, session.eligibleJoinCompanies),
@@ -55,6 +64,21 @@ class AuthenticationService(val project: Project) {
         )
     }
 
+    private fun resolveToken(settings: SettingsService): String? {
+        val credentialAttributes = settings.credentialAttributes()
+        PasswordSafe.instance.getPassword(credentialAttributes)?.let {
+            logger.info("Auto sign-in password safe found settings.credentialAttributes()")
+            return it
+        }
+
+        val credentialAttributesNoTeam = settings.credentialAttributes(false)
+        PasswordSafe.instance.getPassword(credentialAttributesNoTeam)?.let {
+            logger.info("Auto sign-in password safe found using settings.credentialAttributes(false)")
+            return it
+        }
+        return null
+    }
+
     /**
      * Attempts to auto-sign in using a token stored in the password safe. Returns false
      * only if the token login fails or in case of an exception. If the auto-login fails for
@@ -66,8 +90,7 @@ class AuthenticationService(val project: Project) {
                 ?: return true.also { logger.warn("Auto sign-in failed: settings service not available") }
             if (!appSettings.autoSignIn)
                 return true.also { logger.warn("Auto sign-in failed: auto sign-in disabled") }
-            val tokenStr = PasswordSafe.instance.getPassword(settings.credentialAttributes())
-                ?: PasswordSafe.instance.getPassword(settings.credentialAttributes(false))
+            val tokenStr = resolveToken(settings)
                 ?: return true.also { logger.warn("Auto sign-in failed: unable to retrieve token from password safe") }
             val agent = project.agentService?.agent
                 ?: return true.also { logger.warn("Auto sign-in failed: agent service not available") }
@@ -77,35 +100,35 @@ class AuthenticationService(val project: Project) {
                 agent.loginToken(
                     LoginWithTokenParams(
                         token,
-                        settings.state.teamId
+                        settings.state.teamId // seems to not be used
                     )
                 ).await()
 
             return if (loginResult.error != null) {
-                logger.warn(loginResult.error)
+                logger.warn("Auto sign-in error ${loginResult.error}")
                 settings.state.teamId = null
                 appSettings.state.teamId = null
-                saveAccessToken(null)
+                saveAccessToken(SaveTokenReason.LOGIN_ERROR, null)
                 logger.info("Auto sign-in failed: ${loginResult.error}")
                 false
             } else {
-                completeLogin(loginResult)
+                completeLogin(SaveTokenReason.AUTO_SIGN_IN, loginResult)
                 logger.info("Auto sign-in successful")
                 true
             }
         } catch (err: Exception) {
-            logger.warn(err)
+            logger.warn("Auto sign-in error $err")
             return false
         }
     }
 
-    fun completeLogin(result: LoginResult) {
+    fun completeLogin(reason: SaveTokenReason, result: LoginResult) {
         if (project.sessionService?.userLoggedIn == null) {
             result.state?.let {
                 mergedCapabilities = extensionCapabilities.merge(it.capabilities)
                 project.settingsService?.state?.teamId = it.teamId
                 appSettings.state.teamId = it.teamId
-                saveAccessToken(it.token)
+                saveAccessToken(reason, it.token)
             }
             project.sessionService?.login(result.userLoggedIn, result.eligibleJoinCompanies)
         }
@@ -118,7 +141,7 @@ class AuthenticationService(val project: Project) {
 
         session.logout()
         agent.restart(newServerUrl)
-        saveAccessToken(null)
+        saveAccessToken(SaveTokenReason.LOGOUT, null)
         settings.state.teamId = null
         appSettings.state.teamId = null
     }
@@ -152,23 +175,25 @@ class AuthenticationService(val project: Project) {
             ?: return
         val token = gson.fromJson<JsonObject>(tokenStr)
         token["url"] = toServerUrl
-        saveAccessToken(token, toServerUrl, toTeamId)
+        saveAccessToken(SaveTokenReason.COPY, token, toServerUrl, toTeamId)
     }
 
-    private fun saveAccessToken(accessToken: JsonObject?, serverUrl: String? = null, teamId: String? = null) {
+    private fun saveAccessToken(reason: SaveTokenReason, accessToken: JsonObject?, serverUrl: String? = null, teamId: String? = null) {
         val settings = project.settingsService ?: return
         if (accessToken != null) {
-            logger.info("Saving access token to password safe")
+            logger.info("Saving access token to password safe $reason with provided teamid $teamId")
         } else {
-            logger.info("Clearing access token from password safe")
+            logger.info("Clearing access token from password safe $reason with provided teamid $teamId")
         }
 
         val credentials = accessToken?.let {
             Credentials(null, it.toString())
         }
 
+        val credentialAttributes = settings.credentialAttributes(true, serverUrl, teamId)
+
         PasswordSafe.instance.set(
-            settings.credentialAttributes(true, serverUrl, teamId),
+            credentialAttributes,
             credentials
         )
     }

--- a/jb/src/main/kotlin/settings/SettingsService.kt
+++ b/jb/src/main/kotlin/settings/SettingsService.kt
@@ -66,7 +66,11 @@ class SettingsService(val project: Project) : PersistentStateComponent<SettingsS
     }
 
     fun credentialAttributes(includeTeam: Boolean = true, serverUrl: String? = null, teamId: String? = null, userName: String? = null): CredentialAttributes {
-        val actualTeamId = teamId ?: state.teamId ?: applicationSettings.state.teamId
+        // The more global IDE level team id will be sync'd with the serverUrl and be a valid server / teamId pair
+        // The local state.teamId in project directory can refer to teamId from a different server url, especially
+        // when having IDE 1 point to PD and IDE 2 point to staging using the same project
+        val actualTeamId = teamId ?: applicationSettings.state.teamId ?: state.teamId
+        logger.debug("credentialAttributes: actualTeamId=$actualTeamId")
         val teamSuffix = if (includeTeam && actualTeamId != null) actualTeamId.let { "|${it}" } else ""
         val actualServerUrl = serverUrl ?: applicationSettings.state.serverUrl;
         val actualUserName = userName ?: applicationSettings.state.email


### PR DESCRIPTION
Partially addresses NR-85804

- Add params for reason for setting password and more logging for future troubleshooting
- Fix case for selecting correct teamId when you have 2 different IDEs using 2 different server URLs

**This PR Addresses:**  
[NR-85804 Logged out switching between repos on JB and VSC](https://issues.newrelic.com/browse/NR-85804)  


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>