### PR TITLE
NR-171481 Cleanup refreshMaintenancePoll

### DIFF
--- a/jb/src/main/kotlin/agent/CodeStreamLanguageClient.kt
+++ b/jb/src/main/kotlin/agent/CodeStreamLanguageClient.kt
@@ -257,6 +257,12 @@ class CodeStreamLanguageClient(private val project: Project) : LanguageClient {
         project.webViewService?.postNotification("codestream/nr/didResolveStackTraceLine", json, true)
     }
 
+    @JsonNotification("codestream/refreshMaintenancePoll")
+    fun refreshMaintenancePoll(json: JsonElement) {
+        // no-op justo register and stop getting Unsupported notification method logs
+        logger.info("codeStream/refreshMaintenancePoll $json")
+    }
+
     @JsonNotification("codestream/didChangeCodelenses")
     fun didChangeCodelenses(json: JsonElement?) {
         project.sessionService?.didChangeCodelenses()


### PR DESCRIPTION
- Debounce firing RefreshMaintenancePollNotificationType

This helps mostly at startup when there are almost 50 api requests in a very short time - will only fire 2-3 times at startup now