### PR TITLE
Make Recent Errors better match Errors Inbox

### DIFF
--- a/shared/agent/src/providers/newrelic.ts
+++ b/shared/agent/src/providers/newrelic.ts
@@ -166,11 +166,11 @@ export interface INewRelicProvider {
 	getObservabilityEntityRepos: (
 		repoId: string,
 		skipRepoFetch?: boolean,
-		force?: boolean
+		force?: boolean,
 	) => Promise<ObservabilityRepo | undefined>;
 	getGoldenSignalsEntity: (
 		codestreamUser: CSMe,
-		observabilityRepo: ObservabilityRepo
+		observabilityRepo: ObservabilityRepo,
 	) => EntityAccount;
 	errorLogIfNotIgnored: (ex: Error, message: string, ...params: any[]) => void;
 	getDeployments(request: GetDeploymentsRequest): Promise<GetDeploymentsResponse>;
@@ -205,7 +205,7 @@ export class NewRelicProvider
 		super(session, config);
 		this._memoizedBuildRepoRemoteVariants = memoize(
 			this.buildRepoRemoteVariants,
-			(remotes: string[]) => remotes
+			(remotes: string[]) => remotes,
 		);
 	}
 
@@ -321,7 +321,7 @@ export class NewRelicProvider
 		if (!accessToken) {
 			throw new ResponseError(
 				ERROR_NR_CONNECTION_MISSING_API_KEY,
-				"Could not get a New Relic API key"
+				"Could not get a New Relic API key",
 			);
 		}
 		const options = {
@@ -416,7 +416,7 @@ export class NewRelicProvider
 						{
 							id: number;
 							name: string;
-						}
+						},
 					];
 				};
 			}>(`{
@@ -439,7 +439,7 @@ export class NewRelicProvider
 			const accessTokenError = this.getAccessTokenError(ex);
 			throw new ResponseError(
 				ERROR_NR_CONNECTION_INVALID_API_KEY,
-				accessTokenError?.message || ex.message || ex.toString()
+				accessTokenError?.message || ex.message || ex.toString(),
 			);
 		}
 	}
@@ -453,7 +453,7 @@ export class NewRelicProvider
 	async query<T = any>(
 		query: string,
 		variables: any = undefined,
-		tryCount: number = 3
+		tryCount: number = 3,
 	): Promise<T> {
 		await this.ensureConnected();
 
@@ -526,7 +526,7 @@ export class NewRelicProvider
 			requestError.response.errors.length
 		) {
 			return requestError.response.errors.find(
-				_ => _.extensions && _.extensions.error_code === "BAD_API_KEY"
+				_ => _.extensions && _.extensions.error_code === "BAD_API_KEY",
 			);
 		}
 		return undefined;
@@ -568,7 +568,7 @@ export class NewRelicProvider
 				_ =>
 					_.extensions &&
 					_.extensions.errorClass === "SERVER_ERROR" &&
-					_.extensions.classification === "DataFetchingException"
+					_.extensions.classification === "DataFetchingException",
 			);
 		}
 		return undefined;
@@ -591,7 +591,7 @@ export class NewRelicProvider
 	@lspHandler(GetObservabilityEntitiesRequestType)
 	@log({ timed: true })
 	async getEntities(
-		request: GetObservabilityEntitiesRequest
+		request: GetObservabilityEntitiesRequest,
 	): Promise<GetObservabilityEntitiesResponse> {
 		const { limit = 50 } = request;
 		try {
@@ -626,7 +626,7 @@ export class NewRelicProvider
 						guid: _.guid,
 						name: `${_.name} (${_.account.name})`,
 					};
-				}
+				},
 			);
 
 			return {
@@ -645,7 +645,7 @@ export class NewRelicProvider
 		timed: true,
 	})
 	async getErrorGroupMetadata(
-		request: GetObservabilityErrorGroupMetadataRequest
+		request: GetObservabilityErrorGroupMetadataRequest,
 	): Promise<GetObservabilityErrorGroupMetadataResponse | undefined> {
 		if (!request.errorGroupGuid) return undefined;
 
@@ -681,7 +681,7 @@ export class NewRelicProvider
 		timed: true,
 	})
 	async getObservabilityErrorAssignments(
-		request: GetObservabilityErrorAssignmentsRequest
+		request: GetObservabilityErrorAssignmentsRequest,
 	): Promise<GetObservabilityErrorAssignmentsResponse> {
 		const response: GetObservabilityErrorAssignmentsResponse = { items: [] };
 
@@ -741,7 +741,7 @@ export class NewRelicProvider
 		timed: true,
 	})
 	async getObservabilityRepos(
-		request: GetObservabilityReposRequest
+		request: GetObservabilityReposRequest,
 	): Promise<GetObservabilityReposResponse> {
 		const { force = false } = request;
 		const cacheKey = JSON.stringify(request);
@@ -773,7 +773,7 @@ export class NewRelicProvider
 						"getObservabilityRepos skipping repo with missing id and/or repo.remotes",
 						{
 							repo: repo,
-						}
+						},
 					);
 					continue;
 				}
@@ -791,7 +791,7 @@ export class NewRelicProvider
 				// find REPOSITORY entities tied to a remote
 				const repositoryEntitiesResponse = await this.findRepositoryEntitiesByRepoRemotes(
 					remotes,
-					force
+					force,
 				);
 
 				if (isNRErrorResponse(repositoryEntitiesResponse)) {
@@ -804,13 +804,13 @@ export class NewRelicProvider
 				if (repositoryEntitiesResponse?.entities) {
 					// find RELATED entities that are tied to REPOSITORY entities
 					const entitiesReponse = await this.findRelatedEntityByRepositoryGuids(
-						repositoryEntitiesResponse?.entities?.map(_ => _.guid)
+						repositoryEntitiesResponse?.entities?.map(_ => _.guid),
 					);
 					// find the APPLICATION entities themselves
 					applicationAssociations = entitiesReponse?.actor?.entities?.filter(
 						_ =>
 							_?.relatedEntities?.results?.filter(r => r.source?.entity?.type === "APPLICATION")
-								.length
+								.length,
 					);
 					hasRepoAssociation = applicationAssociations?.length > 0;
 
@@ -819,8 +819,8 @@ export class NewRelicProvider
 						_flatten(
 							repositoryEntitiesResponse.entities.map(_ => {
 								return _.tags?.find(t => t.key === "url")?.values;
-							})
-						)
+							}),
+						),
 					).filter(Boolean);
 
 					ContextLogger.log("found repositories matching remotes", {
@@ -870,7 +870,7 @@ export class NewRelicProvider
 									uniqueEntities.find(
 										ue =>
 											ue.guid === relatedResult.source.entity.guid &&
-											ue.account?.id === relatedResult.source.entity.account?.id
+											ue.account?.id === relatedResult.source.entity.account?.id,
 									)
 								) {
 									continue;
@@ -906,7 +906,7 @@ export class NewRelicProvider
 						})
 						.filter(Boolean)
 						.sort((a, b) =>
-							`${a.accountName}-${a.entityName}`.localeCompare(`${b.accountName}-${b.entityName}`)
+							`${a.accountName}-${a.entityName}`.localeCompare(`${b.accountName}-${b.entityName}`),
 						),
 				});
 				ContextLogger.log(`getObservabilityRepos hasRepoAssociation=${hasRepoAssociation}`, {
@@ -957,14 +957,14 @@ export class NewRelicProvider
 			codeNamespace?: string;
 			functionName?: string;
 			relativeFilePath?: string;
-		}
+		},
 	): Promise<ObservabilityError[]> {
 		const parsedId = NewRelicProvider.parseId(entityGuid)!;
 		const query = this.getMethodLevelErrorsQuery(
 			entityGuid,
 			metricTimesliceNames,
 			since,
-			functionIdentifiers
+			functionIdentifiers,
 		);
 		if (!query) return [];
 
@@ -994,7 +994,7 @@ export class NewRelicProvider
 			}`,
 			{
 				accountId: parsedId.accountId,
-			}
+			},
 		);
 		const result = response.actor.account.nrql.results?.length
 			? await Promise.all(
@@ -1002,7 +1002,7 @@ export class NewRelicProvider
 						const response = await this.getErrorGroupFromNameMessageEntity(
 							errorTrace.errorClass,
 							errorTrace.message,
-							errorTrace.entityGuid
+							errorTrace.entityGuid,
 						);
 
 						return {
@@ -1017,7 +1017,7 @@ export class NewRelicProvider
 							lastOccurrence: errorTrace.lastOccurrence,
 							errorGroupUrl: response.actor.errorsInbox.errorGroup.url,
 						};
-					})
+					}),
 			  )
 			: [];
 		return result;
@@ -1031,7 +1031,7 @@ export class NewRelicProvider
 			codeNamespace?: string;
 			functionName?: string;
 			relativeFilePath?: string;
-		}
+		},
 	) {
 		const transactionNameMatch = metricTimesliceNames?.errorRate?.match(/Errors\/(.*)/);
 		if (
@@ -1108,13 +1108,13 @@ export class NewRelicProvider
 
 	private async checkHasCodeLevelMetricSpanData(
 		hasRepoAssociation: boolean,
-		uniqueEntities: Entity[]
+		uniqueEntities: Entity[],
 	): Promise<boolean | NRErrorResponse> {
 		if (!hasRepoAssociation || _isEmpty(uniqueEntities)) {
 			return false;
 		}
 		const repoEntitySpanDataExistsResponse = await this.findClmSpanDataExists(
-			uniqueEntities?.map(_ => _.guid)
+			uniqueEntities?.map(_ => _.guid),
 		);
 		if (isNRErrorResponse(repoEntitySpanDataExistsResponse)) {
 			return repoEntitySpanDataExistsResponse;
@@ -1136,7 +1136,7 @@ export class NewRelicProvider
 		timed: true,
 	})
 	async getObservabilityErrors(
-		request: GetObservabilityErrorsRequest
+		request: GetObservabilityErrorsRequest,
 	): Promise<GetObservabilityErrorsResponse> {
 		const response: GetObservabilityErrorsResponse = { repos: [] };
 		try {
@@ -1148,7 +1148,7 @@ export class NewRelicProvider
 			if (request?.filters?.length) {
 				filteredRepoIds = request.filters.map(_ => _.repoId);
 				filteredRepos = reposResponse.repositories?.filter(
-					r => r.id && filteredRepoIds.includes(r.id)
+					r => r.id && filteredRepoIds.includes(r.id),
 				)!;
 			}
 			filteredRepos = filteredRepos?.filter(_ => _.id);
@@ -1167,7 +1167,7 @@ export class NewRelicProvider
 					});
 
 					const repositoryEntitiesResponse = await this.findRepositoryEntitiesByRepoRemotes(
-						remotes
+						remotes,
 					);
 					if (isNRErrorResponse(repositoryEntitiesResponse)) {
 						return { error: repositoryEntitiesResponse };
@@ -1190,7 +1190,7 @@ export class NewRelicProvider
 										r.type === "BUILT_FROM" &&
 										(entityFilter?.entityGuid
 											? r.source?.entity.guid === entityFilter.entityGuid
-											: true)
+											: true),
 								);
 
 							const urlValue = entity.tags?.find(_ => _.key === "url")?.values[0];
@@ -1207,14 +1207,14 @@ export class NewRelicProvider
 									application.source.entity.account.id,
 									application.source.entity.guid,
 									application.source.entity.entityType,
-									request.timeWindow
+									request.timeWindow,
 								);
 								for (const errorTrace of errorTraces) {
 									try {
 										const response = await this.getErrorGroupFromNameMessageEntity(
 											errorTrace.errorClass,
 											errorTrace.message,
-											errorTrace.entityGuid
+											errorTrace.entityGuid,
 										);
 
 										if (response && response.actor.errorsInbox.errorGroup) {
@@ -1274,7 +1274,7 @@ export class NewRelicProvider
 		timed: true,
 	})
 	getObservabilityResponseTimes(
-		request: GetObservabilityResponseTimesRequest
+		request: GetObservabilityResponseTimesRequest,
 	): Promise<GetObservabilityResponseTimesResponse> {
 		return this._clmManager.getObservabilityResponseTimes(request);
 	}
@@ -1293,7 +1293,7 @@ export class NewRelicProvider
 		timed: true,
 	})
 	async getObservabilityAnomalies(
-		request: GetObservabilityAnomaliesRequest
+		request: GetObservabilityAnomaliesRequest,
 	): Promise<GetObservabilityAnomaliesResponse> {
 		const cached = this._observabilityAnomaliesTimedCache.get(request);
 		if (cached) {
@@ -1348,7 +1348,7 @@ export class NewRelicProvider
 			  	`,
 				{
 					accountId: accountId,
-				}
+				},
 			);
 			const token = response.actor.account.pixie.pixieAccessToken;
 
@@ -1389,7 +1389,7 @@ export class NewRelicProvider
 	@lspHandler(GetNewRelicRelatedEntitiesRequestType)
 	@log()
 	async getNewRelicRelatedEntities(
-		request: GetNewRelicRelatedEntitiesRequest
+		request: GetNewRelicRelatedEntitiesRequest,
 	): Promise<GetNewRelicRelatedEntitiesResponse | undefined> {
 		try {
 			const response = await this.query(
@@ -1432,7 +1432,7 @@ export class NewRelicProvider
 			  	`,
 				{
 					entityGuid: request.entityGuid,
-				}
+				},
 			);
 			if (response?.actor?.entity?.relatedEntities?.results) {
 				const results = response.actor.entity.relatedEntities.results.map((_: RelatedEntity) => {
@@ -1465,7 +1465,7 @@ export class NewRelicProvider
 	@lspHandler(GetNewRelicErrorGroupRequestType)
 	@log()
 	async getNewRelicErrorGroupData(
-		request: GetNewRelicErrorGroupRequest
+		request: GetNewRelicErrorGroupRequest,
 	): Promise<GetNewRelicErrorGroupResponse | undefined> {
 		let errorGroup: NewRelicErrorGroup | undefined = undefined;
 		let accountId = 0;
@@ -1485,13 +1485,13 @@ export class NewRelicProvider
 					errorGroupGuid,
 					entityGuid,
 					request.occurrenceId,
-					request.timestamp
+					request.timestamp,
 				);
 			} else {
 				// no entity, look it up
 				const errorGroupPartialResponse = await this.fetchErrorGroupById(
 					errorGroupGuid,
-					request.timestamp
+					request.timestamp,
 				);
 				if (errorGroupPartialResponse?.entityGuid) {
 					entityGuid = errorGroupPartialResponse?.entityGuid;
@@ -1500,7 +1500,7 @@ export class NewRelicProvider
 						errorGroupGuid,
 						entityGuid,
 						request.occurrenceId,
-						request.timestamp
+						request.timestamp,
 					);
 				}
 			}
@@ -1509,7 +1509,7 @@ export class NewRelicProvider
 				`getNewRelicErrorGroupData hasRequest.entityGuid=${request.entityGuid != null}`,
 				{
 					request: request,
-				}
+				},
 			);
 
 			if (errorGroupFullResponse?.actor?.errorsInbox?.errorGroups?.results?.length) {
@@ -1583,7 +1583,7 @@ export class NewRelicProvider
 				let states;
 				if (errorGroupFullResponse.actor.errorsInbox.errorGroupStateTypes) {
 					states = errorGroupFullResponse.actor.errorsInbox.errorGroupStateTypes.map(
-						(_: ErrorGroupStateType) => _.type
+						(_: ErrorGroupStateType) => _.type,
 					);
 				}
 				errorGroup.states =
@@ -1604,7 +1604,7 @@ export class NewRelicProvider
 				}
 
 				const relatedRepos = this.findRelatedReposFromServiceEntity(
-					errorGroupFullResponse.actor.entity.relatedEntities.results
+					errorGroupFullResponse.actor.entity.relatedEntities.results,
 				);
 				if (errorGroup.entity && relatedRepos) {
 					errorGroup.entity["relatedRepos"] = relatedRepos;
@@ -1624,7 +1624,7 @@ export class NewRelicProvider
 						request: request,
 						entityGuid: entityGuid,
 						accountId: accountId,
-					}
+					},
 				);
 				return {
 					accountId: accountId,
@@ -1633,7 +1633,7 @@ export class NewRelicProvider
 						details: (await this.buildErrorDetailSettings(
 							accountId,
 							entityGuid,
-							errorGroupGuid
+							errorGroupGuid,
 						)) as any,
 					},
 				};
@@ -1658,7 +1658,7 @@ export class NewRelicProvider
 			result.details = (await this.buildErrorDetailSettings(
 				accountId,
 				entityGuid,
-				request.errorGroupGuid
+				request.errorGroupGuid,
 			)) as any;
 
 			return {
@@ -1683,7 +1683,7 @@ export class NewRelicProvider
 						email: _,
 						group: "GIT",
 					};
-				})
+				}),
 			);
 		}
 
@@ -1782,7 +1782,7 @@ export class NewRelicProvider
 				{
 					errorGroupGuid: request.errorGroupGuid,
 					state: request.state,
-				}
+				},
 			);
 
 			ContextLogger.log("errorsInboxUpdateErrorGroupState", {
@@ -1861,7 +1861,7 @@ export class NewRelicProvider
 					accountId: accountId,
 					name: name,
 					url: request.url,
-				}
+				},
 			);
 			ContextLogger.log("referenceEntityCreateOrUpdateRepository", {
 				accountId: accountId,
@@ -1895,7 +1895,7 @@ export class NewRelicProvider
 						accountId: accountId,
 						name: name,
 						url: request.url,
-					}
+					},
 				);
 			}
 
@@ -1919,7 +1919,7 @@ export class NewRelicProvider
 					{
 						sourceEntityGuid: entityId,
 						targetEntityGuid: repoEntityId,
-					}
+					},
 				);
 				ContextLogger.log("entityRelationshipUserDefinedCreateOrReplace", {
 					sourceEntityGuid: entityId,
@@ -1964,8 +1964,8 @@ export class NewRelicProvider
 					await Functions.withExponentialRetryBackoff(fn, 5, 1000);
 				ContextLogger.log(
 					`findRepositoryEntitiesByRepoRemotesResult result=${JSON.stringify(
-						findRepositoryEntitiesByRepoRemotesResult
-					)}`
+						findRepositoryEntitiesByRepoRemotesResult,
+					)}`,
 				);
 
 				return {
@@ -1992,7 +1992,7 @@ export class NewRelicProvider
 				};
 			} else {
 				ContextLogger.warn(
-					"entityId needed for entityRelationshipUserDefinedCreateOrReplace is null"
+					"entityId needed for entityRelationshipUserDefinedCreateOrReplace is null",
 				);
 				throw new Error("Could not locate entityId");
 			}
@@ -2029,7 +2029,7 @@ export class NewRelicProvider
 
 	getGoldenSignalsEntity(
 		codestreamUser: CSMe,
-		observabilityRepo: ObservabilityRepo
+		observabilityRepo: ObservabilityRepo,
 	): EntityAccount {
 		let entity: EntityAccount | undefined;
 		if (observabilityRepo.entityAccounts.length > 1) {
@@ -2039,11 +2039,11 @@ export class NewRelicProvider
 					const observabilityRepoEntities =
 						codestreamUser.preferences.observabilityRepoEntities || [];
 					const methodLevelTelemetryRepoEntity = observabilityRepoEntities.find(
-						_ => _.repoId === observabilityRepo.repoId
+						_ => _.repoId === observabilityRepo.repoId,
 					);
 					if (methodLevelTelemetryRepoEntity?.entityGuid) {
 						const foundEntity = observabilityRepo.entityAccounts.find(
-							_ => _.entityGuid === methodLevelTelemetryRepoEntity.entityGuid
+							_ => _.entityGuid === methodLevelTelemetryRepoEntity.entityGuid,
 						);
 						if (foundEntity) {
 							entity = foundEntity;
@@ -2056,7 +2056,7 @@ export class NewRelicProvider
 						// second, try to find something production-like based on name
 						if (
 							["prod", "production", "Production", "PRODUCTION"].find(
-								_ => entityAccount.entityName.indexOf(_) > -1
+								_ => entityAccount.entityName.indexOf(_) > -1,
 							)
 						) {
 							entity = entityAccount;
@@ -2069,7 +2069,7 @@ export class NewRelicProvider
 								if (
 									["env", "environment", "Environment"].includes(tag.key) &&
 									["prod", "production", "Production", "PRODUCTION"].find(value =>
-										tag.values.includes(value)
+										tag.values.includes(value),
 									)
 								) {
 									entity = entityAccount;
@@ -2109,7 +2109,7 @@ export class NewRelicProvider
 	@lspHandler(GetFileLevelTelemetryRequestType)
 	@log()
 	getFileLevelTelemetry(
-		request: GetFileLevelTelemetryRequest
+		request: GetFileLevelTelemetryRequest,
 	): Promise<GetFileLevelTelemetryResponse | NRErrorResponse | undefined> {
 		return this._clmManager.getFileLevelTelemetry(request);
 	}
@@ -2124,7 +2124,7 @@ export class NewRelicProvider
 	@lspHandler(GetMethodLevelTelemetryRequestType)
 	@log()
 	async getMethodLevelTelemetry(
-		request: GetMethodLevelTelemetryRequest
+		request: GetMethodLevelTelemetryRequest,
 	): Promise<GetMethodLevelTelemetryResponse | undefined> {
 		let observabilityRepo: ObservabilityRepo | undefined;
 		let entity: EntityAccount | undefined;
@@ -2138,7 +2138,7 @@ export class NewRelicProvider
 			entityAccounts = observabilityRepo.entityAccounts;
 
 			entity = observabilityRepo.entityAccounts.find(
-				_ => _.entityGuid === request.newRelicEntityGuid
+				_ => _.entityGuid === request.newRelicEntityGuid,
 			);
 			if (!entity) {
 				ContextLogger.warn("Missing entity", {
@@ -2153,7 +2153,7 @@ export class NewRelicProvider
 				request.newRelicEntityGuid || entity!.entityGuid!,
 				request.metricTimesliceNameMapping,
 				request.since,
-				request.timeseriesGroup
+				request.timeseriesGroup,
 			);
 
 			let deployments;
@@ -2173,7 +2173,7 @@ export class NewRelicProvider
 							request.metricTimesliceNameMapping,
 							observabilityRepo?.repoRemote || "",
 							request.since,
-							request.functionIdentifiers
+							request.functionIdentifiers,
 					  )
 					: [];
 
@@ -2200,20 +2200,20 @@ export class NewRelicProvider
 	@lspHandler(GetServiceLevelTelemetryRequestType)
 	@log()
 	async getServiceLevelTelemetry(
-		request: GetServiceLevelTelemetryRequest
+		request: GetServiceLevelTelemetryRequest,
 	): Promise<GetServiceLevelTelemetryResponse | undefined> {
 		const { force } = request;
 		const observabilityRepo = await this.getObservabilityEntityRepos(
 			request.repoId,
 			request.skipRepoFetch === true,
-			force
+			force,
 		);
 		if (!request.skipRepoFetch && (!observabilityRepo || !observabilityRepo.entityAccounts)) {
 			throw new ResponseError(ERROR_SLT_MISSING_OBSERVABILITY_REPOS, "No observabilityRepos");
 		}
 
 		const entity = observabilityRepo?.entityAccounts.find(
-			_ => _.entityGuid === request.newRelicEntityGuid
+			_ => _.entityGuid === request.newRelicEntityGuid,
 		);
 		if (!request.skipRepoFetch && !entity) {
 			ContextLogger.warn("Missing entity", {
@@ -2252,7 +2252,7 @@ export class NewRelicProvider
 	}
 
 	async getRecentAlertViolations(
-		entityGuid: string
+		entityGuid: string,
 	): Promise<GetAlertViolationsResponse | NRErrorResponse> {
 		try {
 			const response = await this.query<GetAlertViolationsQueryResult>(
@@ -2277,13 +2277,13 @@ export class NewRelicProvider
 				`,
 				{
 					entityGuid: entityGuid,
-				}
+				},
 			);
 
 			if (response?.actor?.entity) {
 				const entity = response?.actor?.entity;
 				const recentAlertViolationsArray = entity?.recentAlertViolations.filter(
-					_ => _.closedAt === null
+					_ => _.closedAt === null,
 				);
 
 				const ALERT_SEVERITY_SORTING_ORDER: string[] = [
@@ -2300,14 +2300,14 @@ export class NewRelicProvider
 
 				// sort based on openedAt time
 				recentAlertViolationsArrayUnique.sort((a, b) =>
-					a.openedAt > b.openedAt ? 1 : b.openedAt > a.openedAt ? -1 : 0
+					a.openedAt > b.openedAt ? 1 : b.openedAt > a.openedAt ? -1 : 0,
 				);
 
 				// sort based on alert serverity defined in ALERT_SEVERITY_SORTING_ORDER
 				const recentAlertViolationsArraySorted = this.mapOrder(
 					recentAlertViolationsArray,
 					ALERT_SEVERITY_SORTING_ORDER,
-					"alertSeverity"
+					"alertSeverity",
 				);
 
 				// take top 2
@@ -2349,7 +2349,7 @@ export class NewRelicProvider
 	async getObservabilityEntityRepos(
 		repoId: string,
 		skipRepoFetch = false,
-		force = false
+		force = false,
 	): Promise<ObservabilityRepo | undefined> {
 		let observabilityRepos: GetObservabilityReposResponse | undefined;
 		try {
@@ -2398,7 +2398,7 @@ export class NewRelicProvider
 
 	private async getMethodLevelGoldenMetricQueries(
 		entityGuid: string,
-		metricTimesliceNameMapping?: MetricTimesliceNameMapping
+		metricTimesliceNameMapping?: MetricTimesliceNameMapping,
 	): Promise<MethodLevelGoldenMetricQueryResult | undefined> {
 		if (!metricTimesliceNameMapping) {
 			return undefined;
@@ -2454,7 +2454,7 @@ export class NewRelicProvider
 		entityGuid: string,
 		metricTimesliceNames?: MetricTimesliceNameMapping,
 		since?: string,
-		timeseriesGroup?: string
+		timeseriesGroup?: string,
 	): Promise<MethodGoldenMetrics[] | undefined> {
 		const queries = await this.getMethodLevelGoldenMetricQueries(entityGuid, metricTimesliceNames);
 
@@ -2509,7 +2509,7 @@ export class NewRelicProvider
 				}).catch(ex => {
 					Logger.warn(ex);
 				});
-			})
+			}),
 		);
 
 		const response = queries.metricQueries.map((_, i) => {
@@ -2547,7 +2547,7 @@ export class NewRelicProvider
 	}
 
 	async getEntityLevelGoldenMetrics(
-		entityGuid: string
+		entityGuid: string,
 	): Promise<EntityGoldenMetrics | NRErrorResponse | undefined> {
 		try {
 			const entityGoldenMetricsQuery = `
@@ -2572,7 +2572,7 @@ export class NewRelicProvider
 			`;
 
 			const entityGoldenMetricsQueryResults = await this.query<EntityGoldenMetricsQueries>(
-				entityGoldenMetricsQuery
+				entityGoldenMetricsQuery,
 			);
 			const metricDefinitions =
 				entityGoldenMetricsQueryResults?.actor?.entity?.goldenMetrics?.metrics;
@@ -2662,7 +2662,7 @@ export class NewRelicProvider
 	@lspHandler(GetServiceLevelObjectivesRequestType)
 	@log()
 	async getServiceLevelObjectives(
-		request: GetServiceLevelObjectivesRequest
+		request: GetServiceLevelObjectivesRequest,
 	): Promise<GetServiceLevelObjectivesResponse | undefined> {
 		try {
 			const sliQuery = `{
@@ -2739,7 +2739,7 @@ export class NewRelicProvider
 						target: this.toFixedNoRounding(sliTarget, 2) ?? "Unknown",
 						timeWindow: this.formatSLOTimeWindow(
 							objective?.timeWindow?.rolling?.count,
-							objective?.timeWindow?.rolling?.unit
+							objective?.timeWindow?.rolling?.unit,
 						),
 						actual: this.toFixedNoRounding(actualValue, 2) ?? "Unknown",
 						result: actualValue < sliTarget ? "UNDER" : "OVER",
@@ -2779,7 +2779,7 @@ export class NewRelicProvider
 	@log()
 	private async getPrimaryEntityTransactionType(
 		accountId: number,
-		entityGuid: string
+		entityGuid: string,
 	): Promise<string> {
 		try {
 			const query = `{
@@ -2820,7 +2820,7 @@ export class NewRelicProvider
 			});
 
 			const primaryTransactionType = Object.keys(transactionTypeCountObject).reduce((a, b) =>
-				transactionTypeCountObject[a] > transactionTypeCountObject[b] ? a : b
+				transactionTypeCountObject[a] > transactionTypeCountObject[b] ? a : b,
 			);
 
 			return _isEmpty(primaryTransactionType) ? "Web" : primaryTransactionType;
@@ -2890,7 +2890,7 @@ export class NewRelicProvider
 						}
 					}
 				}`,
-				{}
+				{},
 			);
 			return response?.actor?.organization?.id;
 		} catch (ex) {
@@ -2904,7 +2904,7 @@ export class NewRelicProvider
 
 	private async fetchErrorGroupById(
 		errorGroupGuid: string,
-		timestamp?: number
+		timestamp?: number,
 	): Promise<ErrorGroup | undefined> {
 		try {
 			const timestampRange = this.generateTimestampRange(timestamp);
@@ -2940,7 +2940,7 @@ export class NewRelicProvider
 				  }`,
 				{
 					ids: [errorGroupGuid],
-				}
+				},
 			);
 			return response?.actor?.errorsInbox?.errorGroups?.results[0] || undefined;
 		} catch (ex) {
@@ -2964,7 +2964,7 @@ export class NewRelicProvider
 	@log()
 	private async fetchStackTrace(
 		entityGuid: string,
-		occurrenceId: number | string
+		occurrenceId: number | string,
 	): Promise<StackTraceResponse> {
 		let fingerprintId = 0;
 		try {
@@ -3051,7 +3051,7 @@ export class NewRelicProvider
 				entityGuid: entityGuid,
 				occurrenceId: occurrenceId,
 				fingerprintId: fingerprintId,
-			}
+			},
 		);
 	}
 
@@ -3060,7 +3060,7 @@ export class NewRelicProvider
 		accountId: number,
 		errorGroupGuid: string,
 		entityGuid: string,
-		timestamp?: number
+		timestamp?: number,
 	): Promise<ErrorGroupResponse> {
 		const timestampRange = this.generateTimestampRange(timestamp);
 		const q = `query getErrorGroup($accountId: Int!, $errorGroupGuids: [ID!], $entityGuid: EntityGuid!) {
@@ -3142,7 +3142,7 @@ export class NewRelicProvider
 		errorGroupGuid: string,
 		entityGuid: string,
 		occurrenceId?: string,
-		timestamp?: number
+		timestamp?: number,
 	): Promise<ErrorGroupResponse> {
 		let stackTracePromise;
 		if (entityGuid && occurrenceId) {
@@ -3163,7 +3163,7 @@ export class NewRelicProvider
 			accountId,
 			errorGroupGuid,
 			entityGuid,
-			timestamp
+			timestamp,
 		);
 		if (response?.actor?.errorsInbox?.errorGroups?.results?.length === 0) {
 			ContextLogger.warn("fetchErrorGroup (retrying without timestamp)", {
@@ -3180,11 +3180,11 @@ export class NewRelicProvider
 				if (response.actor.entity) {
 					response.actor.entity.crash = this.tryFormatStack(
 						stackTrace.actor.entity.entityType,
-						stackTrace.actor.entity.crash
+						stackTrace.actor.entity.crash,
 					);
 					response.actor.entity.exception = this.tryFormatStack(
 						stackTrace.actor.entity.entityType,
-						stackTrace.actor.entity.exception
+						stackTrace.actor.entity.exception,
 					);
 				}
 			}
@@ -3245,7 +3245,7 @@ export class NewRelicProvider
 	private async buildErrorDetailSettings(
 		accountId: number,
 		entityGuid: string,
-		errorGroupGuid: string
+		errorGroupGuid: string,
 	) {
 		let meUser = undefined;
 		const { users, session } = SessionContainer.instance();
@@ -3280,7 +3280,7 @@ export class NewRelicProvider
 					set.add(v.value);
 				});
 				return true;
-			})
+			}),
 		);
 
 		return Array.from(set);
@@ -3297,7 +3297,7 @@ export class NewRelicProvider
 	 */
 	protected async findRepositoryEntitiesByRepoRemotes(
 		remotes: string[],
-		force = false
+		force = false,
 	): Promise<RepoEntitiesByRemotesResponse | NRErrorResponse> {
 		const cacheKey = JSON.stringify(remotes);
 		if (!force) {
@@ -3353,7 +3353,7 @@ export class NewRelicProvider
 	}
 
 	protected async findClmSpanDataExists(
-		newRelicGuids: string[]
+		newRelicGuids: string[],
 	): Promise<ClmSpanData[] | NRErrorResponse> {
 		try {
 			const results = await Promise.all(
@@ -3374,7 +3374,7 @@ export class NewRelicProvider
 						this._clmSpanDataExistsCache.put(_, spanData);
 					}
 					return spanData;
-				})
+				}),
 			);
 
 			return results;
@@ -3387,7 +3387,7 @@ export class NewRelicProvider
 	private getFingerprintedErrorTraceQueries(
 		applicationGuid: String,
 		entityType?: EntityType,
-		timeWindow?: string
+		timeWindow?: string,
 	): String[] {
 		const since = timeWindow ? `${timeWindow} ago` : "3 days ago";
 		const apmNrql = [
@@ -3399,10 +3399,11 @@ export class NewRelicProvider
 			"latest(error.class) AS 'errorClass',",
 			"latest(message) AS 'message',",
 			"latest(entityGuid) AS 'entityGuid',",
+			"latest(fingerprint) AS 'fingerprintId',",
 			"count(id) AS 'length'",
 			"FROM ErrorTrace",
 			`WHERE fingerprint IS NOT NULL and entityGuid='${applicationGuid}'`,
-			"FACET fingerprint AS 'fingerPrintId'", // group the results by fingerprint
+			"FACET error.class, message", // group the results by identifiers
 			`SINCE ${since}`,
 			"LIMIT MAX",
 		].join(" ");
@@ -3480,7 +3481,7 @@ export class NewRelicProvider
 		accountId: number,
 		applicationGuid: string,
 		entityType?: EntityType,
-		timeWindow?: string
+		timeWindow?: string,
 	) {
 		const queries = this.getFingerprintedErrorTraceQueries(applicationGuid, entityType, timeWindow);
 
@@ -3497,7 +3498,7 @@ export class NewRelicProvider
 					  `,
 				{
 					accountId: accountId,
-				}
+				},
 			);
 			if (response.actor.account.nrql.results?.length) {
 				results.push(...response.actor.account.nrql.results);
@@ -3507,7 +3508,7 @@ export class NewRelicProvider
 	}
 
 	protected async findRelatedEntityByRepositoryGuids(
-		repositoryGuids: string[]
+		repositoryGuids: string[],
 	): Promise<RelatedEntityByRepositoryGuidsResult> {
 		return this.query(
 			`query fetchRelatedEntities($guids:[EntityGuid]!){
@@ -3554,7 +3555,7 @@ export class NewRelicProvider
 		  `,
 			{
 				guids: repositoryGuids,
-			}
+			},
 		);
 	}
 
@@ -3609,7 +3610,7 @@ export class NewRelicProvider
 		  `,
 			{
 				guid: repositoryGuid,
-			}
+			},
 		);
 	}
 
@@ -3617,7 +3618,7 @@ export class NewRelicProvider
 	private async getErrorGroupFromNameMessageEntity(
 		name: string,
 		message: string,
-		entityGuid: string
+		entityGuid: string,
 	) {
 		return this.query(
 			`query getErrorGroupGuid($name: String!, $message:String!, $entityGuid:EntityGuid!) {
@@ -3636,14 +3637,14 @@ export class NewRelicProvider
 				name: name,
 				message: message,
 				entityGuid: entityGuid,
-			}
+			},
 		);
 	}
 
 	@log({ timed: true })
 	private async getErrorsInboxAssignments(
 		emailAddress: string,
-		userId?: number
+		userId?: number,
 	): Promise<ErrorGroupsResponse | undefined> {
 		try {
 			if (userId == null || userId === 0) {
@@ -3670,7 +3671,7 @@ export class NewRelicProvider
 				{
 					userId: userId,
 					emailAddress: emailAddress,
-				}
+				},
 			);
 		} catch (ex) {
 			ContextLogger.warn("getErrorsInboxAssignments", {
@@ -3731,7 +3732,7 @@ export class NewRelicProvider
 			// NOTE: we need to add the date range or we risk missing results.
 			const errorTraceQuery = `${errorGroupResponse.eventsQuery.replace(
 				" TransactionError ",
-				" ErrorTrace "
+				" ErrorTrace ",
 			)} SINCE ${(errorGroupResponse.lastSeenAt || now) - 100000} until ${
 				(errorGroupResponse.lastSeenAt || now) + 100000
 			} ORDER BY timestamp DESC LIMIT 1`;
@@ -3789,14 +3790,14 @@ export class NewRelicProvider
 	}
 
 	private async findMappedRemoteByEntity(
-		entityGuid: string
+		entityGuid: string,
 	): Promise<RelatedRepoWithRemotes[] | undefined> {
 		if (!entityGuid) return undefined;
 
 		const relatedEntityResponse = await this.findRelatedEntityByRepositoryGuid(entityGuid);
 		if (relatedEntityResponse) {
 			let relatedRepoData = this.findRelatedReposFromServiceEntity(
-				relatedEntityResponse.actor.entity.relatedEntities.results
+				relatedEntityResponse.actor.entity.relatedEntities.results,
 			);
 
 			let relatedRepoDataWithRemotes;
@@ -3805,15 +3806,15 @@ export class NewRelicProvider
 				relatedRepoDataWithRemotes = await Promise.all(
 					relatedRepoData.map(
 						async (
-							_
+							_,
 						): Promise<{ url?: string; remotes?: string[]; error?: any; name?: string }> => {
 							let remotes = await this._memoizedBuildRepoRemoteVariants([_.url]);
 							if (!_isEmpty(remotes)) {
 								return { ..._, remotes };
 							}
 							return { ..._ };
-						}
-					)
+						},
+					),
 				);
 			}
 			Logger.log("findMappedRemoteByEntity", { entityGuid, relatedRepoDataWithRemotes });
@@ -3823,7 +3824,7 @@ export class NewRelicProvider
 		}
 		Logger.warn(
 			"findMappedRemoteByEntity: no response data from findRelatedEntityByRepositoryGuid",
-			entityGuid
+			entityGuid,
 		);
 		return undefined;
 	}
@@ -3847,7 +3848,7 @@ export class NewRelicProvider
 			{
 				email: request.emailAddress,
 				errorGroupGuid: request.errorGroupGuid,
-			}
+			},
 		);
 	}
 
@@ -3869,7 +3870,7 @@ export class NewRelicProvider
 			{
 				errorGroupGuid: request.errorGroupGuid,
 				userId: parseInt(request.userId, 10),
-			}
+			},
 		);
 	}
 
@@ -3919,7 +3920,7 @@ export class NewRelicProvider
 	}
 
 	private findRelatedReposFromServiceEntity(
-		relatedEntities: RelatedEntity[]
+		relatedEntities: RelatedEntity[],
 	): BuiltFromResult[] | undefined {
 		if (!relatedEntities || !relatedEntities.length) return undefined;
 
@@ -4005,7 +4006,7 @@ export class NewRelicProvider
 	 */
 	private generateTimestampRange(
 		timestampInMilliseconds?: number,
-		plusOrMinusInMinutes: number = 5
+		plusOrMinusInMinutes: number = 5,
 	): { startTime: number; endTime: number } | undefined {
 		try {
 			if (!timestampInMilliseconds || isNaN(timestampInMilliseconds)) return undefined;


### PR DESCRIPTION
Relevant code is on lines 3402 and 3406.

Errors Inbox doesn't group errors based on fingerprint; rather, they use metrics data and heuristics. This attempts to replicate what Errors Inbox as close as possible without major rewrites.