### PR TITLE
Fix C# CLM in VSCode

### DIFF
--- a/vscode/src/providers/instrumentationCodeLensProvider.ts
+++ b/vscode/src/providers/instrumentationCodeLensProvider.ts
@@ -399,17 +399,24 @@ export class InstrumentationCodeLensProvider implements vscode.CodeLensProvider 
 			};
 
 			let functionLocator: FunctionLocator | undefined = undefined;
-			if (document.languageId === "csharp" || document.languageId === "java") {
-				const thePackage = instrumentableSymbols.find(_ => _.parent?.kind === SymbolKind.Package);
-				if (thePackage && thePackage?.parent?.name) {
-					functionLocator = { namespace: thePackage.parent.name };
-				}
+			if (document.languageId === "csharp") {
+				// for whatever reason, Omnisharp is naming Namespace with the Module kind
+				// in C# speak, it would really be Namespace
+				const namespace = allSymbols.find(_ => _.kind === SymbolKind.Module);
+
+				functionLocator = {
+					namespace: namespace?.name
+				};
 			}
 
-			if (document.languageId === "java" && functionLocator?.namespace) {
-				functionLocator.namespace = `${this.parseJavaPackage(document.getText())}.${
-					functionLocator.namespace
-				}`;
+			if (document.languageId === "java") {
+				const thePackage = instrumentableSymbols.find(_ => _.parent?.kind === SymbolKind.Package);
+
+				if (thePackage && thePackage?.parent?.name) {
+					functionLocator = {
+						namespace: `${this.parseJavaPackage(document.getText())}.${thePackage.parent.name}`
+					};
+				}
 			}
 
 			if (document.languageId === "go") {


### PR DESCRIPTION
I can't explain why this is broken, as it looks like this code hasn't changed in quite some time, but I broke out the C# and Java blocks so I could search the symbols for "Module" (dunno why Omnisharp is using that instead of Namespace, but I digress).


The issue ultimately is that prior to this change, the namespace was getting set to the class name (as you can see in the logs


```
{"locator":{"namespace":"AgentsController"},"resolutionMethod":"locator","relativeFilePath":"/AspNetCoreMvc/Controllers/AgentsController.cs","accountId":1}
```


Locator SHOULD have been "AspNetCoreMvc.Controllers"


[Changes reviewed on CodeStream](https://codestream-stg.staging-service.newrelic.com/r/Ya5We-trHA5di0uy/ivX_pvBaQu2SFPpmnWQ6Fw?src=GitHub) by bcanzanella on Jul 22, 2023

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>