### PR TITLE
[FOSSA] Determine Current Repo Context 

### DIFF
--- a/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
@@ -4,11 +4,13 @@ import { ReposScm, FetchThirdPartyCodeAnalyzersRequestType } from "@codestream/p
 import { HostApi } from "@codestream/webview/webview-api";
 import { CodeStreamState } from "@codestream/webview/store";
 import { getUserProviderInfoFromState } from "@codestream/webview/store/providers/utils";
-import { WebviewPanels } from "@codestream/webview/ipc/webview.protocol.common";
-import { PaneBody, PaneHeader, PaneState } from "@codestream/webview/src/components/Pane";
+import { useMemoizedState } from "@codestream/webview/utilities/hooks";
+import { WebviewPanels } from "../../ipc/webview.protocol.common";
+import { PaneBody, PaneHeader, PaneState } from "../../src/components/Pane";
 import Icon from "../Icon";
 import { ConnectFossa } from "./ConnectFossa";
 import { FossaResults } from "./FossaResults";
+import { CurrentRepoContext } from "@codestream/webview/Stream/CurrentRepoContext";
 
 interface Props {
 	openRepos: ReposScm[];
@@ -40,6 +42,7 @@ export const CodeAnalyzers = (props: Props) => {
 			providers,
 		};
 	}, shallowEqual);
+	const [currentRepoId, setCurrentRepoId] = useMemoizedState<string | undefined>(undefined);
 
 	useEffect(() => {
 		if (props.paneState === PaneState.Collapsed) return;
@@ -85,20 +88,7 @@ export const CodeAnalyzers = (props: Props) => {
 			<PaneHeader
 				title="Code Analyzers"
 				id={WebviewPanels.CodeAnalyzers}
-				subtitle={
-					derivedState.currentRepo && (
-						<>
-							<span>
-								<Icon
-									name="repo"
-									className="inline-label"
-									style={{ transform: "scale(0.7)", display: "inline-block" }}
-								/>
-								{derivedState.currentRepo.folder.name}
-							</span>
-						</>
-					)
-				}
+				subtitle={<CurrentRepoContext currentRepoCallback={setCurrentRepoId} />}
 			></PaneHeader>
 			{props.paneState != PaneState.Collapsed && (
 				<PaneBody key="fossa">

--- a/shared/ui/Stream/CurrentRepoContext.tsx
+++ b/shared/ui/Stream/CurrentRepoContext.tsx
@@ -19,14 +19,14 @@ import { useAppDispatch } from "../utilities/hooks";
 
 interface Props {
 	currentRepoCallback: (repoId?: string) => void;
-	observabilityRepos: ObservabilityRepo[];
+	observabilityRepos?: ObservabilityRepo[];
 }
 
 const CurrentRepoContainer = styled.span`
 	color: var(--text-color-subtle);
 `;
 
-export const ObservabilityCurrentRepo = React.memo((props: Props) => {
+export const CurrentRepoContext = React.memo((props: Props) => {
 	const dispatch = useAppDispatch();
 	const derivedState = useSelector((state: CodeStreamState) => {
 		return {

--- a/shared/ui/Stream/Observability.tsx
+++ b/shared/ui/Stream/Observability.tsx
@@ -73,7 +73,7 @@ import Icon from "./Icon";
 import { Provider } from "./IntegrationsPanel";
 import { Link } from "./Link";
 import { ObservabilityAddAdditionalService } from "./ObservabilityAddAdditionalService";
-import { ObservabilityCurrentRepo } from "./ObservabilityCurrentRepo";
+import { CurrentRepoContext } from "./CurrentRepoContext";
 import { ObservabilityErrorWrapper } from "./ObservabilityErrorWrapper";
 import { ObservabilityGoldenMetricDropdown } from "./ObservabilityGoldenMetricDropdown";
 import Timestamp from "./Timestamp";
@@ -1021,7 +1021,7 @@ export const Observability = React.memo((props: Props) => {
 				title="Observability"
 				id={WebviewPanels.Observability}
 				subtitle={
-					<ObservabilityCurrentRepo
+					<CurrentRepoContext
 						observabilityRepos={observabilityRepos}
 						currentRepoCallback={setCurrentRepoId}
 					/>
@@ -1059,8 +1059,8 @@ export const Observability = React.memo((props: Props) => {
 										{!hasEntities && !genericError && (
 											<GenericWrapper>
 												<GenericCopy>
-													Instrument your application with New Relic to see performance data in
-													your IDE, including service-level telemetry and code-level metrics.{" "}
+													Instrument your application with New Relic to see performance data in your
+													IDE, including service-level telemetry and code-level metrics.{" "}
 													<a href="https://docs.newrelic.com/docs/codestream/how-use-codestream/performance-monitoring">
 														Learn more.
 													</a>


### PR DESCRIPTION
This PR handles part of NR-119852 for determining repo context for display purposes in the section header. The PR does not handle determining which results from FOSSA to display based on a match with the current repo. Working with FOSSA's API will come as part of a future task. 

![current-repo-context](https://github.com/TeamCodeStream/codestream/assets/14142356/d2f1058c-fc7b-4226-8dd7-d283c54dbf14)
