### PR TITLE
NR-177957 Newly opened repo not always getting recognized by CS pane

### DIFF
--- a/shared/agent/src/git/gitService.ts
+++ b/shared/agent/src/git/gitService.ts
@@ -32,7 +32,7 @@ SOFTWARE.
 import * as fs from "fs";
 import * as path from "path";
 
-import { CommitsChangedData, WorkspaceChangedData } from "@codestream/protocols/agent";
+import { CommitsChangedData, RepoMap, WorkspaceChangedData } from "@codestream/protocols/agent";
 import { FileStatus } from "@codestream/protocols/api";
 import { Iterables } from "@codestream/utils/system/iterable";
 import { createPatch, ParsedDiff, parsePatch } from "diff";
@@ -1648,7 +1648,7 @@ export class GitService implements IGitService, Disposable {
 		return result;
 	}
 
-	async setKnownRepository(repos: { repoId: string; path: string }[]) {
+	async setKnownRepository(repos: RepoMap[]) {
 		return this._repositories.setKnownRepository(repos);
 	}
 

--- a/shared/agent/src/git/models/repository.ts
+++ b/shared/agent/src/git/models/repository.ts
@@ -26,7 +26,6 @@ export class GitRepository {
 		public readonly path: string,
 		public readonly root: boolean,
 		public readonly folder: WorkspaceFolder,
-
 		public readonly isInWorkspace?: boolean
 	) {
 		this.normalizedPath = (this.path.endsWith("/") ? this.path : `${this.path}/`).toLowerCase();

--- a/shared/agent/src/git/repositoryLocator.ts
+++ b/shared/agent/src/git/repositoryLocator.ts
@@ -19,7 +19,10 @@ export class RepositoryLocator {
 	private readonly _searchPromise: Promise<GitRepository[]> | undefined;
 	private _startCorePromise: Promise<any> | undefined;
 
-	constructor(public readonly session: CodeStreamSession, private readonly _git: GitServiceLite) {
+	constructor(
+		public readonly session: CodeStreamSession,
+		private readonly _git: GitServiceLite
+	) {
 		this._repositoryTree = TernarySearchTree.forPaths();
 
 		this._searchPromise = this.start();
@@ -138,8 +141,10 @@ export class RepositoryLocator {
 			rootPath = await this._git.getRepoRoot(folderUri.fsPath);
 		} catch {}
 		if (rootPath) {
-			Logger.log(`repositorySearch: Repository found in '${rootPath}'`);
-			const repo = new GitRepository(rootPath, true, folder);
+			Logger.log(
+				`repositorySearch: Repository found in rootPath '${rootPath}' isInWorkspace=${isInWorkspace}`
+			);
+			const repo = new GitRepository(rootPath, true, folder, isInWorkspace);
 			repositories.push(repo);
 		}
 
@@ -180,10 +185,13 @@ export class RepositoryLocator {
 				}),
 			];
 
-			excludes = excludedPaths.reduce((accumulator, current) => {
-				accumulator[current] = true;
-				return accumulator;
-			}, Object.create(null) as any);
+			excludes = excludedPaths.reduce(
+				(accumulator, current) => {
+					accumulator[current] = true;
+					return accumulator;
+				},
+				Object.create(null) as any
+			);
 		}
 
 		let paths;
@@ -220,8 +228,10 @@ export class RepositoryLocator {
 			} catch {}
 			if (!rp) continue;
 
-			Logger.log(`repositorySearch: Repository found in '${rp}'`);
-			const repo = new GitRepository(rp, false, folder);
+			Logger.log(
+				`repositorySearch: Repository found in subdir '${rp}' isInWorkspace=${isInWorkspace}`
+			);
+			const repo = new GitRepository(rp, false, folder, isInWorkspace);
 			repositories.push(repo);
 		}
 

--- a/shared/agent/src/managers/repositoryMappingManager.ts
+++ b/shared/agent/src/managers/repositoryMappingManager.ts
@@ -94,6 +94,7 @@ export class RepositoryMappingManager {
 							return {
 								repoId: _.repoId,
 								path: URI.file(_.path).toString(),
+								isInWorkspace: _.isInWorkspace,
 							};
 						})
 					);

--- a/shared/ui/Stream/CurrentRepoContext.tsx
+++ b/shared/ui/Stream/CurrentRepoContext.tsx
@@ -81,7 +81,7 @@ export const CurrentRepoContext = React.memo((props: Props) => {
 
 			setCurrentRepoName(repoName);
 			console.debug(
-				`o11y: setting currentRepoCallback currentRepo?.id  ${repo.id} scmInfo?.scm?.repoId ${scmInfo?.scm?.repoId}`
+				`o11y: currentRepoContext: setting currentRepoCallback currentRepo?.id  ${repo.id} scmInfo?.scm?.repoId ${scmInfo?.scm?.repoId}`
 			);
 			props.currentRepoCallback(currentRepoId);
 			dispatch(

--- a/shared/util/src/protocol/agent/agent.protocol.repos.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.repos.ts
@@ -48,6 +48,7 @@ export const GetRepoRequestType = new RequestType<GetRepoRequest, GetRepoRespons
 export interface RepoMap {
 	path: string;
 	repoId: string;
+	isInWorkspace?: boolean;
 }
 
 export interface MapReposRequest {


### PR DESCRIPTION
- New repos are added via event with `isInWorkspace` but when syncKnownRepositories is run it overwrites `isInWorkspace` to false. Retain the `isInWorkspace` state and pass it through the call to mapRepos / setKnownRepository / setKnownRepositoryCore