### PR TITLE
Exclude InternalErrors from New Relic

### DIFF
--- a/shared/agent/src/agentError.ts
+++ b/shared/agent/src/agentError.ts
@@ -41,7 +41,7 @@ export enum ReportSuppressedMessages {
 }
 
 /**
- * InternalErrors thrown are ignored by Sentry
+ * InternalErrors thrown are not sent to New Relic
  * based on its class name (InternalError)
  */
 export class InternalError extends AgentError {

--- a/shared/agent/src/nrErrorReporter.ts
+++ b/shared/agent/src/nrErrorReporter.ts
@@ -13,6 +13,7 @@ import StackMapper, { Callsite } from "stack-mapper";
 import { Parser } from "./managers/stackTraceParsers/javascriptStackTraceParser";
 import { CSStackTraceInfo } from "@codestream/protocols/api";
 import { md5 } from "@codestream/utils/system/string";
+import { InternalError } from "agentError";
 
 const STACK_INDENT = "    ";
 
@@ -166,6 +167,9 @@ export function reportErrorToNr(request: ReportMessageRequest, attributes?: Erro
 				// eventually setting the stack _should_ show in NR...
 				error.stack = stack = deserializedError.stack;
 			} else {
+				if (request.error.constructor.name === InternalError.name) {
+					return;
+				}
 				error = request.error as Error;
 				stack = error.stack;
 			}

--- a/shared/agent/src/nrErrorReporter.ts
+++ b/shared/agent/src/nrErrorReporter.ts
@@ -167,7 +167,7 @@ export function reportErrorToNr(request: ReportMessageRequest, attributes?: Erro
 				// eventually setting the stack _should_ show in NR...
 				error.stack = stack = deserializedError.stack;
 			} else {
-				if (request.error.constructor.name === InternalError.name) {
+				if (request.error.constructor?.name === InternalError.name) {
 					return;
 				}
 				error = request.error as Error;


### PR DESCRIPTION



[Changes reviewed on CodeStream](https://codestream-stg.staging-service.newrelic.com/r/Ya5We-trHA5di0uy/5BXtqgdVTSOFZZZ5UatqiA?src=GitHub) by bcanzanella on Aug 16, 2023

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>