### PR TITLE
[FOSSA] Add Vulnerability and License Dependency Details View, and Error Handling

### DIFF
--- a/shared/agent/src/providers/fossa.ts
+++ b/shared/agent/src/providers/fossa.ts
@@ -177,7 +177,10 @@ export class FossaProvider extends ThirdPartyCodeAnalyzerProviderBase<CSFossaPro
 			return { isRepoMatch: true };
 		} catch (error) {
 			Logger.error(error);
-			return { error: error.message };
+			if (error.message === "Unauthorized") {
+				return { error: "API token is invalid" };
+			}
+			return { error: "Project not found on FOSSA" };
 		}
 	}
 
@@ -208,9 +211,7 @@ export class FossaProvider extends ThirdPartyCodeAnalyzerProviderBase<CSFossaPro
 			};
 		} catch (error) {
 			Logger.error(error);
-			return {
-				error,
-			};
+			return { error: "Error fetching issues from FOSSA" };
 		}
 	}
 
@@ -241,7 +242,7 @@ export class FossaProvider extends ThirdPartyCodeAnalyzerProviderBase<CSFossaPro
 			};
 		} catch (error) {
 			Logger.error(error);
-			return { error: error.message };
+			return { error: "Error fetching issues from FOSSA" };
 		}
 	}
 }

--- a/shared/agent/src/providers/fossa.ts
+++ b/shared/agent/src/providers/fossa.ts
@@ -177,7 +177,7 @@ export class FossaProvider extends ThirdPartyCodeAnalyzerProviderBase<CSFossaPro
 			return { isRepoMatch: true };
 		} catch (error) {
 			Logger.error(error);
-			if (error.message === "Unauthorized") {
+			if (error.message.toLowerCase() === "unauthorized") {
 				return { error: "API token is invalid" };
 			}
 			return { error: "Project not found on FOSSA" };

--- a/shared/agent/src/providers/fossa.ts
+++ b/shared/agent/src/providers/fossa.ts
@@ -164,16 +164,21 @@ export class FossaProvider extends ThirdPartyCodeAnalyzerProviderBase<CSFossaPro
 	async fetchIsRepoMatch(
 		request: FetchThirdPartyRepoMatchToFossaRequest,
 	): Promise<FetchThirdPartyRepoMatchToFossaResponse> {
-		const [currentRepo] = await this._getCurrentRepo(request.repoId);
-		if (!currentRepo) {
-			return { isRepoMatch: false };
+		try {
+			const [currentRepo] = await this._getCurrentRepo(request.repoId);
+			if (!currentRepo) {
+				return { isRepoMatch: false };
+			}
+			const projects: FossaProject[] = await this._getProjects();
+			const project = await this._matchRepoToFossaProject(currentRepo, projects, request.repoId);
+			if (!project) {
+				return { isRepoMatch: false };
+			}
+			return { isRepoMatch: true };
+		} catch (error) {
+			Logger.error(error);
+			return { error: error.message };
 		}
-		const projects: FossaProject[] = await this._getProjects();
-		const project = await this._matchRepoToFossaProject(currentRepo, projects, request.repoId);
-		if (!project) {
-			return { isRepoMatch: false };
-		}
-		return { isRepoMatch: true };
 	}
 
 	@log()
@@ -236,9 +241,7 @@ export class FossaProvider extends ThirdPartyCodeAnalyzerProviderBase<CSFossaPro
 			};
 		} catch (error) {
 			Logger.error(error);
-			return {
-				error,
-			};
+			return { error: error.message };
 		}
 	}
 }

--- a/shared/agent/src/providers/fossa.ts
+++ b/shared/agent/src/providers/fossa.ts
@@ -6,20 +6,17 @@ import {
 	FetchThirdPartyRepoMatchToFossaRequest,
 	FetchThirdPartyRepoMatchToFossaResponse,
 	FetchThirdPartyVulnerabilitiesResponse,
+	FossaProject,
+	GetFossaProjectsResponse,
+	IssueParams,
+	LicenseDependencyIssues,
 	ReposScm,
 	ThirdPartyProviderConfig,
+	VulnerabilityIssues,
 } from "@codestream/protocols/agent";
 import { log, lspProvider } from "../system";
 import { CodeStreamSession } from "session";
 import { GitRemoteParser } from "../git/parsers/remoteParser";
-
-import {
-	FossaProject,
-	GetFossaProjectsResponse,
-	LicenseDependencyIssues,
-	VulnerabilityIssues,
-	IssueParams,
-} from "../../../util/src/protocol/agent/agent.protocol.fossa";
 import { ThirdPartyCodeAnalyzerProviderBase } from "./thirdPartyCodeAnalyzerProviderBase";
 import { CSFossaProviderInfo } from "@codestream/protocols/api";
 import { SessionContainer } from "../container";

--- a/shared/agent/src/providers/provider.ts
+++ b/shared/agent/src/providers/provider.ts
@@ -30,6 +30,7 @@ import {
 	FetchThirdPartyPullRequestResponse,
 	GetMyPullRequestsRequest,
 	GetMyPullRequestsResponse,
+	IssueParams,
 	MoveThirdPartyCardRequest,
 	MoveThirdPartyCardResponse,
 	ProviderConfigurationData,
@@ -47,8 +48,6 @@ import { Response } from "node-fetch";
 import { SessionContainer } from "../container";
 import { GitRemote, GitRemoteLike, GitRepository } from "../git/gitService";
 import { Logger } from "../logger";
-
-import { IssueParams } from "../../../util/src/protocol/agent/agent.protocol.fossa";
 
 export const providerDisplayNamesByNameKey = new Map<string, string>([
 	["asana", "Asana"],

--- a/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/CodeAnalyzers.tsx
@@ -64,11 +64,10 @@ export const CodeAnalyzers = (props: Props) => {
 		const hasActiveFile =
 			!editorContext?.textEditorUri?.includes("terminal") &&
 			editorContext?.activeFile &&
-			editorContext?.activeFile &&
 			editorContext?.activeFile.length > 0;
 
 		const hasRemotes = currentRepo?.remotes && currentRepo?.remotes.length > 0;
-		const hasReposOpened = props.openRepos.length > 0;
+		const hasOpenRepos = props.openRepos.length > 0;
 
 		return {
 			bootstrapped: Object.keys(providerInfo).length > 0,
@@ -76,7 +75,7 @@ export const CodeAnalyzers = (props: Props) => {
 			fossaProvider,
 			hasActiveFile,
 			hasRemotes,
-			hasReposOpened,
+			hasOpenRepos,
 			showCodeAnalyzers: isFeatureEnabled(state, "showCodeAnalyzers"),
 		};
 	}, shallowEqual);
@@ -99,6 +98,8 @@ export const CodeAnalyzers = (props: Props) => {
 					} else {
 						setLoading(false);
 					}
+				} else {
+					setLoading(false);
 				}
 			} catch (err) {
 				console.error("Error fetching data: ", err);
@@ -196,28 +197,28 @@ export const CodeAnalyzers = (props: Props) => {
 		setLicDepLoading(false);
 	};
 
-	const loaded = derivedState.bootstrapped && !loading && !props.reposLoading;
-
-	const conditionalText = (): string => {
+	const errorText = (): string => {
 		if (error) {
 			return "Sorry an error occurred, please try again";
 		}
 		if (repoMatchError) {
 			return repoMatchError;
 		}
-		if (!derivedState.hasReposOpened) {
+		if (!derivedState.hasOpenRepos) {
 			return "No repositories found";
 		}
 		if (currentRepoId && isRepoMatch === false) {
 			return "Project not found on FOSSA";
 		}
-		if (derivedState.hasRemotes === false && derivedState.hasActiveFile) {
+		if (derivedState.hasRemotes === false) {
 			return "Repo does not have a git remote, try another repo.";
 		}
 		return "";
 	};
 
-	const hasConditionalText = conditionalText();
+	const hasError = errorText();
+
+	const loaded = derivedState.bootstrapped && !loading && !props.reposLoading;
 
 	if (!derivedState.showCodeAnalyzers) return null;
 	return (
@@ -239,11 +240,9 @@ export const CodeAnalyzers = (props: Props) => {
 							vulnError={vulnError}
 						/>
 					)}
-					{loaded && derivedState.hasReposOpened && !derivedState.hasActiveFile && (
+					{loaded && hasError && <ErrorRow title={hasError} customPadding={"0 10px 0 20px"} />}
+					{loaded && !derivedState.hasActiveFile && !hasError && !isRepoMatch && (
 						<NoContent>Open a source file to see FOSSA results.</NoContent>
-					)}
-					{loaded && hasConditionalText && (
-						<ErrorRow title={hasConditionalText} customPadding={"0 10px 0 20px"} />
 					)}
 				</PaneBody>
 			)}

--- a/shared/ui/Stream/CodeAnalyzers/FossaIssues.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/FossaIssues.tsx
@@ -274,14 +274,14 @@ export const FossaIssues = React.memo((props: Props) => {
 				{!vulnExpanded && <Icon name="chevron-right-thin" />}
 				<span style={{ marginLeft: "2px", marginRight: "5px" }}>Vulnerabilities</span>
 			</Row>
-			{vulnExpanded && vulnIssues?.length && (
+			{vulnExpanded && vulnIssues && vulnIssues.length > 0 && (
 				<>
 					{vulnIssues.map(vuln => {
 						return <LibraryWithVulnRow vuln={vuln} />;
 					})}
 				</>
 			)}
-			{vulnExpanded && vulnIssues && vulnIssues.length === 0 && (
+			{vulnExpanded && vulnIssues?.length === 0 && (
 				<Row style={{ padding: "0 10px 0 40px" }}>👍 No vulnerabilities found</Row>
 			)}
 			{vulnExpanded && vulnError && (
@@ -301,14 +301,14 @@ export const FossaIssues = React.memo((props: Props) => {
 				{!licenseDepExpanded && <Icon name="chevron-right-thin" />}
 				<StyledSpan>License Dependencies</StyledSpan>
 			</Row>
-			{licenseDepExpanded && licDepIssues && licDepIssues?.length && (
+			{licenseDepExpanded && licDepIssues && licDepIssues.length > 0 && (
 				<>
 					{licDepIssues.map(issue => {
 						return <LicenseDependencyRow licenseDependency={issue} />;
 					})}
 				</>
 			)}
-			{licenseDepExpanded && licDepIssues && licDepIssues.length === 0 && (
+			{licenseDepExpanded && licDepIssues?.length === 0 && (
 				<Row style={{ padding: "0 10px 0 40px" }}>👍 No license dependency issues found</Row>
 			)}
 			{licenseDepExpanded && licDepError && (

--- a/shared/ui/Stream/CodeAnalyzers/FossaIssues.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/FossaIssues.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { lowerCase, upperCase } from "lodash-es";
+import { lowerCase, capitalize } from "lodash-es";
 import styled from "styled-components";
 import {
 	LicenseDependencyIssue,
@@ -8,45 +8,61 @@ import {
 } from "@codestream/protocols/agent";
 import Icon from "../Icon";
 import Tooltip from "../Tooltip";
+import { Link } from "@codestream/webview/Stream/Link";
 import { Row } from "../CrossPostIssueControls/IssuesPane";
+import { Modal } from "@codestream/webview/Stream/Modal";
+import { MarkdownText } from "@codestream/webview/Stream/MarkdownText";
 
 const StyledSpan = styled.span`
 	margin-left: 2px;
 	margin-right: 5px;
 `;
 
+const CardTitle = styled.div`
+	font-size: 16px;
+	line-height: 20px;
+	display: flex;
+	justify-content: flex-start;
+	width: 100%;
+	margin-left: -28px;
+
+	.title {
+		flex-grow: 3;
+	}
+
+	.icon,
+	.stream .icon,
+	.ticket-icon {
+		display: block;
+		transform: scale(1.25);
+		margin-top: 2px;
+		padding: 0 8px 0 3px;
+		vertical-align: -2px;
+	}
+
+	& + & {
+		margin-left: 20px;
+	}
+
+	.link-to-ticket {
+		.icon {
+			padding: 0 8px;
+			margin-left: 0;
+		}
+	}
+`;
 interface Props {
 	issues: LicenseDependencyIssue[];
 	vulnIssues: VulnerabilityIssue[];
 }
 
 const severityColorMap: Record<VulnSeverity, string> = {
-	CRITICAL: "#f52222",
-	HIGH: "#F5554B",
-	MEDIUM: "#F0B400",
-	LOW: "#0776e5",
-	UNKNOWN: "#ee8608",
+	critical: "#f52222",
+	high: "#F5554B",
+	medium: "#F0B400",
+	low: "#0776e5",
+	unknown: "#ee8608",
 };
-
-function LicenseDependencyRow(props: { licenseDependency }) {
-	const { licenseDependency } = props;
-	const { source } = licenseDependency;
-	const licenseText = licenseDependency.license ? licenseDependency.license : "No license found";
-	const licenseIssueText = `${licenseText} in ${source.name} (${source.version})`;
-
-	return (
-		<>
-			<Row style={{ padding: "0 10px 0 30px" }} className={"pr-row"}>
-				<div></div>
-				<div>
-					<Tooltip placement="bottom" title={licenseIssueText} delay={1}>
-						<span>{licenseIssueText}</span>
-					</Tooltip>
-				</div>
-			</Row>
-		</>
-	);
-}
 
 function Severity(props: { severity: VulnSeverity }) {
 	return (
@@ -57,23 +73,62 @@ function Severity(props: { severity: VulnSeverity }) {
 }
 
 function criticalityToRiskSeverity(riskSeverity: VulnSeverity): VulnSeverity {
-	switch (upperCase(riskSeverity)) {
-		case "CRITICAL":
-			return "CRITICAL";
-		case "HIGH":
-			return "HIGH";
-		case "MEDIUM":
-			return "MEDIUM";
-		case "LOW":
-			return "LOW";
-		case "UNKNOWN":
-			return "UNKNOWN";
+	switch (riskSeverity) {
+		case "critical":
+			return "critical";
+		case "high":
+			return "high";
+		case "medium":
+			return "medium";
+		case "low":
+			return "low";
+		case "unknown":
+			return "unknown";
 		default:
-			return "LOW";
+			return "low";
 	}
 }
 
-function LibraryRow(props: { vuln }) {
+function ModalView(props: {
+	issue: VulnerabilityIssue | LicenseDependencyIssue;
+	displays: (string | boolean)[][];
+	title: string;
+	onClose: () => void;
+}) {
+	const { issue, displays, title } = props;
+
+	return (
+		<div className="codemark-form-container">
+			<div className="codemark-form standard-form vscroll">
+				<div className="form-body" style={{ padding: "20px 5px 20px 28px" }}>
+					<div className="contents">
+						<CardTitle>
+							<Icon name="lock" className="ticket-icon" />
+							<div className="title">{title}</div>
+						</CardTitle>
+						<div style={{ margin: "10px 0" }}>
+							{displays.map(display => {
+								const [title, description, link] = display;
+								return (
+									<div>
+										<b>{title} </b>
+										{link && <Link href={`${description}`}>{description}</Link>}
+										{!link && description}
+									</div>
+								);
+							})}
+						</div>
+						<div>
+							<MarkdownText className="less-space" text={issue.details ?? ""} inline={false} />
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function LibraryWithVulnRow(props: { vuln: VulnerabilityIssue }) {
 	const [expanded, setExpanded] = useState<boolean>(false);
 	const { vuln } = props;
 
@@ -103,20 +158,94 @@ function LibraryRow(props: { vuln }) {
 						<span className="subtle">{subtleText}</span>
 					</Tooltip>
 				</div>
-				<Severity severity={criticalityToRiskSeverity(vuln.severity)} />
+				<Severity severity={criticalityToRiskSeverity(vuln.severity ?? "unknown")} />
 			</Row>
 			{expanded && <VulnRow vuln={vuln} />}
 		</>
 	);
 }
 
-function VulnRow(props: { vuln }) {
+function VulnRow(props: { vuln: VulnerabilityIssue }) {
+	const [expanded, setExpanded] = useState<boolean>(false);
+	const { vuln } = props;
 	return (
 		<>
 			<Row style={{ padding: "0 10px 0 40px" }} className={"pr-row"}>
 				<div></div>
 				<div>{props.vuln.title}</div>
 			</Row>
+			{expanded && (
+				<Modal
+					translucent
+					onClose={() => {
+						setExpanded(false);
+					}}
+				>
+					<ModalView
+						issue={vuln}
+						title={vuln.title ?? ""}
+						displays={[
+							["Dependency:", "vuln.source?.name"],
+							["Remediation Advice:", vuln.remediation ?? ""],
+							["CVSS Severity:", capitalize(vuln.severity) ?? ""],
+							["CVE", vuln.cve ?? ""],
+							["CVSS score:", JSON.stringify(vuln.cvss) ?? ""],
+							["Affected Project:", vuln.projects[0]?.title ?? "", true],
+							["Reference(s):", vuln.source?.url, true],
+							["Dependency Depths:", vuln.depths?.direct ? "Direct" : "Transitive"],
+						]}
+						onClose={() => setExpanded(false)}
+					/>
+				</Modal>
+			)}
+		</>
+	);
+}
+
+function LicenseDependencyRow(props: { licenseDependency: LicenseDependencyIssue }) {
+	const [expanded, setExpanded] = useState<boolean>(false);
+	const { licenseDependency } = props;
+	const { source } = licenseDependency;
+	const licenseText = licenseDependency.license ? licenseDependency.license : "No license found";
+	const licenseIssueText = `${licenseText} in ${source.name} (${source.version})`;
+
+	return (
+		<>
+			<Row
+				style={{ padding: "0 10px 0 30px" }}
+				className={"pr-row"}
+				onClick={() => {
+					setExpanded(!expanded);
+				}}
+			>
+				<div></div>
+				<div>
+					<Tooltip placement="bottom" title={licenseIssueText} delay={1}>
+						<span>{licenseIssueText}</span>
+					</Tooltip>
+				</div>
+			</Row>
+			{expanded && (
+				<Modal
+					translucent
+					onClose={() => {
+						setExpanded(false);
+					}}
+				>
+					<ModalView
+						issue={licenseDependency}
+						title={`${capitalize(licenseDependency.source.name)}: ${licenseDependency.license}`}
+						displays={[
+							["Dependency:", licenseDependency.source.name ?? ""],
+							["Issue Type: ", licenseDependency.type.split("_").join(" ")],
+							["License: ", licenseDependency.license ?? ""],
+							["Affected Project:", licenseDependency.projects[0]?.title ?? "", true],
+							["Dependency Depths:", licenseDependency.depths?.direct ? "Direct" : "Transitive"],
+						]}
+						onClose={() => setExpanded(false)}
+					/>
+				</Modal>
+			)}
 		</>
 	);
 }
@@ -144,7 +273,7 @@ export const FossaIssues = React.memo((props: Props) => {
 			{vulnExpanded && props.vulnIssues && props.vulnIssues.length > 0 && (
 				<>
 					{props.vulnIssues.map(vuln => {
-						return <LibraryRow vuln={vuln} />;
+						return <LibraryWithVulnRow vuln={vuln} />;
 					})}
 				</>
 			)}

--- a/shared/ui/Stream/CodeAnalyzers/FossaIssues.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/FossaIssues.tsx
@@ -10,8 +10,16 @@ import Icon from "../Icon";
 import Tooltip from "../Tooltip";
 import { Link } from "@codestream/webview/Stream/Link";
 import { Row } from "../CrossPostIssueControls/IssuesPane";
+import { ErrorRow } from "@codestream/webview/Stream/Observability";
 import { Modal } from "@codestream/webview/Stream/Modal";
 import { MarkdownText } from "@codestream/webview/Stream/MarkdownText";
+
+interface Props {
+	licDepIssues: LicenseDependencyIssue[] | null;
+	licDepError: string | null;
+	vulnIssues: VulnerabilityIssue[] | null;
+	vulnError: string | null;
+}
 
 const StyledSpan = styled.span`
 	margin-left: 2px;
@@ -51,10 +59,6 @@ const CardTitle = styled.div`
 		}
 	}
 `;
-interface Props {
-	issues: LicenseDependencyIssue[];
-	vulnIssues: VulnerabilityIssue[];
-}
 
 const severityColorMap: Record<VulnSeverity, string> = {
 	critical: "#f52222",
@@ -253,7 +257,7 @@ function LicenseDependencyRow(props: { licenseDependency: LicenseDependencyIssue
 export const FossaIssues = React.memo((props: Props) => {
 	const [licenseDepExpanded, setLicenseDepExpanded] = useState<boolean>(false);
 	const [vulnExpanded, setVulnExpanded] = useState<boolean>(false);
-
+	const { vulnIssues, vulnError, licDepIssues, licDepError } = props;
 	return (
 		<>
 			<Row
@@ -270,17 +274,18 @@ export const FossaIssues = React.memo((props: Props) => {
 				{!vulnExpanded && <Icon name="chevron-right-thin" />}
 				<span style={{ marginLeft: "2px", marginRight: "5px" }}>Vulnerabilities</span>
 			</Row>
-			{vulnExpanded && props.vulnIssues && props.vulnIssues.length > 0 && (
+			{vulnExpanded && vulnIssues?.length && (
 				<>
-					{props.vulnIssues.map(vuln => {
+					{vulnIssues.map(vuln => {
 						return <LibraryWithVulnRow vuln={vuln} />;
 					})}
 				</>
 			)}
-			{vulnExpanded && props.vulnIssues && props.vulnIssues.length === 0 && (
-				<Row style={{ padding: "0 10px 0 30px" }}>
-					<div>👍 No vulnerability issues found</div>
-				</Row>
+			{vulnExpanded && vulnIssues && vulnIssues.length === 0 && (
+				<Row style={{ padding: "0 10px 0 40px" }}>👍 No vulnerabilities found</Row>
+			)}
+			{vulnExpanded && vulnError && (
+				<ErrorRow title="Error fetching data from FOSSA" customPadding={"0 10px 0 40px"} />
 			)}
 			<Row
 				style={{
@@ -296,17 +301,18 @@ export const FossaIssues = React.memo((props: Props) => {
 				{!licenseDepExpanded && <Icon name="chevron-right-thin" />}
 				<StyledSpan>License Dependencies</StyledSpan>
 			</Row>
-			{licenseDepExpanded && props.issues?.length > 0 && (
+			{licenseDepExpanded && licDepIssues && licDepIssues?.length && (
 				<>
-					{props.issues.map(issue => {
+					{licDepIssues.map(issue => {
 						return <LicenseDependencyRow licenseDependency={issue} />;
 					})}
 				</>
 			)}
-			{licenseDepExpanded && props.issues?.length === 0 && (
-				<Row style={{ padding: "0 10px 0 30px" }}>
-					<div>👍 No license dependency issues found</div>
-				</Row>
+			{licenseDepExpanded && licDepIssues && licDepIssues.length === 0 && (
+				<Row style={{ padding: "0 10px 0 40px" }}>👍 No license dependency issues found</Row>
+			)}
+			{licenseDepExpanded && licDepError && (
+				<ErrorRow title="Error fetching data from FOSSA" customPadding={"0 10px 0 40px"} />
 			)}
 		</>
 	);

--- a/shared/ui/Stream/CodeAnalyzers/FossaIssues.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/FossaIssues.tsx
@@ -94,12 +94,12 @@ function criticalityToRiskSeverity(riskSeverity: VulnSeverity): VulnSeverity {
 }
 
 function ModalView(props: {
-	issue: VulnerabilityIssue | LicenseDependencyIssue;
 	displays: (string | boolean)[][];
 	title: string;
+	details: string;
 	onClose: () => void;
 }) {
-	const { issue, displays, title } = props;
+	const { displays, title, details } = props;
 
 	return (
 		<div className="codemark-form-container">
@@ -110,7 +110,7 @@ function ModalView(props: {
 							<Icon name="lock" className="ticket-icon" />
 							<div className="title">{title}</div>
 						</CardTitle>
-						<div style={{ margin: "10px 0" }}>
+						<div style={{ margin: "10px 0", whiteSpace: "pre-wrap", wordWrap: "break-word" }}>
 							{displays.map(display => {
 								const [title, description, link] = display;
 								return (
@@ -123,7 +123,7 @@ function ModalView(props: {
 							})}
 						</div>
 						<div>
-							<MarkdownText className="less-space" text={issue.details ?? ""} inline={false} />
+							<MarkdownText className="less-space" text={details} inline={false} />
 						</div>
 					</div>
 				</div>
@@ -186,8 +186,8 @@ function VulnRow(props: { vuln: VulnerabilityIssue }) {
 					}}
 				>
 					<ModalView
-						issue={vuln}
 						title={vuln.title ?? ""}
+						details={vuln.details ?? ""}
 						displays={[
 							["Dependency:", "vuln.source?.name"],
 							["Remediation Advice:", vuln.remediation ?? ""],
@@ -237,8 +237,8 @@ function LicenseDependencyRow(props: { licenseDependency: LicenseDependencyIssue
 					}}
 				>
 					<ModalView
-						issue={licenseDependency}
 						title={`${capitalize(licenseDependency.source.name)}: ${licenseDependency.license}`}
+						details={licenseDependency.details ?? ""}
 						displays={[
 							["Dependency:", licenseDependency.source.name ?? ""],
 							["Issue Type: ", licenseDependency.type.split("_").join(" ")],

--- a/shared/ui/Stream/SecurityIssuesWrapper.tsx
+++ b/shared/ui/Stream/SecurityIssuesWrapper.tsx
@@ -45,7 +45,7 @@ function isResponseUrlError<T>(obj: unknown): obj is ResponseError<{ url: string
 	);
 }
 
-const CardTitle = styled.div`
+export const CardTitle = styled.div`
 	font-size: 16px;
 	line-height: 20px;
 	display: flex;
@@ -270,7 +270,7 @@ export const SecurityIssuesWrapper = React.memo((props: Props) => {
 			rows,
 		},
 		[selectedItems, props.entityGuid, rows, expanded],
-		expanded
+		expanded,
 	);
 
 	function handleSelect(severity: RiskSeverity) {
@@ -319,7 +319,7 @@ export const SecurityIssuesWrapper = React.memo((props: Props) => {
 			}
 			return unexpectedError;
 		},
-		[error]
+		[error],
 	);
 
 	return (

--- a/shared/util/src/protocol/agent/agent.protocol.fossa.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.fossa.ts
@@ -53,6 +53,10 @@ export interface VulnerabilityIssue extends BaseIssueType {
 	references: string[];
 }
 
+export interface VulnerabilityIssues {
+	issues: VulnerabilityIssue[];
+}
+
 export interface FossaProject {
 	id: string;
 	title: string;
@@ -72,14 +76,6 @@ export interface FossaProject {
 
 export interface GetFossaProjectsResponse {
 	projects: FossaProject[];
-}
-
-export interface LicenseDependencyIssues {
-	issues: LicenseDependencyIssue[];
-}
-
-export interface VulnerabilityIssues {
-	issues: VulnerabilityIssue[];
 }
 
 export interface IssueParams {

--- a/shared/util/src/protocol/agent/agent.protocol.fossa.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.fossa.ts
@@ -36,19 +36,18 @@ export interface LicenseDependencyIssues {
 	issues: LicenseDependencyIssue[];
 }
 
-interface Metric {
-	name: string;
-	value: string;
-}
+export const vulnSeverityList = ["critical", "high", "medium", "low", "unknown"] as const;
+
+export type VulnSeverity = (typeof vulnSeverityList)[number];
 export interface VulnerabilityIssue extends BaseIssueType {
 	vulnId: string;
 	title: string;
 	cve: string;
 	cvss: number;
-	severity: string;
+	severity: VulnSeverity;
 	details: string;
 	remediation: string;
-	metrics: Metric[];
+	metrics: { name: string; value: string }[];
 	cveStatus: string;
 	cwes: string[];
 	published: string;

--- a/shared/util/src/protocol/agent/agent.protocol.fossa.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.fossa.ts
@@ -32,6 +32,10 @@ export interface LicenseDependencyIssue extends BaseIssueType {
 	license: string;
 }
 
+export interface LicenseDependencyIssues {
+	issues: LicenseDependencyIssue[];
+}
+
 interface Metric {
 	name: string;
 	value: string;

--- a/shared/util/src/protocol/agent/agent.protocol.providers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.providers.ts
@@ -498,7 +498,7 @@ export interface FetchThirdPartyCodeAnalyzersRequest {
 }
 export interface FetchThirdPartyLicenseDependenciesResponse {
 	issues?: LicenseDependencyIssue[];
-	error?: string; // CHECK THE TYPE! could be object
+	error?: string;
 }
 
 export const FetchThirdPartyLicenseDependenciesRequestType = new RequestType<
@@ -510,7 +510,7 @@ export const FetchThirdPartyLicenseDependenciesRequestType = new RequestType<
 
 export interface FetchThirdPartyVulnerabilitiesResponse {
 	issues?: VulnerabilityIssue[];
-	error?: string; // CHECK THE TYPE! could be object
+	error?: string;
 }
 
 export const FetchThirdPartyVulnerabilitiesRequestType = new RequestType<
@@ -527,7 +527,8 @@ export interface FetchThirdPartyRepoMatchToFossaRequest {
 	repoId?: string;
 }
 export interface FetchThirdPartyRepoMatchToFossaResponse {
-	isRepoMatch: boolean;
+	isRepoMatch?: boolean;
+	error?: string;
 }
 
 export const FetchThirdPartyRepoMatchToFossaRequestType = new RequestType<

--- a/shared/util/src/protocol/agent/agent.protocol.providers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.providers.ts
@@ -2184,10 +2184,6 @@ export const riskSeverityList = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN",
 
 export type RiskSeverity = (typeof riskSeverityList)[number];
 
-export const vulnSeverityList = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"] as const;
-
-export type VulnSeverity = (typeof vulnSeverityList)[number];
-
 export const criticalityList = ["CRITICAL", "HIGH", "MODERATE", "LOW"] as const;
 
 export type CriticalityType = (typeof criticalityList)[number];

--- a/shared/util/src/protocol/agent/agent.protocol.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.ts
@@ -17,6 +17,7 @@ export * from "./agent.protocol.codemarks";
 export * from "./agent.protocol.companies";
 export * from "./agent.protocol.documentMarkers";
 export * from "./agent.protocol.errors";
+export * from "./agent.protocol.fossa";
 export * from "./agent.protocol.github";
 export * from "./agent.protocol.gitlab";
 export * from "./agent.protocol.jira";


### PR DESCRIPTION
This PR handles NR-119857 which is for adding modal details view. Also did clean up for imports and exports, and added error handling.

Vuln modal
<img width="1657" alt="Screenshot 2023-07-26 at 5 13 02 PM" src="https://github.com/TeamCodeStream/codestream/assets/14142356/f4fb630d-8d8c-43bc-a978-3724131d6d24">
Lic Dep modal
<img width="1657" alt="Screenshot 2023-07-26 at 5 13 15 PM" src="https://github.com/TeamCodeStream/codestream/assets/14142356/5aea01f0-236b-40fa-bf0c-6459f983a360">
Fetch vuln and lic dep error
<img width="1655" alt="Screenshot 2023-07-26 at 5 11 20 PM" src="https://github.com/TeamCodeStream/codestream/assets/14142356/525a04dc-6523-4159-a19b-4cde7059e163">
Only vuln error
<img width="1658" alt="Screenshot 2023-07-27 at 11 28 02 AM" src="https://github.com/TeamCodeStream/codestream/assets/14142356/d10a26d8-3fce-47ba-9e37-41d5a6d967df">
Only lic dep error
<img width="1659" alt="Screenshot 2023-07-27 at 11 29 06 AM" src="https://github.com/TeamCodeStream/codestream/assets/14142356/2fb2a73d-e974-4954-a552-e6d139e012a9">
No repo match error
<img width="1656" alt="Screenshot 2023-07-27 at 12 13 28 PM" src="https://github.com/TeamCodeStream/codestream/assets/14142356/c2de8b84-239a-49fa-a18e-68f63f5faa9a">


