### PR TITLE
Dependency Mismatch Causing Catastrophic Failure Loading CodeStream

### DIFF
--- a/vs/src/CodeStream.VisualStudio.Shared/Services/MessageInterceptorService.cs
+++ b/vs/src/CodeStream.VisualStudio.Shared/Services/MessageInterceptorService.cs
@@ -73,13 +73,23 @@ namespace CodeStream.VisualStudio.Shared.Services
 			{
 				var uri = uriToken.Value<string>();
 
-				// 1. Must be a temp file URI
+				// 1. Must be a temp file URId
 				// 2. DiffViewer must contain the OverrideFileUri
 				// 3. DiffViewer must contain the original temp file URI, and it must match our token path
-				if(
+
+				var codeStreamDiffUri = string.Empty;
+				if(!diffViewer.Properties?.TryGetProperty(PropertyNames.OverrideFileUri, out codeStreamDiffUri) ?? false){
+					continue;
+				}
+
+				var tempFileUri = string.Empty;
+				if(!diffViewer.Properties?.TryGetProperty(PropertyNames.OriginalTempFileUri, out tempFileUri) ?? false)
+				{
+					continue;
+				}
+
+				if (
 					uri.IsTempFile() 
-					&& (diffViewer.Properties?.TryGetProperty(PropertyNames.OverrideFileUri, out string codeStreamDiffUri) ?? false)
-					&& (diffViewer.Properties?.TryGetProperty(PropertyNames.OriginalTempFileUri, out string tempFileUri) ?? false)
 					&& tempFileUri.ToUri().EqualsIgnoreCase(uri.ToUri()))
 				{
 					message?.SelectToken(uriToken.Path)?.Replace(new JValue(codeStreamDiffUri));

--- a/vs/src/CodeStream.VisualStudio.Shared/Services/SymbolService.cs
+++ b/vs/src/CodeStream.VisualStudio.Shared/Services/SymbolService.cs
@@ -66,8 +66,11 @@ namespace CodeStream.VisualStudio.Shared.Services
 							continue;
 						}
 
-						_ = await _workspace.TryGoToDefinitionAsync(symbol, project, cancellationToken);
-
+						#if X86
+							_workspace.TryGoToDefinition(symbol, project, cancellationToken);
+						#else
+							_ = await _workspace.TryGoToDefinitionAsync(symbol, project, cancellationToken);
+						#endif
 						break;
 					}
 				}

--- a/vs/src/CodeStream.VisualStudio.UnitTests/CodeStream.VisualStudio.UnitTests.csproj
+++ b/vs/src/CodeStream.VisualStudio.UnitTests/CodeStream.VisualStudio.UnitTests.csproj
@@ -113,23 +113,17 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ApprovalTests">
-      <Version>5.7.3</Version>
-    </PackageReference>
-    <PackageReference Include="ApprovalUtilities">
-      <Version>5.7.3</Version>
-    </PackageReference>
     <PackageReference Include="Castle.Core">
-      <Version>5.1.0</Version>
+      <Version>5.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>17.3.0</Version>
+      <Version>17.7.2</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Validation">
+      <Version>15.3.58</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.18.2</Version>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>4.18.4</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
       <Version>6.0.0</Version>
@@ -138,19 +132,21 @@
       <Version>4.5.4</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.4.2</Version>
+      <Version>2.5.0</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.console">
-      <Version>2.4.2</Version>
+      <Version>2.5.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.4.5</Version>
+      <Version>2.5.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/vs/src/CodeStream.VisualStudio.UnitTests/Services/MessageInterceptorServiceTests/InterceptAndModify.cs
+++ b/vs/src/CodeStream.VisualStudio.UnitTests/Services/MessageInterceptorServiceTests/InterceptAndModify.cs
@@ -242,7 +242,7 @@ namespace CodeStream.VisualStudio.UnitTests.Services.MessageInterceptorServiceTe
 
 			var result = _messageInterceptorService.InterceptAndModify(message);
 
-			Assert.NotEqual(message.Params, result["params"]);
+			Assert.Equal(message.Params, result["params"]); //collection structure unchanged
 			Assert.Equal(result["params"]?["uri"], realFile);
 		}
 
@@ -279,7 +279,7 @@ namespace CodeStream.VisualStudio.UnitTests.Services.MessageInterceptorServiceTe
 
 			var result = _messageInterceptorService.InterceptAndModify(message);
 
-			Assert.NotEqual(message.Params, result["params"]);
+			Assert.Equal(result["params"], message.Params); //collection structure unchanged
 			Assert.Equal(result["params"]?["someParam"]?["anotherParam"]?["uri"], realFile);
 		}
 

--- a/vs/src/CodeStream.VisualStudio.UnitTests/app.config
+++ b/vs/src/CodeStream.VisualStudio.UnitTests/app.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+	<runtime>
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Newtonsoft.Json"
+								  publicKeyToken="30ad4fe6b2a6aeed"
+								  culture="neutral" />
+
+				<bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
+</configuration>

--- a/vs/src/CodeStream.VisualStudio.Vsix.x86/CodeStream.VisualStudio.Vsix.x86.csproj
+++ b/vs/src/CodeStream.VisualStudio.Vsix.x86/CodeStream.VisualStudio.Vsix.x86.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <TargetVsixContainerName>codestream-vs.vsix</TargetVsixContainerName>
@@ -586,7 +586,7 @@
       <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>4.6.0</Version>
+      <Version>3.11.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>6.0.0</Version>
@@ -625,7 +625,7 @@
       <Version>16.2.1079</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
-      <Version>4.6.0</Version>
+      <Version>3.11.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
       <Version>16.0.206</Version>


### PR DESCRIPTION
Found the culprit package and downgraded to get proper transitive dependencies. Also had to make minor changes for Symbol lookup (for the downgrade), and refactor the code for the MessageInterceptorService because it didnt compile natively in VS2019