### PR TITLE
fossa remediation advice logic NR-162079

### DIFF
--- a/shared/ui/Stream/CodeAnalyzers/FossaIssues.tsx
+++ b/shared/ui/Stream/CodeAnalyzers/FossaIssues.tsx
@@ -211,10 +211,26 @@ const VulnerabilityRow = (props: { issue: VulnerabilityIssue }) => {
 	const [expanded, setExpanded] = useState<boolean>(false);
 	const vuln = props.issue;
 
+	function remediationFix() {
+		if (vuln.remediation.partialFix === vuln.remediation.completeFix) {
+			if (vuln.remediation.partialFixDistance) {
+				return `${vuln.remediation.partialFixDistance} : ${vuln.remediation.partialFix}`;
+			} else {
+				return vuln.remediation.partialFix;
+			}
+		} else {
+			if (vuln.remediation.partialFixDistance && vuln.remediation.completeFixDistance) {
+				return `Partial Remediation: ${vuln.remediation.partialFixDistance} : ${vuln.remediation.partialFix} Complete Remediation: ${vuln.remediation.completeFixDistance} : ${vuln.remediation.completeFix}`;
+			} else {
+				return `Partial Remediation: ${vuln.remediation.partialFix} Complete Remediation: ${vuln.remediation.completeFix}`;
+			}
+		}
+	}
+
+	const remedFix = remediationFix();
+
 	const subtleText = vuln.remediation
-		? `${vuln.source.version} -> ${
-				vuln.remediation.completeFixDistance ? vuln.remediation.completeFixDistance : "Unknown Fix"
-		  }`
+		? `${vuln.source.version} -> ${remedFix}`
 		: vuln.source.version;
 	const tooltipText = `Vulnerability: ${vuln.title}`;
 
@@ -250,7 +266,7 @@ const VulnerabilityRow = (props: { issue: VulnerabilityIssue }) => {
 						details={vuln.details}
 						displays={[
 							{ label: "Dependency", description: vuln.source.name },
-							{ label: "Remediation Advice", description: vuln.remediation.completeFixDistance },
+							{ label: "Remediation Advice", description: remedFix },
 							{ label: "CVE", description: vuln.cve },
 							{
 								label: "Affected Project:",


### PR DESCRIPTION
This is the block coming in:
```
"remediation": {
                "partialFix": "5.7.2",
                "partialFixDistance": "PATCH", (this key wont be present if they cant determine if PATCH, MINOR, MAJOR, etc)
                "completeFix": "5.7.2",
                "completeFixDistance": "PATCH" (also might not be set)
            }
```
The logic we want to do here is:
```
// if these are the same, the partial and complete are the same
if (remediation.partialFix.equals(remediation.completeFix)) {
     if (isset(remediation.partialFixDistance)) {
                display remediation.partialFixDistance + ":" + remediation.partialFix
      } else {
                 display remediation.partialFix
      }
} else {
// we have both a partial and a complete fix, so we need to display both
      display 'Partial Remediation:' + isset(remediation.partialFixDistance) ? remediation.partialFixDistance : "" + remediation.partialFix
      display 'Complete Remediation:' + isset(remediation.completeFixDistance) ? remediation.completeFixDistance : "" + remediation.completeFix
}
```