### PR TITLE
NR-152794 Can't upload files in codemarks (and other areas)

### DIFF
--- a/shared/agent/package-lock.json
+++ b/shared/agent/package-lock.json
@@ -24,7 +24,6 @@
 				"diff-match-patch": "1.0.5",
 				"encoding": "0.1.13",
 				"eol": "0.9.1",
-				"form-data": "3.0.0",
 				"glob-promise": "4.2.2",
 				"graphql": "15.5.0",
 				"graphql-request": "4.0.0",

--- a/shared/agent/package.json
+++ b/shared/agent/package.json
@@ -71,7 +71,6 @@
 		"diff-match-patch": "1.0.5",
 		"encoding": "0.1.13",
 		"eol": "0.9.1",
-		"form-data": "3.0.0",
 		"glob-promise": "4.2.2",
 		"graphql": "15.5.0",
 		"graphql-request": "4.0.0",

--- a/shared/util/src/protocol/agent/agent.protocol.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.ts
@@ -410,11 +410,10 @@ export interface CodeStreamDiffUriData {
 }
 
 export interface UploadFileRequest {
-	path: string;
 	name: string;
 	mimetype: string;
 	size: number;
-	buffer?: any;
+	buffer?: string | ArrayBuffer | null;
 }
 
 export interface UploadFileResponse {

--- a/shared/util/src/protocol/agent/api.protocol.models.ts
+++ b/shared/util/src/protocol/agent/api.protocol.models.ts
@@ -400,7 +400,7 @@ export interface Attachment {
 	title: string;
 	type: string;
 	url?: string;
-	size?: number;
+	size: number;
 }
 
 export interface CSPost extends CSEntity {


### PR DESCRIPTION
- Removed unsued path in UploadFileRequest
- Give buffer a type
- Remove obsolete library form-data
- Use Blob to append form data for file upload
- Add error handling to uploadFile
- Disentangle browser File from react AttachmentField