### PR TITLE
NR-117687 Investigate "O11y Rendered" segment event

### DIFF
--- a/jb/.prettierrc
+++ b/jb/.prettierrc
@@ -2,7 +2,8 @@
 	"printWidth": 100,
 	"tabWidth": 2,
 	"useTabs": true,
-	"semi": true,
+	"arrowParens": "avoid",
+	"trailingComma": "es5",
 	"overrides": [
 		{
 			"files": ".prettierrc",

--- a/shared/agent/.prettierrc
+++ b/shared/agent/.prettierrc
@@ -3,6 +3,7 @@
 	"tabWidth": 2,
 	"useTabs": true,
 	"arrowParens": "avoid",
+	"trailingComma": "es5",
 	"overrides": [
 		{
 			"files": ".prettierrc",

--- a/shared/ui/.prettierrc
+++ b/shared/ui/.prettierrc
@@ -1,14 +1,15 @@
 {
-  "printWidth": 100,
-  "tabWidth": 2,
-  "useTabs": true,
-  "arrowParens": "avoid",
-  "overrides": [
-    {
-      "files": ".prettierrc",
-      "options": {
-        "parser": "json"
-      }
-    }
-  ]
+	"printWidth": 100,
+	"tabWidth": 2,
+	"useTabs": true,
+	"arrowParens": "avoid",
+	"trailingComma": "es5",
+	"overrides": [
+		{
+			"files": ".prettierrc",
+			"options": {
+				"parser": "json"
+			}
+		}
+	]
 }

--- a/shared/ui/Stream/Observability.tsx
+++ b/shared/ui/Stream/Observability.tsx
@@ -374,7 +374,7 @@ export const Observability = React.memo((props: Props) => {
 		}
 	};
 
-	const doRefresh = async (force: boolean = false) => {
+	const doRefresh = async (force = false) => {
 		if (!derivedState.newRelicIsConnected) return;
 
 		console.debug(`o11y: doRefresh called`);
@@ -383,7 +383,7 @@ export const Observability = React.memo((props: Props) => {
 		setLoadingEntities(true);
 
 		try {
-			await Promise.all([loadAssignments(), fetchObservabilityRepos(force), getEntityCount()]);
+			await Promise.all([loadAssignments(), fetchObservabilityRepos(force), getEntityCount(true)]);
 		} finally {
 			setLoadingEntities(false);
 		}
@@ -429,9 +429,9 @@ export const Observability = React.memo((props: Props) => {
 		}
 	};
 
-	const getEntityCount = async () => {
+	const getEntityCount = async (force = false) => {
 		try {
-			const { entityCount } = await HostApi.instance.send(GetEntityCountRequestType, {});
+			const { entityCount } = await HostApi.instance.send(GetEntityCountRequestType, { force });
 			console.debug(`o11y: entityCount ${entityCount}`);
 			setHasEntities(entityCount > 0);
 		} catch (err) {
@@ -447,7 +447,7 @@ export const Observability = React.memo((props: Props) => {
 		setGenericError(undefined);
 		setLoadingEntities(true);
 		try {
-			await Promise.all([loadAssignments(), fetchObservabilityRepos(force), getEntityCount()]);
+			await Promise.all([loadAssignments(), fetchObservabilityRepos(force), getEntityCount(true)]);
 			console.debug(`o11y: Promise.all finished`);
 		} finally {
 			setLoadingEntities(false);
@@ -576,9 +576,8 @@ export const Observability = React.memo((props: Props) => {
 	const callServiceClickedTelemetry = () => {
 		console.debug("o11y: callServiceClickedTelemetry");
 		try {
-			let currentRepoErrors = observabilityErrors?.find(
-				_ => _ && _.repoId === currentRepoId
-			)?.errors;
+			let currentRepoErrors = observabilityErrors?.find(_ => _ && _.repoId === currentRepoId)
+				?.errors;
 			let filteredCurrentRepoErrors = currentRepoErrors?.filter(_ => _.entityId === expandedEntity);
 			let filteredAssigments = observabilityAssignments?.filter(_ => _.entityId === expandedEntity);
 			const hasAnomalies =

--- a/shared/util/.prettierrc
+++ b/shared/util/.prettierrc
@@ -2,6 +2,7 @@
 	"printWidth": 100,
 	"tabWidth": 2,
 	"useTabs": true,
+	"trailingComma": "es5",
 	"overrides": [
 		{
 			"files": ".prettierrc",


### PR DESCRIPTION
- Prettier: Stop all the commas
- Fix rare case where entity count used by o11y telemetry cached by file level telemetry at 0