### PR TITLE
[FOSSA] Display vulnerabilities and license dependencies

### DIFF
--- a/shared/agent/src/providers/fossa.ts
+++ b/shared/agent/src/providers/fossa.ts
@@ -79,7 +79,7 @@ export class FossaProvider extends ThirdPartyCodeAnalyzerProviderBase<CSFossaPro
 		category: string,
 		page: number,
 		sort?: string,
-	) {
+	): string {
 		return `/issues?${qs.stringify({
 			category,
 			page,

--- a/shared/agent/src/providers/fossa.ts
+++ b/shared/agent/src/providers/fossa.ts
@@ -72,8 +72,13 @@ export class FossaProvider extends ThirdPartyCodeAnalyzerProviderBase<CSFossaPro
 	 * Query string for Fossa Issues API
 	 * @returns query string
 	 */
-	private _getIssuesUrl(params: any) {
-		const { category, page, sort, projectId, type } = params;
+	private _getIssuesUrl(
+		projectId: string,
+		type: string,
+		category: string,
+		page: number,
+		sort?: string,
+	) {
 		return `/issues?${qs.stringify({
 			category,
 			page,
@@ -189,8 +194,9 @@ export class FossaProvider extends ThirdPartyCodeAnalyzerProviderBase<CSFossaPro
 				return { issues: [] };
 			}
 
+			const { type, category, page, sort } = params;
 			const issueResponse = await this.get<VulnerabilityIssues | LicenseDependencyIssues>(
-				this._getIssuesUrl({ projectId: project.id, ...params }),
+				this._getIssuesUrl(project.id, type, category, page, sort),
 			);
 
 			return {

--- a/shared/agent/src/providers/fossa.ts
+++ b/shared/agent/src/providers/fossa.ts
@@ -4,8 +4,8 @@ import { isEmpty as _isEmpty } from "lodash-es";
 import {
 	FetchThirdPartyCodeAnalyzersRequest,
 	FetchThirdPartyCodeAnalyzersResponse,
-	FetchThirdPartyRepoMatchToFossaProjectRequest,
-	FetchThirdPartyRepoMatchToFossaProjectResponse,
+	FetchThirdPartyRepoMatchToFossaRequest,
+	FetchThirdPartyRepoMatchToFossaResponse,
 	ReposScm,
 	ThirdPartyProviderConfig,
 } from "@codestream/protocols/agent";
@@ -147,19 +147,19 @@ export class FossaProvider extends ThirdPartyCodeAnalyzerProviderBase<CSFossaPro
 	}
 
 	@log()
-	async fetchRepoMatchToFossaProject(
-		request: FetchThirdPartyRepoMatchToFossaProjectRequest,
-	): Promise<FetchThirdPartyRepoMatchToFossaProjectResponse> {
+	async fetchIsRepoMatch(
+		request: FetchThirdPartyRepoMatchToFossaRequest,
+	): Promise<FetchThirdPartyRepoMatchToFossaResponse> {
 		const [currentRepo] = await this.getCurrentRepo(request.repoId);
 		if (!currentRepo) {
-			return { matchedRepoToFossaProject: false };
+			return { isRepoMatch: false };
 		}
 		const projects: FossaProject[] = await this.getProjects();
 		const project = await this.matchRepoToFossaProject(currentRepo, projects, request.repoId);
 		if (_isEmpty(project)) {
-			return { matchedRepoToFossaProject: false };
+			return { isRepoMatch: false };
 		}
-		return { matchedRepoToFossaProject: true };
+		return { isRepoMatch: true };
 	}
 
 	@log()

--- a/shared/agent/src/providers/fossa.ts
+++ b/shared/agent/src/providers/fossa.ts
@@ -55,7 +55,624 @@ export class FossaProvider extends ThirdPartyCodeAnalyzerProviderBase<CSFossaPro
 		request: FetchThirdPartyCodeAnalyzersRequest
 	): Promise<FetchThirdPartyCodeAnalyzersResponse> {
 		return {
-			message: "HELLO WORLD",
+			issues: [
+				{
+					id: 3523803,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "nuget+DotNetBrowser32$1.20.0",
+						name: "DotNetBrowser32",
+						url: "https://www.teamdev.com/dotnetbrowser",
+						version: "1.20.0",
+						packageManager: "nuget",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "unlicensed_dependency",
+					license: null,
+				},
+				{
+					id: 3523805,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "nuget+DotNetBrowser64$1.20.0",
+						name: "DotNetBrowser64",
+						url: "https://www.teamdev.com/dotnetbrowser",
+						version: "1.20.0",
+						packageManager: "nuget",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "unlicensed_dependency",
+					license: null,
+				},
+				{
+					id: 3523807,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "nuget+Microsoft.VisualStudio.CommandBars$8.0.0.1",
+						name: "Microsoft.VisualStudio.CommandBars",
+						url: "https://aka.ms/vsextensibility",
+						version: "8.0.0.1",
+						packageManager: "nuget",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "unlicensed_dependency",
+					license: null,
+				},
+				{
+					id: 3523806,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "nuget+Microsoft.VisualStudio.LanguageServer.Client$16.2.1079",
+						name: "Microsoft.VisualStudio.LanguageServer.Client",
+						url: "https://aka.ms/vslsp",
+						version: "16.2.1079",
+						packageManager: "nuget",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "unlicensed_dependency",
+					license: null,
+				},
+				{
+					id: 3523810,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "nuget+Microsoft.VisualStudio.LanguageServer.Protocol$17.2.8",
+						name: "Microsoft.VisualStudio.LanguageServer.Protocol",
+						url: "https://aka.ms/vslsp",
+						version: "17.2.8",
+						packageManager: "nuget",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "unlicensed_dependency",
+					license: null,
+				},
+				{
+					id: 3523804,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "nuget+Microsoft.VisualStudio.LanguageServer.Protocol$16.2.1079",
+						name: "Microsoft.VisualStudio.LanguageServer.Protocol",
+						url: "https://aka.ms/vslsp",
+						version: "16.2.1079",
+						packageManager: "nuget",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "unlicensed_dependency",
+					license: null,
+				},
+				{
+					id: 3523808,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "nuget+Microsoft.VisualStudio.SDK$16.0.206",
+						name: "Microsoft.VisualStudio.SDK",
+						url: "https://aka.ms/vsextensibility",
+						version: "16.0.206",
+						packageManager: "nuget",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "unlicensed_dependency",
+					license: null,
+				},
+				{
+					id: 3523824,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "nuget+Microsoft.VSSDK.BuildTools$17.2.2186",
+						name: "Microsoft.VSSDK.BuildTools",
+						url: "https://aka.ms/vsextensibility",
+						version: "17.2.2186",
+						packageManager: "nuget",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "policy_flag",
+					details:
+						"Requires you to (effectively) disclose your source code if the library is statically linked to your project. Not triggered if dynamically linked or a separate process.",
+					license: "LGPL-3.0-only",
+				},
+				{
+					id: 3523809,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "nuget+Nerdbank.Streams$2.1.37",
+						name: "Nerdbank.Streams",
+						url: "https://github.com/AArnott/Nerdbank.Streams",
+						version: "2.1.37",
+						packageManager: "nuget",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "unlicensed_dependency",
+					license: null,
+				},
+				{
+					id: 3523825,
+					createdAt: "2023-06-23T19:32:05.784Z",
+					source: {
+						id: "npm+newrelic$9.8.1",
+						name: "newrelic",
+						url: "https://www.npmjs.com/package/newrelic",
+						version: "9.8.1",
+						packageManager: "npm",
+					},
+					depths: {
+						direct: 2,
+						deep: 0,
+					},
+					statuses: {
+						active: 2,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream-server",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream-server.git",
+						},
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "policy_flag",
+					details:
+						"Requires you to (effectively) disclose your source code if the library is statically linked to your project. Not triggered if dynamically linked or a separate process.",
+					license: "LGPL-3.0-only",
+				},
+				{
+					id: 3523822,
+					createdAt: "2023-06-23T19:32:05.784Z",
+					source: {
+						id: "npm+newrelic$9.8.1",
+						name: "newrelic",
+						url: "https://www.npmjs.com/package/newrelic",
+						version: "9.8.1",
+						packageManager: "npm",
+					},
+					depths: {
+						direct: 2,
+						deep: 0,
+					},
+					statuses: {
+						active: 2,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream-server",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream-server.git",
+						},
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "policy_flag",
+					details:
+						"Requires you to (effectively) disclose your source code if the library is statically linked to your project. Not triggered if dynamically linked or a separate process.",
+					license: "LGPL-3.0-or-later",
+				},
+				{
+					id: 3523814,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "npm+newrelic$9.14.1",
+						name: "newrelic",
+						url: "https://www.npmjs.com/package/newrelic",
+						version: "9.14.1",
+						packageManager: "npm",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "policy_flag",
+					details:
+						"Requires you to (effectively) disclose your source code if the library is statically linked to your project. Not triggered if dynamically linked or a separate process.",
+					license: "LGPL-3.0-only",
+				},
+				{
+					id: 3523815,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "npm+newrelic$9.15.0",
+						name: "newrelic",
+						url: "https://www.npmjs.com/package/newrelic",
+						version: "9.15.0",
+						packageManager: "npm",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "policy_flag",
+					details:
+						"Requires you to (effectively) disclose your source code if the library is statically linked to your project. Not triggered if dynamically linked or a separate process.",
+					license: "LGPL-3.0-or-later",
+				},
+				{
+					id: 3523816,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "npm+newrelic$9.15.0",
+						name: "newrelic",
+						url: "https://www.npmjs.com/package/newrelic",
+						version: "9.15.0",
+						packageManager: "npm",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "policy_flag",
+					details:
+						"Requires you to (effectively) disclose your source code if the library is statically linked to your project. Not triggered if dynamically linked or a separate process.",
+					license: "LGPL-3.0-only",
+				},
+				{
+					id: 3523817,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "npm+newrelic$9.7.1",
+						name: "newrelic",
+						url: "https://www.npmjs.com/package/newrelic",
+						version: "9.7.1",
+						packageManager: "npm",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "policy_flag",
+					details:
+						"Requires you to (effectively) disclose your source code if the library is statically linked to your project. Not triggered if dynamically linked or a separate process.",
+					license: "LGPL-3.0-or-later",
+				},
+				{
+					id: 3523818,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "npm+newrelic$9.7.1",
+						name: "newrelic",
+						url: "https://www.npmjs.com/package/newrelic",
+						version: "9.7.1",
+						packageManager: "npm",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "policy_flag",
+					details:
+						"Requires you to (effectively) disclose your source code if the library is statically linked to your project. Not triggered if dynamically linked or a separate process.",
+					license: "LGPL-3.0-only",
+				},
+				{
+					id: 3523819,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "npm+newrelic$9.7.4",
+						name: "newrelic",
+						url: "https://www.npmjs.com/package/newrelic",
+						version: "9.7.4",
+						packageManager: "npm",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "policy_flag",
+					details:
+						"Requires you to (effectively) disclose your source code if the library is statically linked to your project. Not triggered if dynamically linked or a separate process.",
+					license: "LGPL-3.0-or-later",
+				},
+				{
+					id: 3523820,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "npm+newrelic$9.7.5",
+						name: "newrelic",
+						url: "https://www.npmjs.com/package/newrelic",
+						version: "9.7.5",
+						packageManager: "npm",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "policy_flag",
+					details:
+						"Requires you to (effectively) disclose your source code if the library is statically linked to your project. Not triggered if dynamically linked or a separate process.",
+					license: "LGPL-3.0-or-later",
+				},
+				{
+					id: 3523821,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "npm+newrelic$9.7.4",
+						name: "newrelic",
+						url: "https://www.npmjs.com/package/newrelic",
+						version: "9.7.4",
+						packageManager: "npm",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "policy_flag",
+					details:
+						"Requires you to (effectively) disclose your source code if the library is statically linked to your project. Not triggered if dynamically linked or a separate process.",
+					license: "LGPL-3.0-only",
+				},
+				{
+					id: 3523811,
+					createdAt: "2023-06-23T19:06:36.425Z",
+					source: {
+						id: "npm+newrelic$9.13.0",
+						name: "newrelic",
+						url: "https://www.npmjs.com/package/newrelic",
+						version: "9.13.0",
+						packageManager: "npm",
+					},
+					depths: {
+						direct: 1,
+						deep: 0,
+					},
+					statuses: {
+						active: 1,
+						ignored: 0,
+					},
+					projects: [
+						{
+							id: "custom+38453/github.com/TeamCodeStream/codestream",
+							status: "active",
+							depth: 1,
+							title: "https://github.com/TeamCodeStream/codestream.git",
+						},
+					],
+					type: "policy_flag",
+					details:
+						"Requires you to (effectively) disclose your source code if the library is statically linked to your project. Not triggered if dynamically linked or a separate process.",
+					license: "LGPL-3.0-or-later",
+				},
+			],
 		};
 	}
 }

--- a/shared/agent/src/providers/fossa.ts
+++ b/shared/agent/src/providers/fossa.ts
@@ -1,6 +1,5 @@
 import Cache from "timed-cache";
 import * as qs from "querystring";
-import { isEmpty as _isEmpty } from "lodash-es";
 import {
 	FetchThirdPartyCodeAnalyzersRequest,
 	FetchThirdPartyLicenseDependenciesResponse,
@@ -139,7 +138,7 @@ export class FossaProvider extends ThirdPartyCodeAnalyzerProviderBase<CSFossaPro
 		currentRepo: ReposScm,
 		fossaProjects: FossaProject[],
 		repoId?: string,
-	): Promise<FossaProject | Record<string, never>> {
+	): Promise<FossaProject | undefined> {
 		if (repoId) {
 			for (const project of fossaProjects) {
 				let parsed;
@@ -161,7 +160,7 @@ export class FossaProvider extends ThirdPartyCodeAnalyzerProviderBase<CSFossaPro
 				}
 			}
 		}
-		return {};
+		return;
 	}
 
 	@log()
@@ -174,7 +173,7 @@ export class FossaProvider extends ThirdPartyCodeAnalyzerProviderBase<CSFossaPro
 		}
 		const projects: FossaProject[] = await this._getProjects();
 		const project = await this._matchRepoToFossaProject(currentRepo, projects, request.repoId);
-		if (_isEmpty(project)) {
+		if (!project) {
 			return { isRepoMatch: false };
 		}
 		return { isRepoMatch: true };
@@ -193,7 +192,7 @@ export class FossaProvider extends ThirdPartyCodeAnalyzerProviderBase<CSFossaPro
 
 			const projects: FossaProject[] = await this._getProjects();
 			const project = await this._matchRepoToFossaProject(currentRepo, projects, request.repoId);
-			if (_isEmpty(project)) {
+			if (!project) {
 				return { issues: [] };
 			}
 
@@ -226,7 +225,7 @@ export class FossaProvider extends ThirdPartyCodeAnalyzerProviderBase<CSFossaPro
 
 			const projects: FossaProject[] = await this._getProjects();
 			const project = await this._matchRepoToFossaProject(currentRepo, projects, request.repoId);
-			if (_isEmpty(project)) {
+			if (!project) {
 				return { issues: [] };
 			}
 

--- a/shared/agent/src/providers/provider.ts
+++ b/shared/agent/src/providers/provider.ts
@@ -21,8 +21,8 @@ import {
 	FetchThirdPartyCardWorkflowResponse,
 	FetchThirdPartyChannelsRequest,
 	FetchThirdPartyChannelsResponse,
-	FetchThirdPartyRepoMatchToFossaProjectRequest,
-	FetchThirdPartyRepoMatchToFossaProjectResponse,
+	FetchThirdPartyRepoMatchToFossaRequest,
+	FetchThirdPartyRepoMatchToFossaResponse,
 	FetchThirdPartyCodeAnalyzersRequest,
 	FetchThirdPartyCodeAnalyzersResponse,
 	FetchThirdPartyPullRequestCommitsRequest,
@@ -148,9 +148,9 @@ export interface ThirdPartyProviderSupportsCodeAnalyzers {
 		params: IssueParams,
 	): Promise<FetchThirdPartyCodeAnalyzersResponse>;
 
-	fetchRepoMatchToFossaProject(
-		request: FetchThirdPartyRepoMatchToFossaProjectRequest,
-	): Promise<FetchThirdPartyRepoMatchToFossaProjectResponse>;
+	fetchIsRepoMatch(
+		request: FetchThirdPartyRepoMatchToFossaRequest,
+	): Promise<FetchThirdPartyRepoMatchToFossaResponse>;
 }
 
 export namespace ThirdPartyIssueProvider {

--- a/shared/agent/src/providers/provider.ts
+++ b/shared/agent/src/providers/provider.ts
@@ -24,7 +24,6 @@ import {
 	FetchThirdPartyRepoMatchToFossaRequest,
 	FetchThirdPartyRepoMatchToFossaResponse,
 	FetchThirdPartyCodeAnalyzersRequest,
-	FetchThirdPartyCodeAnalyzersResponse,
 	FetchThirdPartyPullRequestCommitsRequest,
 	FetchThirdPartyPullRequestCommitsResponse,
 	FetchThirdPartyPullRequestRequest,
@@ -39,6 +38,8 @@ import {
 	ThirdPartyProviderConfig,
 	UpdateThirdPartyStatusRequest,
 	UpdateThirdPartyStatusResponse,
+	FetchThirdPartyLicenseDependenciesResponse,
+	FetchThirdPartyVulnerabilitiesResponse,
 } from "@codestream/protocols/agent";
 import { CSMe, CSProviderInfos } from "@codestream/protocols/api";
 import { Response } from "node-fetch";
@@ -143,10 +144,15 @@ export interface ThirdPartyProviderSupportsBuilds {
 }
 
 export interface ThirdPartyProviderSupportsCodeAnalyzers {
-	fetchCodeAnalysis(
+	fetchLicenseDependencies(
 		request: FetchThirdPartyCodeAnalyzersRequest,
 		params: IssueParams,
-	): Promise<FetchThirdPartyCodeAnalyzersResponse>;
+	): Promise<FetchThirdPartyLicenseDependenciesResponse>;
+
+	fetchVulnerabilities(
+		request: FetchThirdPartyCodeAnalyzersRequest,
+		params: IssueParams,
+	): Promise<FetchThirdPartyVulnerabilitiesResponse>;
 
 	fetchIsRepoMatch(
 		request: FetchThirdPartyRepoMatchToFossaRequest,
@@ -203,7 +209,11 @@ export namespace ThirdPartyCodeAnalyzerProvider {
 	export function supportsCodeAnalysis(
 		provider: ThirdPartyCodeAnalyzerProvider,
 	): provider is ThirdPartyCodeAnalyzerProvider & ThirdPartyProviderSupportsCodeAnalyzers {
-		return (provider as any).fetchCodeAnalysis !== undefined;
+		return (
+			(provider as any).fetchIsRepoMatch !== undefined &&
+			(provider as any).fetchLicenseDependencies !== undefined &&
+			(provider as any).fetchVulnerabilities !== undefined
+		);
 	}
 }
 

--- a/shared/agent/src/providers/provider.ts
+++ b/shared/agent/src/providers/provider.ts
@@ -21,6 +21,8 @@ import {
 	FetchThirdPartyCardWorkflowResponse,
 	FetchThirdPartyChannelsRequest,
 	FetchThirdPartyChannelsResponse,
+	FetchThirdPartyRepoMatchToFossaProjectRequest,
+	FetchThirdPartyRepoMatchToFossaProjectResponse,
 	FetchThirdPartyCodeAnalyzersRequest,
 	FetchThirdPartyCodeAnalyzersResponse,
 	FetchThirdPartyPullRequestCommitsRequest,
@@ -44,6 +46,8 @@ import { Response } from "node-fetch";
 import { SessionContainer } from "../container";
 import { GitRemote, GitRemoteLike, GitRepository } from "../git/gitService";
 import { Logger } from "../logger";
+
+import { IssueParams } from "../../../util/src/protocol/agent/agent.protocol.fossa";
 
 export const providerDisplayNamesByNameKey = new Map<string, string>([
 	["asana", "Asana"],
@@ -74,7 +78,7 @@ export interface ThirdPartyProviderSupportsIssues {
 	getCards(request: FetchThirdPartyCardsRequest): Promise<FetchThirdPartyCardsResponse>;
 
 	getCardWorkflow(
-		request: FetchThirdPartyCardWorkflowRequest
+		request: FetchThirdPartyCardWorkflowRequest,
 	): Promise<FetchThirdPartyCardWorkflowResponse>;
 
 	moveCard(request: MoveThirdPartyCardRequest): Promise<MoveThirdPartyCardResponse>;
@@ -82,7 +86,7 @@ export interface ThirdPartyProviderSupportsIssues {
 	getAssignableUsers(request: FetchAssignableUsersRequest): Promise<FetchAssignableUsersResponse>;
 
 	getAssignableUsersAutocomplete(
-		request: FetchAssignableUsersAutocompleteRequest
+		request: FetchAssignableUsersAutocompleteRequest,
 	): Promise<FetchAssignableUsersResponse>;
 
 	createCard(request: CreateThirdPartyCardRequest): Promise<CreateThirdPartyCardResponse>;
@@ -108,29 +112,29 @@ export interface ThirdPartyProviderSupportsPullRequests {
 	getOwnerFromRemote(remote: string): { owner: string; name: string };
 	getPullRequestsContainigSha(
 		repoIdentifier: { owner: string; name: string }[],
-		sha: string
+		sha: string,
 	): Promise<any[]>;
 }
 
 export interface ThirdPartyProviderSupportsCreatingPullRequests
 	extends ThirdPartyProviderSupportsPullRequests {
 	createPullRequest(
-		request: ProviderCreatePullRequestRequest
+		request: ProviderCreatePullRequestRequest,
 	): Promise<ProviderCreatePullRequestResponse | undefined>;
 }
 
 export interface ThirdPartyProviderSupportsViewingPullRequests
 	extends ThirdPartyProviderSupportsPullRequests {
 	getPullRequest(
-		request: FetchThirdPartyPullRequestRequest
+		request: FetchThirdPartyPullRequestRequest,
 	): Promise<FetchThirdPartyPullRequestResponse>;
 
 	getPullRequestCommits(
-		request: FetchThirdPartyPullRequestCommitsRequest
+		request: FetchThirdPartyPullRequestCommitsRequest,
 	): Promise<FetchThirdPartyPullRequestCommitsResponse>;
 
 	getMyPullRequests(
-		request: GetMyPullRequestsRequest
+		request: GetMyPullRequestsRequest,
 	): Promise<GetMyPullRequestsResponse[][] | undefined>;
 }
 
@@ -140,13 +144,18 @@ export interface ThirdPartyProviderSupportsBuilds {
 
 export interface ThirdPartyProviderSupportsCodeAnalyzers {
 	fetchCodeAnalysis(
-		request: FetchThirdPartyCodeAnalyzersRequest
+		request: FetchThirdPartyCodeAnalyzersRequest,
+		params: IssueParams,
 	): Promise<FetchThirdPartyCodeAnalyzersResponse>;
+
+	fetchRepoMatchToFossaProject(
+		request: FetchThirdPartyRepoMatchToFossaProjectRequest,
+	): Promise<FetchThirdPartyRepoMatchToFossaProjectResponse>;
 }
 
 export namespace ThirdPartyIssueProvider {
 	export function supportsIssues(
-		provider: ThirdPartyProvider
+		provider: ThirdPartyProvider,
 	): provider is ThirdPartyProvider & ThirdPartyProviderSupportsIssues {
 		return (
 			(provider as any).getBoards !== undefined &&
@@ -156,13 +165,13 @@ export namespace ThirdPartyIssueProvider {
 	}
 
 	export function supportsViewingPullRequests(
-		provider: ThirdPartyProvider
+		provider: ThirdPartyProvider,
 	): provider is ThirdPartyProvider & ThirdPartyProviderSupportsPullRequests {
 		return (provider as any).getMyPullRequests !== undefined;
 	}
 
 	export function supportsCreatingPullRequests(
-		provider: ThirdPartyProvider
+		provider: ThirdPartyProvider,
 	): provider is ThirdPartyProvider & ThirdPartyProviderSupportsPullRequests {
 		return (provider as any).createPullRequest !== undefined;
 	}
@@ -170,13 +179,13 @@ export namespace ThirdPartyIssueProvider {
 
 export namespace ThirdPartyPostProvider {
 	export function supportsSharing(
-		provider: ThirdPartyPostProvider
+		provider: ThirdPartyPostProvider,
 	): provider is ThirdPartyPostProvider & ThirdPartyProviderSupportsPosts {
 		return (provider as any).createPost !== undefined;
 	}
 
 	export function supportsStatus(
-		provider: ThirdPartyProvider
+		provider: ThirdPartyProvider,
 	): provider is ThirdPartyProvider & ThirdPartyProviderSupportsStatus {
 		return (provider as any).updateStatus !== undefined;
 	}
@@ -184,7 +193,7 @@ export namespace ThirdPartyPostProvider {
 
 export namespace ThirdPartyBuildProvider {
 	export function supportsBuilds(
-		provider: ThirdPartyBuildProvider
+		provider: ThirdPartyBuildProvider,
 	): provider is ThirdPartyBuildProvider & ThirdPartyProviderSupportsBuilds {
 		return (provider as any).fetchBuilds !== undefined;
 	}
@@ -192,7 +201,7 @@ export namespace ThirdPartyBuildProvider {
 
 export namespace ThirdPartyCodeAnalyzerProvider {
 	export function supportsCodeAnalysis(
-		provider: ThirdPartyCodeAnalyzerProvider
+		provider: ThirdPartyCodeAnalyzerProvider,
 	): provider is ThirdPartyCodeAnalyzerProvider & ThirdPartyProviderSupportsCodeAnalyzers {
 		return (provider as any).fetchCodeAnalysis !== undefined;
 	}
@@ -272,7 +281,7 @@ interface RefreshableProviderInfo {
 }
 
 export function isRefreshable<TProviderInfo extends CSProviderInfos>(
-	providerInfo: TProviderInfo
+	providerInfo: TProviderInfo,
 ): providerInfo is TProviderInfo & RefreshableProviderInfo {
 	return typeof (providerInfo as any).expiresAt === "number";
 }
@@ -351,7 +360,7 @@ export interface PullRequestComment {
 export async function getOpenedRepos<R>(
 	predicate: (remote: GitRemote) => boolean,
 	queryFn: (path: string) => Promise<ApiResponse<R>>,
-	remoteRepos: Map<string, R>
+	remoteRepos: Map<string, R>,
 ): Promise<Map<string, R>> {
 	const openRepos = new Map<string, R>();
 
@@ -389,7 +398,7 @@ export async function getOpenedRepos<R>(
 export async function getRemotePaths<R extends { path: string }>(
 	repo: GitRepository | undefined,
 	predicate: (remote: GitRemote) => boolean,
-	remoteRepos: Map<string, R>
+	remoteRepos: Map<string, R>,
 ): Promise<string[] | undefined> {
 	try {
 		if (repo === undefined) return undefined;

--- a/shared/agent/src/providers/registry.ts
+++ b/shared/agent/src/providers/registry.ts
@@ -54,9 +54,9 @@ import {
 	FetchThirdPartyPullRequestCommitsType,
 	FetchThirdPartyPullRequestRequest,
 	FetchThirdPartyPullRequestRequestType,
-	FetchThirdPartyRepoMatchToFossaProjectRequest,
-	FetchThirdPartyRepoMatchToFossaProjectRequestType,
-	FetchThirdPartyRepoMatchToFossaProjectResponse,
+	FetchThirdPartyRepoMatchToFossaRequest,
+	FetchThirdPartyRepoMatchToFossaRequestType,
+	FetchThirdPartyRepoMatchToFossaResponse,
 	FetchThirdPartyVulnerabilitiesRequestType,
 	FetchThirdPartyVulnerabilitiesResponse,
 	GetMyPullRequestsResponse,
@@ -862,10 +862,10 @@ export class ThirdPartyProviderRegistry {
 	}
 
 	@log()
-	@lspHandler(FetchThirdPartyRepoMatchToFossaProjectRequestType)
-	async fetchRepoMatchToFossaProject(
-		request: FetchThirdPartyRepoMatchToFossaProjectRequest,
-	): Promise<FetchThirdPartyRepoMatchToFossaProjectResponse> {
+	@lspHandler(FetchThirdPartyRepoMatchToFossaRequestType)
+	async fetchIsRepoMatch(
+		request: FetchThirdPartyRepoMatchToFossaRequest,
+	): Promise<FetchThirdPartyRepoMatchToFossaResponse> {
 		const provider = getProvider(request.providerId);
 		if (provider === undefined) {
 			throw new Error(`No registered provider for '${request.providerId}'`);
@@ -880,7 +880,7 @@ export class ThirdPartyProviderRegistry {
 			throw new Error(`Provider(${provider.name}) doesn't support code analyzers`);
 		}
 
-		const response = await codeAnalyzersProvider.fetchRepoMatchToFossaProject(request);
+		const response = await codeAnalyzersProvider.fetchIsRepoMatch(request);
 		return response;
 	}
 

--- a/shared/agent/src/providers/registry.ts
+++ b/shared/agent/src/providers/registry.ts
@@ -48,12 +48,17 @@ import {
 	FetchThirdPartyChannelsRequestType,
 	FetchThirdPartyChannelsResponse,
 	FetchThirdPartyCodeAnalyzersRequest,
-	FetchThirdPartyCodeAnalyzersRequestType,
-	FetchThirdPartyCodeAnalyzersResponse,
+	FetchThirdPartyLicenseDependenciesRequestType,
+	FetchThirdPartyLicenseDependenciesResponse,
 	FetchThirdPartyPullRequestCommitsRequest,
 	FetchThirdPartyPullRequestCommitsType,
 	FetchThirdPartyPullRequestRequest,
 	FetchThirdPartyPullRequestRequestType,
+	FetchThirdPartyRepoMatchToFossaProjectRequest,
+	FetchThirdPartyRepoMatchToFossaProjectRequestType,
+	FetchThirdPartyRepoMatchToFossaProjectResponse,
+	FetchThirdPartyVulnerabilitiesRequestType,
+	FetchThirdPartyVulnerabilitiesResponse,
 	GetMyPullRequestsResponse,
 	MoveThirdPartyCardRequest,
 	MoveThirdPartyCardRequestType,
@@ -166,7 +171,7 @@ export class ThirdPartyProviderRegistry {
 		this._pollingInterval = Functions.repeatInterval(
 			this.pullRequestsStateHandler.bind(this),
 			2000,
-			900000
+			900000,
 		); // every 15 minutes
 		return this;
 	}
@@ -187,7 +192,7 @@ export class ThirdPartyProviderRegistry {
 					name === "gitlab_enterprise" ||
 					name === "bitbucket"
 				);
-			}
+			},
 		);
 		const providersPullRequests: ProviderPullRequests[] = [];
 
@@ -234,7 +239,7 @@ export class ThirdPartyProviderRegistry {
 			toastPrNotify;
 		if (!result) {
 			Logger.log(
-				`Skipping PR toast notify due to user settings notificationDelivery: ${notificationDelivery}, toastPrNotify: ${toastPrNotify}`
+				`Skipping PR toast notify due to user settings notificationDelivery: ${notificationDelivery}, toastPrNotify: ${toastPrNotify}`,
 			);
 		}
 		return result;
@@ -250,7 +255,7 @@ export class ThirdPartyProviderRegistry {
 							return pullRequests[pullRequests.length - 1].createdAt;
 						}
 						return 0;
-					}
+					},
 				);
 				return {
 					providerId: providerPRs.providerId,
@@ -262,7 +267,7 @@ export class ThirdPartyProviderRegistry {
 
 		providersPRs.map(providerPRs => {
 			const previousProviderPRs = this._lastProvidersPRs?.find(
-				_ => _.providerId === providerPRs.providerId
+				_ => _.providerId === providerPRs.providerId,
 			);
 			if (!previousProviderPRs) {
 				return;
@@ -272,19 +277,19 @@ export class ThirdPartyProviderRegistry {
 			providerPRs.queriedPullRequests.map(
 				(pullRequests: GetMyPullRequestsResponse[], index: number) => {
 					const ageLimit = this._queriedPRsAgeLimit?.find(
-						_ => _.providerId === providerPRs.providerId
+						_ => _.providerId === providerPRs.providerId,
 					);
 					const actualPRs = pullRequests.filter(
-						pr => pr.createdAt >= (ageLimit ? ageLimit.ageLimit[index] : 0)
+						pr => pr.createdAt >= (ageLimit ? ageLimit.ageLimit[index] : 0),
 					);
 					queriedPullRequests.push(
 						differenceWith(
 							actualPRs,
 							previousProviderPRs.queriedPullRequests[index],
-							(value, other) => value.id === other.id
-						)
+							(value, other) => value.id === other.id,
+						),
 					);
-				}
+				},
 			);
 
 			newProvidersPRs.push({
@@ -305,9 +310,9 @@ export class ThirdPartyProviderRegistry {
 					...pullRequests.map(pullRequest => ({
 						queryName: PR_QUERIES[_.providerId][queryIndex].name!,
 						pullRequest,
-					}))
+					})),
 				);
-			})
+			}),
 		);
 
 		if (prNotificationMessages.length > 0) {
@@ -323,7 +328,7 @@ export class ThirdPartyProviderRegistry {
 	@log()
 	@lspHandler(ConnectThirdPartyProviderRequestType)
 	async connect(
-		request: ConnectThirdPartyProviderRequest
+		request: ConnectThirdPartyProviderRequest,
 	): Promise<ConnectThirdPartyProviderResponse> {
 		const provider = getProvider(request.providerId);
 		if (provider === undefined) {
@@ -336,7 +341,7 @@ export class ThirdPartyProviderRegistry {
 	@log()
 	@lspHandler(ConfigureThirdPartyProviderRequestType)
 	async configure(
-		request: ConfigureThirdPartyProviderRequest
+		request: ConfigureThirdPartyProviderRequest,
 	): Promise<ConfigureThirdPartyProviderResponse> {
 		const provider = getProvider(request.providerId);
 		if (provider === undefined) {
@@ -350,7 +355,7 @@ export class ThirdPartyProviderRegistry {
 	@log()
 	@lspHandler(AddEnterpriseProviderRequestType)
 	async addEnterpriseProvider(
-		request: AddEnterpriseProviderRequest
+		request: AddEnterpriseProviderRequest,
 	): Promise<AddEnterpriseProviderResponse> {
 		const provider = getProvider(request.providerId);
 		if (provider === undefined) {
@@ -372,7 +377,7 @@ export class ThirdPartyProviderRegistry {
 	@log()
 	@lspHandler(DisconnectThirdPartyProviderRequestType)
 	async disconnect(
-		request: DisconnectThirdPartyProviderRequest
+		request: DisconnectThirdPartyProviderRequest,
 	): Promise<DisconnectThirdPartyProviderResponse> {
 		const provider = getProvider(request.providerId);
 		if (provider === undefined) return {};
@@ -473,7 +478,7 @@ export class ThirdPartyProviderRegistry {
 	@log()
 	@lspHandler(FetchThirdPartyCardWorkflowRequestType)
 	fetchCardWorkflow(
-		request: FetchThirdPartyCardWorkflowRequest
+		request: FetchThirdPartyCardWorkflowRequest,
 	): Promise<FetchThirdPartyCardWorkflowResponse> {
 		const provider = getProvider(request.providerId);
 		if (provider === undefined) {
@@ -536,7 +541,7 @@ export class ThirdPartyProviderRegistry {
 	@log()
 	@lspHandler(FetchThirdPartyChannelsRequestType)
 	async getChannels(
-		request: FetchThirdPartyChannelsRequest
+		request: FetchThirdPartyChannelsRequest,
 	): Promise<FetchThirdPartyChannelsResponse> {
 		const provider = getProvider(request.providerId);
 		if (provider === undefined) {
@@ -558,7 +563,7 @@ export class ThirdPartyProviderRegistry {
 	@log()
 	@lspHandler(UpdateThirdPartyStatusRequestType)
 	async updateStatus(
-		request: UpdateThirdPartyStatusRequest
+		request: UpdateThirdPartyStatusRequest,
 	): Promise<UpdateThirdPartyStatusResponse> {
 		const provider = getProvider(request.providerId);
 		if (provider === undefined) {
@@ -620,7 +625,7 @@ export class ThirdPartyProviderRegistry {
 	}
 
 	async createPullRequest(
-		request: ProviderCreatePullRequestRequest
+		request: ProviderCreatePullRequestRequest,
 	): Promise<ProviderCreatePullRequestResponse | undefined> {
 		const provider = getProvider(request.providerId);
 		if (provider === undefined) {
@@ -756,7 +761,7 @@ export class ThirdPartyProviderRegistry {
 					if (fn && fn({ domain: uri.authority, uri: uri })) {
 						const id = provider.getConfig().id;
 						Logger.log(
-							`queryThirdParty: found matching provider for ${uri.authority}. providerId=${id}`
+							`queryThirdParty: found matching provider for ${uri.authority}. providerId=${id}`,
 						);
 						return {
 							providerId: id,
@@ -801,10 +806,10 @@ export class ThirdPartyProviderRegistry {
 	}
 
 	@log()
-	@lspHandler(FetchThirdPartyCodeAnalyzersRequestType)
-	async fetchCodeAnalysis(
-		request: FetchThirdPartyCodeAnalyzersRequest
-	): Promise<FetchThirdPartyCodeAnalyzersResponse> {
+	@lspHandler(FetchThirdPartyLicenseDependenciesRequestType)
+	async fetchLicenseDependencies(
+		request: FetchThirdPartyCodeAnalyzersRequest,
+	): Promise<FetchThirdPartyLicenseDependenciesResponse> {
 		const provider = getProvider(request.providerId);
 		if (provider === undefined) {
 			throw new Error(`No registered provider for '${request.providerId}'`);
@@ -819,14 +824,70 @@ export class ThirdPartyProviderRegistry {
 			throw new Error(`Provider(${provider.name}) doesn't support code analyzers`);
 		}
 
-		const response = await codeAnalyzersProvider.fetchCodeAnalysis(request);
+		const response = await codeAnalyzersProvider.fetchCodeAnalysis(request, {
+			category: "licensing",
+			type: "project",
+			page: 1,
+		});
+
+		return response;
+	}
+
+	@log()
+	@lspHandler(FetchThirdPartyVulnerabilitiesRequestType)
+	async fetchVulnerabilities(
+		request: FetchThirdPartyCodeAnalyzersRequest,
+	): Promise<FetchThirdPartyVulnerabilitiesResponse> {
+		const provider = getProvider(request.providerId);
+		if (provider === undefined) {
+			throw new Error(`No registered provider for '${request.providerId}'`);
+		}
+
+		const codeAnalyzersProvider = provider as ThirdPartyCodeAnalyzerProvider;
+		if (
+			codeAnalyzersProvider == null ||
+			typeof codeAnalyzersProvider.supportsCodeAnalysis !== "function" ||
+			!codeAnalyzersProvider.supportsCodeAnalysis()
+		) {
+			throw new Error(`Provider(${provider.name}) doesn't support code analyzers`);
+		}
+
+		const response = await codeAnalyzersProvider.fetchCodeAnalysis(request, {
+			category: "vulnerability",
+			sort: "package_asc",
+			type: "project",
+			page: 1,
+		});
+		return response;
+	}
+
+	@log()
+	@lspHandler(FetchThirdPartyRepoMatchToFossaProjectRequestType)
+	async fetchRepoMatchToFossaProject(
+		request: FetchThirdPartyRepoMatchToFossaProjectRequest,
+	): Promise<FetchThirdPartyRepoMatchToFossaProjectResponse> {
+		const provider = getProvider(request.providerId);
+		if (provider === undefined) {
+			throw new Error(`No registered provider for '${request.providerId}'`);
+		}
+
+		const codeAnalyzersProvider = provider as ThirdPartyCodeAnalyzerProvider;
+		if (
+			codeAnalyzersProvider == null ||
+			typeof codeAnalyzersProvider.supportsCodeAnalysis !== "function" ||
+			!codeAnalyzersProvider.supportsCodeAnalysis()
+		) {
+			throw new Error(`Provider(${provider.name}) doesn't support code analyzers`);
+		}
+
+		const response = await codeAnalyzersProvider.fetchRepoMatchToFossaProject(request);
 		return response;
 	}
 
 	@log()
 	@lspHandler(FetchProviderDefaultPullRequestsType)
 	async getProviderDefaultPullRequestQueries(
-		_request: FetchProviderDefaultPullRequest
+		_request: FetchProviderDefaultPullRequest,
 	): Promise<FetchProviderDefaultPullResponse> {
 		const response: FetchProviderDefaultPullResponse = {
 			"github*com": [
@@ -974,7 +1035,7 @@ export class ThirdPartyProviderRegistry {
 	}
 
 	getPullRequestProvider(
-		provider: ThirdPartyProvider
+		provider: ThirdPartyProvider,
 	): ThirdPartyIssueProvider & ThirdPartyProviderSupportsViewingPullRequests {
 		const pullRequestProvider = provider as ThirdPartyIssueProvider;
 		if (
@@ -999,14 +1060,14 @@ export class ThirdPartyProviderRegistry {
 	getConnectedProviders(user: CSMe): ThirdPartyProvider[];
 	getConnectedProviders<T extends ThirdPartyProvider>(
 		user: CSMe,
-		predicate: (p: ThirdPartyProvider) => p is T
+		predicate: (p: ThirdPartyProvider) => p is T,
 	): T[];
 	getConnectedProviders<T extends ThirdPartyProvider>(
 		user: CSMe,
-		predicate?: (p: ThirdPartyProvider) => boolean
+		predicate?: (p: ThirdPartyProvider) => boolean,
 	) {
 		return this.getProviders(
-			(p): p is T => p.isConnected(user) && (predicate == null || predicate(p))
+			(p): p is T => p.isConnected(user) && (predicate == null || predicate(p)),
 		);
 	}
 
@@ -1014,7 +1075,7 @@ export class ThirdPartyProviderRegistry {
 		try {
 			if (!providerId) return false;
 			const providers = this.getProviders().filter(
-				(_: ThirdPartyProvider) => _.getConfig().id === providerId
+				(_: ThirdPartyProvider) => _.getConfig().id === providerId,
 			);
 			if (!providers || !providers.length) return false;
 			return this.getPullRequestProvider(providers[0]);
@@ -1030,7 +1091,7 @@ export class ThirdPartyProviderRegistry {
 	 * @param user
 	 */
 	async getConnectedPullRequestProviders(
-		user: CSMe
+		user: CSMe,
 	): Promise<(ThirdPartyProvider & ThirdPartyProviderSupportsPullRequests)[]> {
 		const connectedProviders = this.getConnectedProviders(
 			user,
@@ -1045,7 +1106,7 @@ export class ThirdPartyProviderRegistry {
 					name === "bitbucket" ||
 					name === "bitbucket_server"
 				);
-			}
+			},
 		);
 		return connectedProviders;
 	}

--- a/shared/agent/src/providers/registry.ts
+++ b/shared/agent/src/providers/registry.ts
@@ -48,8 +48,8 @@ import {
 	FetchThirdPartyChannelsRequestType,
 	FetchThirdPartyChannelsResponse,
 	FetchThirdPartyCodeAnalyzersRequest,
-	FetchThirdPartyLicenseDependenciesRequestType,
 	FetchThirdPartyLicenseDependenciesResponse,
+	FetchThirdPartyLicenseDependenciesRequestType,
 	FetchThirdPartyPullRequestCommitsRequest,
 	FetchThirdPartyPullRequestCommitsType,
 	FetchThirdPartyPullRequestRequest,
@@ -57,8 +57,8 @@ import {
 	FetchThirdPartyRepoMatchToFossaRequest,
 	FetchThirdPartyRepoMatchToFossaRequestType,
 	FetchThirdPartyRepoMatchToFossaResponse,
-	FetchThirdPartyVulnerabilitiesRequestType,
 	FetchThirdPartyVulnerabilitiesResponse,
+	FetchThirdPartyVulnerabilitiesRequestType,
 	GetMyPullRequestsResponse,
 	MoveThirdPartyCardRequest,
 	MoveThirdPartyCardRequestType,
@@ -824,7 +824,7 @@ export class ThirdPartyProviderRegistry {
 			throw new Error(`Provider(${provider.name}) doesn't support code analyzers`);
 		}
 
-		const response = await codeAnalyzersProvider.fetchCodeAnalysis(request, {
+		const response = await codeAnalyzersProvider.fetchLicenseDependencies(request, {
 			category: "licensing",
 			type: "project",
 			page: 1,
@@ -852,7 +852,7 @@ export class ThirdPartyProviderRegistry {
 			throw new Error(`Provider(${provider.name}) doesn't support code analyzers`);
 		}
 
-		const response = await codeAnalyzersProvider.fetchCodeAnalysis(request, {
+		const response = await codeAnalyzersProvider.fetchVulnerabilities(request, {
 			category: "vulnerability",
 			sort: "package_asc",
 			type: "project",

--- a/shared/agent/src/providers/thirdPartyCodeAnalyzerProviderBase.ts
+++ b/shared/agent/src/providers/thirdPartyCodeAnalyzerProviderBase.ts
@@ -9,7 +9,7 @@ import {
 import { ThirdPartyProviderBase } from "./thirdPartyProviderBase";
 
 export abstract class ThirdPartyCodeAnalyzerProviderBase<
-		TProviderInfo extends CSProviderInfos = CSProviderInfos
+		TProviderInfo extends CSProviderInfos = CSProviderInfos,
 	>
 	extends ThirdPartyProviderBase<TProviderInfo>
 	implements ThirdPartyCodeAnalyzerProvider

--- a/shared/ui/Authentication/actions.ts
+++ b/shared/ui/Authentication/actions.ts
@@ -54,7 +54,6 @@ import { localStore } from "../utilities/storage";
 import { emptyObject, uuid } from "../utils";
 import { HostApi } from "../webview-api";
 import { WebviewPanels } from "@codestream/webview/ipc/webview.protocol.common";
-import { setUserPreferences } from "../Stream/actions";
 
 export enum SignupType {
 	JoinTeam = "joinTeam",

--- a/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
@@ -6,7 +6,7 @@ import {
 	VulnerabilityIssue,
 	FetchThirdPartyLicenseDependenciesRequestType,
 	FetchThirdPartyVulnerabilitiesRequestType,
-	FetchThirdPartyRepoMatchToFossaProjectRequestType,
+	FetchThirdPartyRepoMatchToFossaRequestType,
 } from "@codestream/protocols/agent";
 import { HostApi } from "@codestream/webview/webview-api";
 import { CodeStreamState } from "@codestream/webview/store";
@@ -112,30 +112,25 @@ export const CodeAnalyzers = (props: Props) => {
 		props.paneState,
 	]);
 
-	const fetchMatchRepoToFossaProject = async (): Promise<boolean | undefined> => {
-		if (!derivedState.currentRepo) {
-			return;
-		}
-		let matchedRepoToFossaProject;
+	const fetchMatchRepoToFossa = async (): Promise<boolean | undefined> => {
+		if (!(derivedState.activeFile || currentRepoId === null)) return;
+
+		let isRepoMatch;
 		const [providerId] = derivedState.fossaProvider ?? [];
 		try {
 			if (providerId) {
-				const result = await HostApi.instance.send(
-					FetchThirdPartyRepoMatchToFossaProjectRequestType,
-					{
-						providerId,
-						repoId: derivedState.currentRepoId || currentRepoId,
-					},
-				);
-				if (result.matchedRepoToFossaProject !== undefined) {
-					matchedRepoToFossaProject = result.matchedRepoToFossaProject;
+				const result = await HostApi.instance.send(FetchThirdPartyRepoMatchToFossaRequestType, {
+					providerId,
+					repoId: currentRepoId,
+				});
+				if (result.isRepoMatch !== undefined) {
+					isRepoMatch = result.isRepoMatch;
 				}
 			}
 		} catch (error) {
 			console.error(error);
 		}
-
-		return matchedRepoToFossaProject;
+		return isRepoMatch;
 	};
 
 	const fetchVulnerabilities = async (): Promise<VulnerabilityIssue[]> => {

--- a/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
@@ -58,6 +58,7 @@ export const CodeAnalyzers = (props: Props) => {
 		const hasActiveFile =
 			!editorContext?.textEditorUri?.includes("terminal") &&
 			editorContext?.activeFile &&
+			editorContext?.activeFile &&
 			editorContext?.activeFile.length > 0;
 
 		const hasRemotes = currentRepo?.remotes && currentRepo?.remotes.length > 0;
@@ -74,7 +75,7 @@ export const CodeAnalyzers = (props: Props) => {
 	}, shallowEqual);
 
 	useEffect(() => {
-		if (props.reposLoading || props.paneState === PaneState.Collapsed) {
+		if (props.paneState === PaneState.Collapsed) {
 			return;
 		}
 		if (!derivedState.hasActiveFile) {
@@ -180,7 +181,7 @@ export const CodeAnalyzers = (props: Props) => {
 		if (currentRepoId && isRepoMatched === false) {
 			return "Project not found on FOSSA";
 		}
-		if (!derivedState.hasRemotes && derivedState.hasActiveFile) {
+		if (derivedState.hasRemotes === false && derivedState.hasActiveFile) {
 			return "Repo does not have a git remote, try another repo.";
 		}
 		return "";

--- a/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
@@ -7,6 +7,7 @@ import { getUserProviderInfoFromState } from "@codestream/webview/store/provider
 import { useMemoizedState } from "@codestream/webview/utilities/hooks";
 import { WebviewPanels } from "@codestream/webview/ipc/webview.protocol.common";
 import { PaneBody, PaneHeader, PaneState } from "@codestream/webview/src/components/Pane";
+import Icon from "../Icon";
 import { ConnectFossa } from "./ConnectFossa";
 import { FossaResults } from "./FossaResults";
 import { CurrentRepoContext } from "@codestream/webview/Stream/CurrentRepoContext";

--- a/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
@@ -80,10 +80,12 @@ export const CodeAnalyzers = (props: Props) => {
 					const isRepoMatch: boolean | undefined = await fetchMatchRepoToFossa();
 					setIsRepoMatched(isRepoMatch);
 					if (isRepoMatch) {
-						await fetchCodeAnalysis();
+						await fetchLicenseDependencies();
 						await fetchVulnerabilities();
+						setLoading(false);
+					} else {
+						setLoading(false);
 					}
-					setLoading(false);
 				}
 			} catch (error) {
 				console.error("Error fetching data:", error);
@@ -114,7 +116,6 @@ export const CodeAnalyzers = (props: Props) => {
 	};
 
 	const fetchVulnerabilities = async (): Promise<void> => {
-		let vulnerabilities: VulnerabilityIssue[] = [];
 		if (vulnLoading) return;
 		setVulnLoading(true);
 		if (!currentRepoId) {
@@ -122,6 +123,7 @@ export const CodeAnalyzers = (props: Props) => {
 			return;
 		}
 
+		let vulnerabilities: VulnerabilityIssue[] = [];
 		const [providerId] = derivedState.fossaProvider ?? [];
 		try {
 			if (providerId) {
@@ -138,10 +140,9 @@ export const CodeAnalyzers = (props: Props) => {
 		}
 		setVulnIssues(vulnerabilities);
 		setVulnLoading(false);
-		setLoading(false);
 	};
 
-	const fetchCodeAnalysis = async (): Promise<void> => {
+	const fetchLicenseDependencies = async (): Promise<void> => {
 		if (licDeploading) return;
 		setLicDepLoading(true);
 
@@ -166,7 +167,6 @@ export const CodeAnalyzers = (props: Props) => {
 		}
 		setLicenseDepIssues(licenseDepIssues);
 		setLicDepLoading(false);
-		setLoading(false);
 		return;
 	};
 

--- a/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
@@ -187,7 +187,7 @@ export const CodeAnalyzers = (props: Props) => {
 		return "";
 	};
 
-	const hasConditonalText = conditionalText();
+	const hasConditionalText = conditionalText();
 
 	return (
 		<>
@@ -206,8 +206,8 @@ export const CodeAnalyzers = (props: Props) => {
 					{loaded && derivedState.hasReposOpened && !derivedState.hasActiveFile && (
 						<NoContent>Open a source file to see FOSSA results.</NoContent>
 					)}
-					{loaded && hasConditonalText && (
-						<div style={{ padding: "0 20px" }}>{hasConditonalText}</div>
+					{loaded && hasConditionalText && (
+						<div style={{ padding: "0 20px" }}>{hasConditionalText}</div>
 					)}
 				</PaneBody>
 			)}

--- a/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
@@ -182,10 +182,12 @@ export const CodeAnalyzers = (props: Props) => {
 					{!derivedState.bootstrapped && <ConnectFossa />}
 					{derivedState.bootstrapped && loading && <FossaLoading />}
 					{derivedState.bootstrapped &&
+						!loading &&
 						currentRepoId &&
 						isRepoMatched &&
-						derivedState.activeFile?.length &&
-						!loading && <FossaIssues issues={licenseDepIssues} vulnIssues={vulnIssues} />}
+						derivedState.activeFile?.length && (
+							<FossaIssues issues={licenseDepIssues} vulnIssues={vulnIssues} />
+						)}
 					{derivedState.bootstrapped && !derivedState.activeFile?.length && !loading && (
 						<div style={{ padding: "0 20px" }}>Open a source file to see FOSSA results.</div>
 					)}

--- a/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
@@ -78,10 +78,6 @@ export const CodeAnalyzers = (props: Props) => {
 		if (props.paneState === PaneState.Collapsed) {
 			return;
 		}
-		if (!derivedState.hasActiveFile) {
-			setLoading(false);
-			return;
-		}
 
 		const fetchData = async (): Promise<void> => {
 			try {

--- a/shared/ui/Stream/CodeAnalyzers/FossaIssues.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/FossaIssues.tsx
@@ -111,17 +111,9 @@ function LibraryRow(props: { vuln }) {
 }
 
 function VulnRow(props: { vuln }) {
-	const [expanded, setExpanded] = useState<boolean>(false);
-
 	return (
 		<>
-			<Row
-				style={{ padding: "0 10px 0 40px" }}
-				className={"pr-row"}
-				onClick={() => {
-					setExpanded(!expanded);
-				}}
-			>
+			<Row style={{ padding: "0 10px 0 40px" }} className={"pr-row"}>
 				<div></div>
 				<div>{props.vuln.title}</div>
 			</Row>
@@ -157,7 +149,9 @@ export const FossaIssues = React.memo((props: Props) => {
 				</>
 			)}
 			{vulnExpanded && props.vulnIssues && props.vulnIssues.length === 0 && (
-				<Row style={{ padding: "0 10px 0 40px" }}>👍 No vulnerabilities found</Row>
+				<Row style={{ padding: "0 10px 0 30px" }}>
+					<div>👍 No vulnerability issues found</div>
+				</Row>
 			)}
 			<Row
 				style={{
@@ -181,7 +175,9 @@ export const FossaIssues = React.memo((props: Props) => {
 				</>
 			)}
 			{licenseDepExpanded && props.issues?.length === 0 && (
-				<Row style={{ padding: "0 10px 0 40px" }}>👍 No license dependency issues found</Row>
+				<Row style={{ padding: "0 10px 0 30px" }}>
+					<div>👍 No license dependency issues found</div>
+				</Row>
 			)}
 		</>
 	);

--- a/shared/ui/Stream/CodeAnalyzers/FossaIssues.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/FossaIssues.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { lowerCase } from "lodash-es";
+import { lowerCase, upperCase } from "lodash-es";
 import styled from "styled-components";
 import {
 	LicenseDependencyIssue,
@@ -57,7 +57,7 @@ function Severity(props: { severity: VulnSeverity }) {
 }
 
 function criticalityToRiskSeverity(riskSeverity: VulnSeverity): VulnSeverity {
-	switch (riskSeverity) {
+	switch (upperCase(riskSeverity)) {
 		case "CRITICAL":
 			return "CRITICAL";
 		case "HIGH":

--- a/shared/ui/Stream/CodeAnalyzers/FossaIssues.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/FossaIssues.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from "react";
+import { lowerCase } from "lodash-es";
+import styled from "styled-components";
+import { LicenseDependency, riskSeverityList, RiskSeverity } from "@codestream/protocols/agent";
+import Icon from "../Icon";
+import Tooltip from "../Tooltip";
+import { Row } from "../CrossPostIssueControls/IssuesPane";
+import { MenuItem } from "@codestream/webview/src/components/controls/InlineMenu";
+
+const StyledSpan = styled.span`
+	margin-left: 2px;
+	margin-right: 5px;
+`;
+
+interface Props {
+	issues: LicenseDependency[];
+}
+
+function LicenseDependencyRow(props: { licenseDependency }) {
+	const { licenseDependency } = props;
+	const { source } = licenseDependency;
+	const licenseText = licenseDependency.license ? licenseDependency.license : "No license found";
+	const licenseIssueText = `${licenseText} in ${source.name} (${source.version})`;
+
+	return (
+		<>
+			<Row style={{ padding: "0 10px 0 30px" }} className={"pr-row"}>
+				<div></div>
+				<div>
+					<Tooltip placement="bottom" title={licenseIssueText} delay={1}>
+						<span>{licenseIssueText}</span>
+					</Tooltip>
+				</div>
+			</Row>
+		</>
+	);
+}
+
+export const FossaIssues = React.memo((props: Props) => {
+	const [licenseDepExpanded, setLicenseDepExpanded] = useState<boolean>(false);
+	const [selectedItems, setSelectedItems] = useState<RiskSeverity[]>(["CRITICAL", "HIGH"]);
+
+	function handleSelect(severity: RiskSeverity) {
+		if (selectedItems.includes(severity)) {
+			setSelectedItems(selectedItems.filter(_ => _ !== severity));
+		} else {
+			setSelectedItems([...selectedItems, severity]);
+		}
+	}
+
+	const menuItems: MenuItem[] = riskSeverityList.map(severity => {
+		return {
+			label: lowerCase(severity),
+			key: severity,
+			checked: selectedItems.includes(severity),
+			action: () => handleSelect(severity),
+		};
+	});
+
+	return (
+		<>
+			<Row
+				style={{
+					padding: "0px 10px 0px 20px",
+					alignItems: "baseline",
+				}}
+				className="licenseDep"
+				onClick={() => {
+					setLicenseDepExpanded(!licenseDepExpanded);
+				}}
+			>
+				{licenseDepExpanded && <Icon name="chevron-down-thin" />}
+				{!licenseDepExpanded && <Icon name="chevron-right-thin" />}
+				<StyledSpan>License Dependencies</StyledSpan>
+			</Row>
+			{licenseDepExpanded && props.issues?.length > 0 && (
+				<>
+					{props.issues.map(issue => {
+						return <LicenseDependencyRow licenseDependency={issue} />;
+					})}
+					{/* <Additional onClick={loadAll} additional={additional} /> */}
+				</>
+			)}
+			{licenseDepExpanded && props.issues?.length === 0 && (
+				<Row style={{ padding: "0 10px 0 49px" }}>👍 No license dependency issues found</Row>
+			)}
+		</>
+	);
+});

--- a/shared/ui/Stream/CodeAnalyzers/FossaLoading.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/FossaLoading.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { SkeletonLoader } from "@codestream/webview/Stream/SkeletonLoader";
+
+export const FossaLoading = () => {
+	return (
+		<>
+			<SkeletonLoader style={{ width: "50%", marginLeft: "20px" }} />
+			<SkeletonLoader style={{ width: "70%", marginLeft: "20px" }} />
+		</>
+	);
+};

--- a/shared/ui/Stream/CodeAnalyzers/FossaResults.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/FossaResults.tsx
@@ -1,9 +1,0 @@
-import React from "react";
-
-interface Props {
-	message: string;
-}
-
-export const FossaResults = (props: Props) => {
-	return <>{props.message}</>;
-};

--- a/shared/ui/Stream/Sidebar.tsx
+++ b/shared/ui/Stream/Sidebar.tsx
@@ -115,7 +115,7 @@ export const Sidebar = React.memo(function Sidebar() {
 		}
 		if (isFeatureEnabled(state, "PDIdev")) {
 			sidebarPaneOrder = sidebarPaneOrder.filter(
-				_ => _ !== WebviewPanels.OpenReviews && _ !== WebviewPanels.CodemarksForFile
+				_ => _ !== WebviewPanels.OpenReviews && _ !== WebviewPanels.CodemarksForFile,
 			);
 		}
 		return {
@@ -131,6 +131,7 @@ export const Sidebar = React.memo(function Sidebar() {
 	}, shallowEqual);
 	const { sidebarPanes } = derivedState;
 	const [openRepos, setOpenRepos] = useState<ReposScm[]>(EMPTY_ARRAY);
+	const [reposLoading, setReposLoading] = useState<boolean>(true);
 	const [dragCombinedHeight, setDragCombinedHeight] = useState<number | undefined>(undefined);
 	// const [previousSizes, setPreviousSizes] = useState(EMPTY_HASH);
 	const [sizes, setSizes] = useState(EMPTY_HASH);
@@ -154,6 +155,7 @@ export const Sidebar = React.memo(function Sidebar() {
 		if (response && response.repositories) {
 			setOpenRepos(response.repositories);
 		}
+		setReposLoading(false);
 		requestAnimationFrame(() => {
 			setInitialRender(false);
 		});
@@ -349,11 +351,11 @@ export const Sidebar = React.memo(function Sidebar() {
 		if (firstIndex === undefined || secondIndex === undefined) return;
 		const firstId = positions[firstIndex].id;
 		dispatch(
-			setUserPreference({ prefPath: ["sidebarPanes", firstId, "size"], value: sizes[firstId] })
+			setUserPreference({ prefPath: ["sidebarPanes", firstId, "size"], value: sizes[firstId] }),
 		);
 		const secondId = positions[secondIndex].id;
 		dispatch(
-			setUserPreference({ prefPath: ["sidebarPanes", secondId, "size"], value: sizes[secondId] })
+			setUserPreference({ prefPath: ["sidebarPanes", secondId, "size"], value: sizes[secondId] }),
 		);
 	};
 
@@ -411,7 +413,9 @@ export const Sidebar = React.memo(function Sidebar() {
 			case WebviewPanels.CICD:
 				return <CICD openRepos={openRepos} paneState={paneState} />;
 			case WebviewPanels.CodeAnalyzers:
-				return <CodeAnalyzers openRepos={openRepos} paneState={paneState} />;
+				return (
+					<CodeAnalyzers openRepos={openRepos} reposLoading={reposLoading} paneState={paneState} />
+				);
 		}
 		return null;
 	};

--- a/shared/util/src/protocol/agent/agent.protocol.fossa.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.fossa.ts
@@ -1,4 +1,4 @@
-export interface LicenseDependencyIssue {
+interface BaseIssueType {
 	id: number;
 	createdAt: string;
 	source: {
@@ -25,44 +25,32 @@ export interface LicenseDependencyIssue {
 		}
 	];
 	type: string;
-	details?: string;
-	license?: string;
 }
 
-export interface VulnerabilityIssue {
-	id: number;
-	createdAt: string;
-	source: {
-		id: string;
-		name: string;
-		url: string;
-		version: string;
-		packageManager: string;
-	};
-	depths: {
-		direct: number;
-		deep: number;
-	};
-	statuses: {
-		active: number;
-		ignored: number;
-	};
-	projects: [
-		{
-			id: string;
-			status: string;
-			depth: number;
-			title: string;
-		}
-	];
-	type: string;
-	vulnId?: string;
-	title?: string;
-	cve?: string;
-	cvss?: number;
-	severity?: string;
+export interface LicenseDependencyIssue extends BaseIssueType {
 	details?: string;
-	remediation?: string;
+	license: string;
+}
+
+interface Metric {
+	name: string;
+	value: string;
+}
+export interface VulnerabilityIssue extends BaseIssueType {
+	vulnId: string;
+	title: string;
+	cve: string;
+	cvss: number;
+	severity: string;
+	details: string;
+	remediation: string;
+	metrics: Metric[];
+	cveStatus: string;
+	cwes: string[];
+	published: string;
+	affectedVersionRanges: string[];
+	patchedVersionRanges: string[];
+	references: string[];
 }
 
 export interface FossaProject {
@@ -96,7 +84,7 @@ export interface VulnerabilityIssues {
 
 export interface IssueParams {
 	category: string;
-	sort?: string;
 	type: string;
 	page: number;
+	sort?: string;
 }

--- a/shared/util/src/protocol/agent/agent.protocol.fossa.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.fossa.ts
@@ -1,0 +1,102 @@
+export interface LicenseDependencyIssue {
+	id: number;
+	createdAt: string;
+	source: {
+		id: string;
+		name: string;
+		url: string;
+		version: string;
+		packageManager: string;
+	};
+	depths: {
+		direct: number;
+		deep: number;
+	};
+	statuses: {
+		active: number;
+		ignored: number;
+	};
+	projects: [
+		{
+			id: string;
+			status: string;
+			depth: number;
+			title: string;
+		}
+	];
+	type: string;
+	details?: string;
+	license?: string;
+}
+
+export interface VulnerabilityIssue {
+	id: number;
+	createdAt: string;
+	source: {
+		id: string;
+		name: string;
+		url: string;
+		version: string;
+		packageManager: string;
+	};
+	depths: {
+		direct: number;
+		deep: number;
+	};
+	statuses: {
+		active: number;
+		ignored: number;
+	};
+	projects: [
+		{
+			id: string;
+			status: string;
+			depth: number;
+			title: string;
+		}
+	];
+	type: string;
+	vulnId?: string;
+	title?: string;
+	cve?: string;
+	cvss?: number;
+	severity?: string;
+	details?: string;
+	remediation?: string;
+}
+
+export interface FossaProject {
+	id: string;
+	title: string;
+	branch: string;
+	version: string;
+	type: string;
+	public: boolean;
+	scanned: string;
+	issues: {
+		total: number;
+		licensing: number;
+		security: number;
+		quality: number;
+	};
+	labels?: string[];
+}
+
+export interface GetFossaProjectsResponse {
+	projects: FossaProject[];
+}
+
+export interface LicenseDependencyIssues {
+	issues: LicenseDependencyIssue[];
+}
+
+export interface VulnerabilityIssues {
+	issues: VulnerabilityIssue[];
+}
+
+export interface IssueParams {
+	category: string;
+	sort?: string;
+	type: string;
+	page: number;
+}

--- a/shared/util/src/protocol/agent/agent.protocol.providers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.providers.ts
@@ -495,8 +495,26 @@ export interface FetchThirdPartyCodeAnalyzersRequest {
 	providerId: string;
 }
 
+interface CodeAnalyzerProject {
+	id: string;
+	status: string;
+	depth: number;
+	title: string;
+}
+
+export interface LicenseDependency {
+	id: number;
+	createdAt: string;
+	source: { id: string; name: string; url: string; version: string; packageManager: string };
+	depths: { direct: number; deep: number };
+	statuses: { active: number; ignored: number };
+	projects: CodeAnalyzerProject[];
+	type?: string | null;
+	details?: string | null;
+	license?: string | null;
+}
 export interface FetchThirdPartyCodeAnalyzersResponse {
-	message: string;
+	[issues: string]: LicenseDependency[];
 }
 
 export const FetchThirdPartyCodeAnalyzersRequestType = new RequestType<

--- a/shared/util/src/protocol/agent/agent.protocol.providers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.providers.ts
@@ -543,17 +543,17 @@ export const FetchThirdPartyVulnerabilitiesRequestType = new RequestType<
 	void
 >("codestream/provider/vulnerablitlies");
 
-export interface FetchThirdPartyRepoMatchToFossaProjectRequest {
+export interface FetchThirdPartyRepoMatchToFossaRequest {
 	providerId: string;
 	repoId?: string;
 }
-export interface FetchThirdPartyRepoMatchToFossaProjectResponse {
-	matchedRepoToFossaProject: boolean;
+export interface FetchThirdPartyRepoMatchToFossaResponse {
+	isRepoMatch: boolean;
 }
 
-export const FetchThirdPartyRepoMatchToFossaProjectRequestType = new RequestType<
-	FetchThirdPartyRepoMatchToFossaProjectRequest,
-	FetchThirdPartyRepoMatchToFossaProjectResponse,
+export const FetchThirdPartyRepoMatchToFossaRequestType = new RequestType<
+	FetchThirdPartyRepoMatchToFossaRequest,
+	FetchThirdPartyRepoMatchToFossaResponse,
 	void,
 	void
 >("codestream/provider/fossaRepoMatch");

--- a/shared/util/src/protocol/agent/agent.protocol.providers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.providers.ts
@@ -495,23 +495,6 @@ export const FetchThirdPartyBuildsRequestType = new RequestType<
 export interface FetchThirdPartyCodeAnalyzersRequest {
 	providerId: string;
 	repoId?: string;
-	params: IssueParams;
-}
-export interface FetchThirdPartyCodeAnalyzersResponse {
-	issues?: LicenseDependencyIssue[] | VulnerabilityIssue[];
-	error?: string; // CHECK THE TYPE! could be object
-}
-
-export const FetchThirdPartyCodeAnalyzersRequestType = new RequestType<
-	FetchThirdPartyLicenseDependenciesRequest,
-	FetchThirdPartyLicenseDependenciesResponse,
-	void,
-	void
->("codestream/provider/codeAnalyzers");
-
-export interface FetchThirdPartyLicenseDependenciesRequest {
-	providerId: string;
-	repoId?: string;
 }
 export interface FetchThirdPartyLicenseDependenciesResponse {
 	issues?: LicenseDependencyIssue[];
@@ -519,29 +502,25 @@ export interface FetchThirdPartyLicenseDependenciesResponse {
 }
 
 export const FetchThirdPartyLicenseDependenciesRequestType = new RequestType<
-	FetchThirdPartyLicenseDependenciesRequest,
+	FetchThirdPartyCodeAnalyzersRequest,
 	FetchThirdPartyLicenseDependenciesResponse,
 	void,
 	void
 >("codestream/provider/licenseDependencies");
 
-export { LicenseDependencyIssue, VulnerabilityIssue } from "./agent.protocol.fossa";
-
-export interface FetchThirdPartyVulnerabilitiesRequest {
-	providerId: string;
-	repoId?: string;
-}
 export interface FetchThirdPartyVulnerabilitiesResponse {
 	issues?: VulnerabilityIssue[];
 	error?: string; // CHECK THE TYPE! could be object
 }
 
 export const FetchThirdPartyVulnerabilitiesRequestType = new RequestType<
-	FetchThirdPartyVulnerabilitiesRequest,
+	FetchThirdPartyCodeAnalyzersRequest,
 	FetchThirdPartyVulnerabilitiesResponse,
 	void,
 	void
 >("codestream/provider/vulnerablitlies");
+
+export { LicenseDependencyIssue, VulnerabilityIssue } from "./agent.protocol.fossa";
 
 export interface FetchThirdPartyRepoMatchToFossaRequest {
 	providerId: string;

--- a/shared/util/src/protocol/agent/agent.protocol.providers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.providers.ts
@@ -9,6 +9,7 @@ import {
 } from "./agent.protocol";
 import { CodeErrorPlus } from "./agent.protocol.codeErrors";
 import { CodemarkPlus } from "./agent.protocol.codemarks";
+import { IssueParams, LicenseDependencyIssue, VulnerabilityIssue } from "./agent.protocol.fossa";
 import { ReviewPlus } from "./agent.protocol.reviews";
 import { CSRepository, PullRequestQuery } from "./api.protocol.models";
 import { TrunkCheckResults } from "./agent.protocol.trunk";
@@ -493,36 +494,69 @@ export const FetchThirdPartyBuildsRequestType = new RequestType<
 
 export interface FetchThirdPartyCodeAnalyzersRequest {
 	providerId: string;
-}
-
-interface CodeAnalyzerProject {
-	id: string;
-	status: string;
-	depth: number;
-	title: string;
-}
-
-export interface LicenseDependency {
-	id: number;
-	createdAt: string;
-	source: { id: string; name: string; url: string; version: string; packageManager: string };
-	depths: { direct: number; deep: number };
-	statuses: { active: number; ignored: number };
-	projects: CodeAnalyzerProject[];
-	type?: string | null;
-	details?: string | null;
-	license?: string | null;
+	repoId?: string;
+	params: IssueParams;
 }
 export interface FetchThirdPartyCodeAnalyzersResponse {
-	[issues: string]: LicenseDependency[];
+	issues?: LicenseDependencyIssue[] | VulnerabilityIssue[];
+	error?: string; // CHECK THE TYPE! could be object
 }
 
 export const FetchThirdPartyCodeAnalyzersRequestType = new RequestType<
-	FetchThirdPartyCodeAnalyzersRequest,
-	FetchThirdPartyCodeAnalyzersResponse,
+	FetchThirdPartyLicenseDependenciesRequest,
+	FetchThirdPartyLicenseDependenciesResponse,
 	void,
 	void
 >("codestream/provider/codeAnalyzers");
+
+export interface FetchThirdPartyLicenseDependenciesRequest {
+	providerId: string;
+	repoId?: string;
+}
+export interface FetchThirdPartyLicenseDependenciesResponse {
+	issues?: LicenseDependencyIssue[];
+	error?: string; // CHECK THE TYPE! could be object
+}
+
+export const FetchThirdPartyLicenseDependenciesRequestType = new RequestType<
+	FetchThirdPartyLicenseDependenciesRequest,
+	FetchThirdPartyLicenseDependenciesResponse,
+	void,
+	void
+>("codestream/provider/licenseDependencies");
+
+export { LicenseDependencyIssue, VulnerabilityIssue } from "./agent.protocol.fossa";
+
+export interface FetchThirdPartyVulnerabilitiesRequest {
+	providerId: string;
+	repoId?: string;
+}
+export interface FetchThirdPartyVulnerabilitiesResponse {
+	issues?: VulnerabilityIssue[];
+	error?: string; // CHECK THE TYPE! could be object
+}
+
+export const FetchThirdPartyVulnerabilitiesRequestType = new RequestType<
+	FetchThirdPartyVulnerabilitiesRequest,
+	FetchThirdPartyVulnerabilitiesResponse,
+	void,
+	void
+>("codestream/provider/vulnerablitlies");
+
+export interface FetchThirdPartyRepoMatchToFossaProjectRequest {
+	providerId: string;
+	repoId?: string;
+}
+export interface FetchThirdPartyRepoMatchToFossaProjectResponse {
+	matchedRepoToFossaProject: boolean;
+}
+
+export const FetchThirdPartyRepoMatchToFossaProjectRequestType = new RequestType<
+	FetchThirdPartyRepoMatchToFossaProjectRequest,
+	FetchThirdPartyRepoMatchToFossaProjectResponse,
+	void,
+	void
+>("codestream/provider/fossaRepoMatch");
 
 export type CheckConclusionState =
 	| "ACTION_REQUIRED"
@@ -2170,6 +2204,10 @@ export type VulnerabilityStatus =
 export const riskSeverityList = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN", "INFO"] as const;
 
 export type RiskSeverity = (typeof riskSeverityList)[number];
+
+export const vulnSeverityList = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"] as const;
+
+export type VulnSeverity = (typeof vulnSeverityList)[number];
 
 export const criticalityList = ["CRITICAL", "HIGH", "MODERATE", "LOW"] as const;
 


### PR DESCRIPTION
This PR is for NR-119847. PR contains displaying fossa issues, conditional text for different repo states, and the repo context is also being determined in the agent layer. Error handling in the UI will come in a following PR

Test Cases
- [x] No repo open, no file open
- [x] One repo opened, repo has no remotes, no file opened
- [x] One repo opened, repo has no remotes, open file(s) 
- [x] One repo opened, repo has no remotes, switch between file(s) 
- [x] One repo opened, repo has no fossa match, no file opened
- [x] One repo opened, repo has no fossa match, open file(s) 
- [x] One repo opened, repo has no fossa match, switch between file(s) 
- [x] One repo opened, repo has fossa match, no file opened
- [x] One repo opened, repo has fossa match, open file(s) 
- [x] One repo opened, repo has fossa match, switch between file(s) 
- [x] Multiple repos opened, no file opened
- [x] Multiple repos opened, open file(s) from one repo
- [x] Multiple repos opened, files from some or all repos opened
- [x] Close all files

Edge cases that I ran into:
- CurrentRepoContext doesn't seem to update the section header name (state isn't being updated) when we close out all the files. I checked the staging extension and that happens in the Observability section header as well.
- While testing, in about 1 in 20 times while testing Vuln and Lic Dep, the UI will display the two dropdowns, but the data isn't resolved yet so we display "👍 No X issues found". When the data comes back it will eventually display. A skeleton loader for this issue might be a nice to have. I added a new story for creating two skeleton loaders, one for each fossa issues section (NR-145820)
    - pushed up a fix in CodeAnalyzers fetchData() function in the useEffect
- Repos without remotes are a problem. The way we match the currentRepo to the list of openRepos, we check that the currentRepo id matches an id in openRepos list. A repo without remote(s) has id set to undefined so we will match the currentRepo to the first repo in the openRepos list that has id undefined. If there are multiple opened repos without remotes, we may end up mismatching the currentRepo to the wrong repo in the list. It would also cause the UI to not display repo context switching. 
  - This issue shouldn't be a huge deal since we display a message to users that the git remote doesn't have a remote. Also most people don't have multiple repos opened, let alone multiple without remotes. However since FOSSA allows users to analyze repos without remotes, if we wanted to display the results, it would be challenging with the way we determine the currentRepo. 
   
![repo-context-vln-licdep](https://github.com/TeamCodeStream/codestream/assets/14142356/3951b77a-4426-4aa4-8980-73cc2a2229d7)