### PR TITLE
same org_id show auth domain instead of its type

### DIFF
--- a/shared/util/src/protocol/agent/api.protocol.ts
+++ b/shared/util/src/protocol/agent/api.protocol.ts
@@ -109,6 +109,7 @@ export interface CSPossibleAuthDomain {
 	organization_id: string;
 	organization_name: string;
 	user_id: number;
+	useDomainName: boolean;
 }
 
 export interface CSAccessTokenInfo {


### PR DESCRIPTION
_WIP: blocked by NR work soon to arrive where we will use NR user_id for same org_id checkmark bug_

same organization_id scenario:
![image](https://github.com/TeamCodeStream/codestream/assets/10050393/f1e5bec9-8f9f-4b14-9857-1c39ac201244)


different organization_id scenario:
![image](https://github.com/TeamCodeStream/codestream/assets/10050393/8eba18fb-c040-4449-acad-07e3d3f0f716)
