### PR TITLE
NR-151414 Found X stale requests for ...

### DIFF
--- a/shared/agent/src/api/codestream/codestreamApi.ts
+++ b/shared/agent/src/api/codestream/codestreamApi.ts
@@ -2861,8 +2861,6 @@ export class CodeStreamApiProvider implements ApiProvider {
 	}
 
 	async verifyConnectivity() {
-		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), 5000);
 		const response: VerifyConnectivityResponse = {
 			ok: true,
 		};
@@ -2871,7 +2869,7 @@ export class CodeStreamApiProvider implements ApiProvider {
 			Logger.log("Verifying API server connectivity");
 
 			const resp = await customFetch(this.baseUrl + "/no-auth/capabilities", {
-				signal: controller.signal,
+				timeout: 5000,
 			});
 
 			Logger.log(`API server status: ${resp.status}`);
@@ -2904,16 +2902,12 @@ export class CodeStreamApiProvider implements ApiProvider {
 					message: err.message,
 				};
 			}
-		} finally {
-			clearTimeout(timeout);
 		}
 
 		return response;
 	}
 
 	async pollForMaintenanceMode() {
-		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), 5000);
 		const response: PollForMaintenanceModeResponse = {
 			ok: true,
 		};
@@ -2924,7 +2918,7 @@ export class CodeStreamApiProvider implements ApiProvider {
 			const nonJsonCapabilitiesResponse = await customFetch(
 				this.baseUrl + "/no-auth/capabilities",
 				{
-					signal: controller.signal,
+					timeout: 5000,
 				}
 			);
 
@@ -2943,8 +2937,6 @@ export class CodeStreamApiProvider implements ApiProvider {
 					message: err.message,
 				};
 			}
-		} finally {
-			clearTimeout(timeout);
 		}
 
 		return response;

--- a/shared/agent/src/api/slack/slackSharingApi.ts
+++ b/shared/agent/src/api/slack/slackSharingApi.ts
@@ -696,20 +696,24 @@ export class SlackSharingApiProvider {
 			try {
 				const timeoutMs = 30000;
 				const timer = setTimeout(async () => {
-					Logger.warn(
-						cc,
-						`TIMEOUT ${timeoutMs / 1000}s exceeded while fetching stream '${
-							deferred.stream.id
-						}' in the background`
-					);
+					try {
+						Logger.warn(
+							cc,
+							`TIMEOUT ${timeoutMs / 1000}s exceeded while fetching stream '${
+								deferred.stream.id
+							}' in the background`
+						);
 
-					if (completed.length !== 0) {
-						const message: StreamsRTMessage = { type: MessageType.Streams, data: completed };
-						message.data = await streams.resolve(message);
-						// this._onDidReceiveMessage.fire(message);
+						if (completed.length !== 0) {
+							const message: StreamsRTMessage = { type: MessageType.Streams, data: completed };
+							message.data = await streams.resolve(message);
+							// this._onDidReceiveMessage.fire(message);
 
-						completed.length = 0;
-						timeSinceLastNotification = new Date().getTime();
+							completed.length = 0;
+							timeSinceLastNotification = new Date().getTime();
+						}
+					} catch (e) {
+						Logger.warn("processPendingStreamsQueue error", e);
 					}
 				}, timeoutMs);
 
@@ -1196,7 +1200,7 @@ export class SlackSharingApiProvider {
 	})
 	protected async slackApiCall<
 		TRequest extends WebAPICallOptions,
-		TResponse extends WebAPICallResult
+		TResponse extends WebAPICallResult,
 	>(method: SlackMethods, request?: TRequest): Promise<TResponse> {
 		const cc = Logger.getCorrelationContext();
 
@@ -1266,7 +1270,7 @@ export class SlackSharingApiProvider {
 	})
 	protected async slackApiCallPaginated<
 		TRequest extends WebAPICallOptions,
-		TResponse extends WebAPICallResult
+		TResponse extends WebAPICallResult,
 	>(method: string, request: TRequest): Promise<AsyncIterableIterator<TResponse>> {
 		const cc = Logger.getCorrelationContext();
 

--- a/shared/agent/src/broadcaster/broadcaster.ts
+++ b/shared/agent/src/broadcaster/broadcaster.ts
@@ -271,12 +271,16 @@ export class Broadcaster {
 
 	// one tick of the clock, if longer than 10 seconds, assume a network "hiccup" of some kind
 	private tick() {
-		const now = Date.now();
-		if (this._lastTick > 0 && now - this._lastTick > 10000) {
-			this._debug(`Long tick detected (${now - this._lastTick})`);
-			this.netHiccup();
+		try {
+			const now = Date.now();
+			if (this._lastTick > 0 && now - this._lastTick > 10000) {
+				this._debug(`Long tick detected (${now - this._lastTick})`);
+				this.netHiccup();
+			}
+			this._lastTick = now;
+		} catch (e) {
+			// ignore
 		}
-		this._lastTick = now;
 	}
 
 	// for test purposes, simulate a long tick (since we can't physically close a laptop!)
@@ -747,7 +751,11 @@ export class Broadcaster {
 			const interval = this.getThrottleInterval();
 			this._debug(`Resubscribing in ${interval} ms...`);
 			setTimeout(() => {
-				this.resubscribe(channels);
+				try {
+					this.resubscribe(channels);
+				} catch (e) {
+					// ignore
+				}
 			}, interval);
 		}
 	}

--- a/shared/agent/src/broadcaster/socketClusterConnection.ts
+++ b/shared/agent/src/broadcaster/socketClusterConnection.ts
@@ -78,61 +78,65 @@ export class SocketClusterConnection implements BroadcasterConnection {
 
 	// confirm the connection to the SocketCluster server is good
 	async _confirmConnection(): Promise<void> {
-		if (this._connectionTimer) {
-			this._debug("Not confirming connection because we already have a connection timer");
-			return;
-		}
-		this._connectionPending = true;
-		this._connected = false;
-		this._debug("Confirming connection...");
-		this._connectionTimer = setTimeout(() => {
-			this._debug("Connection timed out");
-			this._connectionPending = false;
-			delete this._connectionTimer;
-			setTimeout(this._confirmConnection.bind(this), 0);
-		}, 5000);
-
-		this._debug(
-			`Authorizing the connection, host=${this._options!.host} port=${this._options!.port}...`
-		);
 		try {
-			await this._confirmAuth();
-		} catch (error) {
-			const message = error instanceof Error ? error.message : JSON.stringify(error);
-			this._debug(`Unable to authorize connection: ${message}`);
+			if (this._connectionTimer) {
+				this._debug("Not confirming connection because we already have a connection timer");
+				return;
+			}
+			this._connectionPending = true;
+			this._connected = false;
+			this._debug("Confirming connection...");
+			this._connectionTimer = setTimeout(() => {
+				this._debug("Connection timed out");
+				this._connectionPending = false;
+				delete this._connectionTimer;
+				setTimeout(this._confirmConnection.bind(this), 0);
+			}, 5000);
+
+			this._debug(
+				`Authorizing the connection, host=${this._options!.host} port=${this._options!.port}...`
+			);
+			try {
+				await this._confirmAuth();
+			} catch (error) {
+				const message = error instanceof Error ? error.message : JSON.stringify(error);
+				this._debug(`Unable to authorize connection: ${message}`);
+				if (this._connectionTimer) {
+					clearTimeout(this._connectionTimer);
+					delete this._connectionTimer;
+				}
+				this._debug("Trying again in 1000 ms...");
+				setTimeout(this._confirmConnection.bind(this), 1000);
+				return;
+			}
+			this._debug(`Connection was authorized, socket ${this._socket!.id}`);
 			if (this._connectionTimer) {
 				clearTimeout(this._connectionTimer);
 				delete this._connectionTimer;
 			}
-			this._debug("Trying again in 1000 ms...");
-			setTimeout(this._confirmConnection.bind(this), 1000);
-			return;
-		}
-		this._debug(`Connection was authorized, socket ${this._socket!.id}`);
-		if (this._connectionTimer) {
-			clearTimeout(this._connectionTimer);
-			delete this._connectionTimer;
-		}
-		this._connectionPending = false;
-		this._connected = true;
+			this._connectionPending = false;
+			this._connected = true;
 
-		(async () => {
-			for await (const { channel } of this._socket!.listener("subscribe")) {
-				this._handleSubscribe(channel);
-			}
-		})();
-
-		(async () => {
-			for await (const { error } of this._socket!.listener("error")) {
-				this._debug(`SOCKET ERROR, socket ${this._socket!.id}: ${JSON.stringify(error)}`);
-				if (this._connectionPending) {
-					const message = error instanceof Error ? error.message : JSON.stringify(error);
-					this._debug(`Received error during connection: ${message}`);
-				} else {
-					this.netHiccup();
+			(async () => {
+				for await (const { channel } of this._socket!.listener("subscribe")) {
+					this._handleSubscribe(channel);
 				}
-			}
-		})();
+			})();
+
+			(async () => {
+				for await (const { error } of this._socket!.listener("error")) {
+					this._debug(`SOCKET ERROR, socket ${this._socket!.id}: ${JSON.stringify(error)}`);
+					if (this._connectionPending) {
+						const message = error instanceof Error ? error.message : JSON.stringify(error);
+						this._debug(`Received error during connection: ${message}`);
+					} else {
+						this.netHiccup();
+					}
+				}
+			})();
+		} catch (e) {
+			this._debug("Error confirming connection", e);
+		}
 	}
 
 	disconnect(): void {

--- a/shared/agent/src/session.ts
+++ b/shared/agent/src/session.ts
@@ -409,9 +409,13 @@ export class CodeStreamSession {
 						if (!this._broadcasterRecoveryTimer) {
 							Logger.log("Will check for recovery in 30s...");
 							this._broadcasterRecoveryTimer = setTimeout(() => {
-								delete this._broadcasterRecoveryTimer;
-								Logger.log("Calling API server to detect broadcaster recovery");
-								this.api.fetch("/no-auth/capabilities");
+								try {
+									delete this._broadcasterRecoveryTimer;
+									Logger.log("Calling API server to detect broadcaster recovery");
+									this.api.fetch("/no-auth/capabilities");
+								} catch (ex) {
+									Logger.warn("broadcast recovery error", ex);
+								}
 							}, 30000);
 						}
 					}
@@ -1808,16 +1812,20 @@ export class CodeStreamSession {
 	}
 
 	echoTimeout() {
-		Logger.warn(
-			"Have not received an echo for 10 seconds, setting connection status to Reconnecting"
-		);
-		this.agent.sendNotification(DidChangeConnectionStatusNotificationType, {
-			status: ConnectionStatus.Reconnecting,
-			code: ConnectionCode.EchoTimeout,
-		});
-		this._echoDidTimeout = true;
-		if (this.isOnPrem && this.apiCapabilities.echoes) {
-			this.listenForEchoes();
+		try {
+			Logger.warn(
+				"Have not received an echo for 10 seconds, setting connection status to Reconnecting"
+			);
+			this.agent.sendNotification(DidChangeConnectionStatusNotificationType, {
+				status: ConnectionStatus.Reconnecting,
+				code: ConnectionCode.EchoTimeout,
+			});
+			this._echoDidTimeout = true;
+			if (this.isOnPrem && this.apiCapabilities.echoes) {
+				this.listenForEchoes();
+			}
+		} catch (ex) {
+			Logger.warn("echoTimeout error", ex);
 		}
 	}
 

--- a/shared/agent/src/system/fetchCore.ts
+++ b/shared/agent/src/system/fetchCore.ts
@@ -56,7 +56,13 @@ export async function fetchCore(
 	try {
 		handleLimit(origin);
 		const controller = new AbortController();
-		timeout = setTimeout(() => controller.abort(), init.timeout ?? 30000);
+		timeout = setTimeout(() => {
+			try {
+				controller.abort();
+			} catch (e) {
+				Logger.warn("AbortController error", e);
+			}
+		}, init.timeout ?? 30000);
 		init.signal = controller.signal;
 		const resp = await fetch(url, init);
 		if (resp.status < 200 || resp.status > 299) {

--- a/shared/agent/src/system/fetchCore.ts
+++ b/shared/agent/src/system/fetchCore.ts
@@ -55,11 +55,9 @@ export async function fetchCore(
 	const init = { ...initIn };
 	try {
 		handleLimit(origin);
-		if (init.timeout) {
-			const controller = new AbortController();
-			timeout = setTimeout(() => controller.abort(), init.timeout);
-			init.signal = controller.signal;
-		}
+		const controller = new AbortController();
+		timeout = setTimeout(() => controller.abort(), init.timeout ?? 30000);
+		init.signal = controller.signal;
 		const resp = await fetch(url, init);
 		if (resp.status < 200 || resp.status > 299) {
 			if (resp.status < 400 || resp.status >= 500) {

--- a/shared/ui/src/__tests__/webview-api.test.ts
+++ b/shared/ui/src/__tests__/webview-api.test.ts
@@ -20,12 +20,12 @@ describe("RequestApiManager", () => {
 		});
 		jest.useFakeTimers().setSystemTime(new Date("2023-02-01T08:05:01"));
 		const stales = subject.collectStaleRequests();
-		expect(stales.length).toBe(1);
+		expect(stales.size).toBe(1);
 	});
 
-	it("should not detect stale requests at or under 5 minutes", () => {
+	it("should not detect stale requests at or under 1 minutes", () => {
 		const subject = new RequestApiManager(false);
-		jest.useFakeTimers().setSystemTime(new Date("2023-02-01T08:00:00"));
+		jest.useFakeTimers().setSystemTime(new Date("2023-02-01T08:04:00"));
 		const id = nextId();
 		subject.set(id, {
 			method: "/whatever",
@@ -34,7 +34,7 @@ describe("RequestApiManager", () => {
 		});
 		jest.useFakeTimers().setSystemTime(new Date("2023-02-01T08:05:00"));
 		const stales = subject.collectStaleRequests();
-		expect(stales.length).toBe(0);
+		expect(stales.size).toBe(0);
 	});
 
 	it("should alert when requests to same method > ALERT_THRESHOLD", () => {
@@ -125,11 +125,11 @@ describe("RequestApiManager", () => {
 		jest.spyOn(Date, "now").mockImplementation(() => theNow);
 		const staleRequests = subject.collectStaleRequests();
 		// expect(spyDateNow).toHaveBeenCalledTimes(6);
-		expect(staleRequests.sort()).toStrictEqual(
-			[
-				"Found 2 stale requests for /whenever with oldest at 2023-03-22T23:41:42.000Z",
-				"Found 5 stale requests for /whatever with oldest at 2023-03-22T23:41:42.000Z",
-			].sort()
-		);
+		const whatevers = staleRequests.get("/whatever");
+		expect(whatevers?.deleteKeys.length).toBe(5);
+		const whenevers = staleRequests.get("/whenever");
+		expect(whenevers?.deleteKeys.length).toBe(2);
+		expect(new Date(whatevers!.oldestDate!).toISOString()).toBe("2023-03-22T23:41:42.000Z");
+		expect(new Date(whenevers!.oldestDate!).toISOString()).toBe("2023-03-22T23:41:42.000Z");
 	});
 });

--- a/shared/ui/webview-api.ts
+++ b/shared/ui/webview-api.ts
@@ -197,7 +197,9 @@ export class RequestApiManager {
 				}
 			}
 		}
-		logError(report);
+		if (report) {
+			logError(report);
+		}
 	}
 
 	public collectStaleRequests(): Map<string, StaleRequestGroup> {

--- a/shared/ui/webview-api.ts
+++ b/shared/ui/webview-api.ts
@@ -36,7 +36,29 @@ type Listener<NT extends NotificationType<any, any> = NotificationType<any, any>
 
 const ALERT_THRESHOLD = 20;
 
-const STALE_THRESHOLD = 300; // 5 minutes
+const STALE_THRESHOLD = 60; // 1 minute
+
+class StaleRequestGroup {
+	private _oldestDate: number | undefined = undefined;
+	private _deleteKeys: string[] = [];
+
+	get deleteKeys() {
+		return this._deleteKeys;
+	}
+
+	get oldestDate() {
+		return this._oldestDate;
+	}
+
+	addRequest(requestId: string, timestamp: number) {
+		this._deleteKeys.push(requestId);
+		if (!this._oldestDate) {
+			this._oldestDate = timestamp;
+		} else if (timestamp < this._oldestDate) {
+			this._oldestDate = timestamp;
+		}
+	}
+}
 
 const normalizeNotificationsMap = new Map<
 	NotificationType<any, any>,
@@ -153,22 +175,34 @@ export class RequestApiManager {
 	private pendingRequests = new Map<string, WebviewApiRequest>();
 	private historyCounter = new HistoryCounter("webview", 15, 25, console.debug, true);
 
-	constructor(enableStaleReport = true) {
-		if (enableStaleReport) {
-			setInterval(this.reportStaleRequests.bind(this), 60000);
+	constructor(enablePurge = true) {
+		if (enablePurge) {
+			setInterval(this.purgeStaleRequests.bind(this), 60000);
 		}
 	}
 
-	private reportStaleRequests() {
-		const report = this.collectStaleRequests();
-		for (const item of report) {
-			logError(item);
+	private purgeStaleRequests() {
+		const result = this.collectStaleRequests();
+		let report = "";
+		for (const [method, staleGroup] of result) {
+			const oldest = staleGroup?.oldestDate
+				? new Date(staleGroup.oldestDate).toISOString()
+				: "unknown";
+			report += `purging ${staleGroup.deleteKeys.length} stale requests for ${method} with oldest ${oldest}\n`;
+			for (const key of staleGroup.deleteKeys) {
+				const pending = this.get(key);
+				if (pending) {
+					this.delete(key);
+					pending.reject("agent request timed out");
+				}
+			}
 		}
+		logError(report);
 	}
 
-	public collectStaleRequests(): Array<string> {
+	public collectStaleRequests(): Map<string, StaleRequestGroup> {
 		const now = Date.now();
-		const staleRequests = new Map<string, { count: number; oldestDate: number }>();
+		const staleRequests = new Map<string, StaleRequestGroup>();
 		for (const [key, value] of this.pendingRequests) {
 			const parts = key.split(":");
 			if (parts.length < 3) {
@@ -177,25 +211,12 @@ export class RequestApiManager {
 			const timestamp = parseInt(parts[3]);
 			const timeAgo = (now - timestamp) / 1000;
 			if (timeAgo > STALE_THRESHOLD) {
-				const existing = staleRequests.get(value.method);
-				if (!existing) {
-					staleRequests.set(value.method, { count: 1, oldestDate: timestamp });
-				} else if (existing) {
-					existing.count = existing.count + 1;
-					if (timestamp < existing.oldestDate) {
-						existing.oldestDate = timestamp;
-					}
-				}
+				const staleGroup = staleRequests.get(value.method) ?? new StaleRequestGroup();
+				staleRequests.set(value.method, staleGroup);
+				staleGroup.addRequest(key, timestamp);
 			}
 		}
-		const stales = new Array<string>();
-		for (const [key, value] of staleRequests) {
-			const theDate = new Date(value.oldestDate);
-			stales.push(
-				`Found ${value.count} stale requests for ${key} with oldest at ${theDate.toISOString()}`
-			);
-		}
-		return stales;
+		return staleRequests;
 	}
 
 	public get(key: string): WebviewApiRequest | undefined {
@@ -237,7 +258,7 @@ export class HostApi extends EventEmitter {
 		port.onmessage = ({ data }: { data: WebviewIpcMessage }) => {
 			if (isIpcResponseMessage(data)) {
 				const pending = this.apiManager.get(data.id);
-				if (pending == null) {
+				if (!pending) {
 					console.debug(
 						`received response from host for ${data.id}; unable to find a pending request`,
 						data


### PR DESCRIPTION
- Use fetchCore built-in timeout so that each retry has the same timeout limit - otherwise the retries were getting aborted without doing a retry
- Instead of reporting, reject and delete stale requests after 60 seconds
- Try catch all setInterval / setTimeout to stop agent crashes
- Gather and report node crash errors in JB to amplitude