### PR TITLE
Replace links to codestream@newrelic.com

### DIFF
--- a/shared/ui/Authentication/ProviderAuth.tsx
+++ b/shared/ui/Authentication/ProviderAuth.tsx
@@ -202,7 +202,7 @@ export const ProviderAuth = (connect(undefined) as any)((props: Props) => {
 					</div>
 					<p>
 						<FormattedMessage id="providerAuth.wrong" defaultMessage="Something went wrong? " />
-						<Link href="mailto:codestream@newrelic.com">
+						<Link href="https://one.newrelic.com/help-xp">
 							<FormattedMessage id="providerAuth.contact" defaultMessage="Contact support" />
 						</Link>{" "}
 						<FormattedMessage id="providerAuth.or" defaultMessage="or " />

--- a/shared/ui/Authentication/Signup.tsx
+++ b/shared/ui/Authentication/Signup.tsx
@@ -511,7 +511,7 @@ export const Signup = (props: Props) => {
 									<div className="error-message form-error">
 										<FormattedMessage id="signUp.conflict" defaultMessage="Invitation conflict." />{" "}
 										<FormattedMessage id="contactSupport" defaultMessage="Contact support">
-											{text => <Link href="mailto:codestream@newrelic.com">{text}</Link>}
+											{text => <Link href="https://one.newrelic.com/help-xp">{text}</Link>}
 										</FormattedMessage>
 										.
 									</div>

--- a/shared/ui/Authentication/SignupNewRelic.tsx
+++ b/shared/ui/Authentication/SignupNewRelic.tsx
@@ -217,7 +217,7 @@ export const SignupNewRelic = () => {
 									<div className="error-message">
 										Invitation conflict.{" "}
 										<FormattedMessage id="contactSupport" defaultMessage="Contact support">
-											{text => <Link href="mailto:codestream@newrelic.com">{text}</Link>}
+											{text => <Link href="https://one.newrelic.com/help-xp">{text}</Link>}
 										</FormattedMessage>
 										.
 									</div>

--- a/shared/ui/Container/index.js
+++ b/shared/ui/Container/index.js
@@ -330,8 +330,8 @@ export default class Container extends React.Component {
 									<a onClick={this.handleClickReload}>Click here</a> to reload.
 									<br />
 									<br />
-									If the problem persists please contact{" "}
-									<a href="mailto:codestream@newrelic.com">codestream@newrelic.com</a>
+									If the problem persists please{" "}
+									<a href="https://one.newrelic.com/help-xp">contact support.</a>
 								</div>
 							</div>
 						</fieldset>

--- a/shared/ui/Stream/PRProviderErrorBanner.tsx
+++ b/shared/ui/Stream/PRProviderErrorBanner.tsx
@@ -152,8 +152,8 @@ export const PRProviderErrorBanner = () => {
 							</Button>
 							<p>
 								If you continue to experience problems with your {derivedState.failedProviderName}{" "}
-								integration, please contact{" "}
-								<a href="mailto:codestream@newrelic.com">customer support</a>.
+								integration, please{" "}
+								<a href="https://one.newrelic.com/help-xp">contact support</a>.
 							</p>
 						</div>
 					</div>


### PR DESCRIPTION
I updated a handful of these to link to https://one.newrelic.com/help-xp instead. Half of these instances aren't even relevant anymore (e.g. signup) but I changed them anyway. There are some that i didn't bother to change.