### PR TITLE
browser mobil otel & lambda support

### DIFF
--- a/shared/agent/src/providers/newrelic/entity/entityProvider.ts
+++ b/shared/agent/src/providers/newrelic/entity/entityProvider.ts
@@ -101,7 +101,7 @@ export class EntityProvider implements Disposable {
 
 			const query = `query search($cursor:String){
 				actor {
-				  entitySearch(query: "type='APPLICATION' and ${statement}", 
+				  entitySearch(query: "type IN ('APPLICATION', 'SERVICE', 'AWSLAMBDAFUNCTION') and ${statement}", 
 				  sortByWithDirection: { attribute: NAME, direction: ASC },
 				  options: { limit: ${limit} }) {
 					count

--- a/shared/agent/src/providers/newrelic/errors/observabilityErrorsProvider.ts
+++ b/shared/agent/src/providers/newrelic/errors/observabilityErrorsProvider.ts
@@ -38,13 +38,18 @@ import { NrApiConfig } from "../nrApiConfig";
 import { isEmpty as _isEmpty } from "lodash";
 import { mapNRErrorResponse, parseId } from "../utils";
 import { ContextLogger } from "../../contextLogger";
+import { CSNewRelicProviderInfo } from "@codestream/protocols/api";
+import { customFetch } from "../../../system/fetchCore";
+
+const ALLOWED_ENTITY_ACCOUNT_DOMAINS_FOR_ERRORS = ["APM", "BROWSER", "EXT", "INFRA"];
 
 @lsp
 export class ObservabilityErrorsProvider {
 	constructor(
 		private reposProvider: ReposProvider,
 		private graphqlClient: NewRelicGraphqlClient,
-		private nrApiConfig: NrApiConfig
+		private nrApiConfig: NrApiConfig,
+		private providerInfo: CSNewRelicProviderInfo | undefined
 	) {}
 
 	/**
@@ -132,7 +137,10 @@ export class ObservabilityErrorsProvider {
 							if (
 								!application.source.entity.guid ||
 								!application.source.entity.account?.id ||
-								application.source.entity.domain !== "APM"
+								!application.source.entity.domain ||
+								!ALLOWED_ENTITY_ACCOUNT_DOMAINS_FOR_ERRORS.includes(
+									application.source.entity.domain
+								)
 							) {
 								continue;
 							}
@@ -327,6 +335,7 @@ export class ObservabilityErrorsProvider {
 		| {
 				entityGuid: string;
 				traceId?: string;
+				stackSourceMap?: string;
 		  }
 		| undefined
 	> {
@@ -379,7 +388,12 @@ export class ObservabilityErrorsProvider {
 						nrql: {
 							results: {
 								entityGuid: string;
-								id: string;
+								id?: string;
+								stackHash?: string;
+								stackTrace?: string;
+								monitorAccountId?: string;
+								appId?: number;
+								releaseIds?: string;
 							}[];
 						};
 					};
@@ -389,7 +403,15 @@ export class ObservabilityErrorsProvider {
 			});
 
 			if (errorTraceResponse) {
-				const errorTraceResult = errorTraceResponse.actor.account.nrql.results[0];
+				const errorTraceResult: {
+					stackHash?: string | number;
+					browserStackHash?: string | number;
+					id?: string;
+					stackTrace?: string;
+					monitorAccountId?: string;
+					appId?: number;
+					releaseIds?: string;
+				} = errorTraceResponse.actor.account.nrql.results[0];
 				if (!errorTraceResult) {
 					ContextLogger.warn("getMetricData missing errorTraceResult", {
 						accountId: accountId,
@@ -401,9 +423,40 @@ export class ObservabilityErrorsProvider {
 					};
 				}
 				if (errorTraceResult) {
+					let stackSourceMap;
+
+					if (
+						errorTraceResult.stackTrace &&
+						errorTraceResult.monitorAccountId &&
+						errorTraceResult.appId &&
+						errorTraceResult.releaseIds
+					) {
+						stackSourceMap = await this.fetchSourceMap(
+							errorTraceResult.stackTrace,
+							errorTraceResult.monitorAccountId,
+							errorTraceResult.appId,
+							errorTraceResult.releaseIds
+						);
+					}
+					let returnTraceId;
+
+					// Use ID if available
+					// otherwise use stackHash unless its negative
+					// then use browserStackHash
+					// make sure they are stringified
+					if (errorTraceResult.id) {
+						returnTraceId = errorTraceResult.id;
+					} else {
+						let stringifiedBrowserStackHash = errorTraceResult.stackTrace?.toString() || "";
+						let stringifiedStackHash = errorTraceResult.stackTrace?.toString() || "";
+						returnTraceId = stringifiedStackHash.startsWith("-")
+							? stringifiedBrowserStackHash
+							: stringifiedStackHash;
+					}
 					return {
 						entityGuid: entityGuid || errorGroupResponse.entityGuid,
-						traceId: errorTraceResult.id,
+						traceId: returnTraceId,
+						stackSourceMap,
 					};
 				}
 			}
@@ -412,6 +465,53 @@ export class ObservabilityErrorsProvider {
 				errorGroupGuid: errorGroupGuid,
 			});
 		}
+		return undefined;
+	}
+
+	private async fetchSourceMap(
+		stackTrace: string,
+		monitorAccountId: string,
+		appId: number,
+		releaseIds: string
+	): Promise<any> {
+		let serviceUrlChunk = "service";
+		if (this.nrApiConfig.productUrl.includes("staging")) {
+			serviceUrlChunk = "staging-service";
+		}
+
+		const url = `https://sourcemaps.${serviceUrlChunk}.newrelic.com/ui/accounts/${monitorAccountId}/applications/${appId}/stacktraces?releaseIds=${encodeURIComponent(
+			releaseIds
+		)}`;
+
+		let headers: { [key: string]: string } = {
+			"Content-Type": "text/plain",
+		};
+
+		const token = this.providerInfo?.accessToken;
+		if (token) {
+			if (this.providerInfo?.tokenType === "access") {
+				headers["x-access-token"] = token;
+			} else {
+				headers["x-id-token"] = token;
+			}
+		}
+
+		try {
+			const response = await customFetch(url, {
+				method: "POST",
+				headers: headers,
+				body: stackTrace,
+			});
+
+			if (!response.ok) {
+				throw new Error(`HTTP error! Status: ${response.status}`);
+			}
+			const responseData = await response.json();
+			return responseData;
+		} catch (error) {
+			ContextLogger.error(error, "fetchSourceMap");
+		}
+
 		return undefined;
 	}
 
@@ -441,7 +541,7 @@ export class ObservabilityErrorsProvider {
 
 		const browserNrql = [
 			"SELECT",
-			"count(guid) as 'count',", // first field is used to sort with FACET
+			"count(*) as 'count',", // first field is used to sort with FACET
 			"latest(timestamp) AS 'lastOccurrence',",
 			"latest(stackHash) AS 'occurrenceId',",
 			"latest(appName) AS 'appName',",
@@ -911,6 +1011,7 @@ export class ObservabilityErrorsProvider {
 				return {
 					entityId: metricResponse?.entityGuid,
 					occurrenceId: metricResponse?.traceId,
+					stackSourceMap: metricResponse?.stackSourceMap,
 					relatedRepos: mappedRepoEntities || [],
 				} as GetObservabilityErrorGroupMetadataResponse;
 			}

--- a/shared/agent/src/providers/newrelic/errors/observabilityErrorsProvider.ts
+++ b/shared/agent/src/providers/newrelic/errors/observabilityErrorsProvider.ts
@@ -447,7 +447,7 @@ export class ObservabilityErrorsProvider {
 					if (errorTraceResult.id) {
 						returnTraceId = errorTraceResult.id;
 					} else {
-						let stringifiedBrowserStackHash = errorTraceResult.stackHash?.toString() || "";
+						let stringifiedBrowserStackHash = errorTraceResult.browserStackHash?.toString() || "";
 						let stringifiedStackHash = errorTraceResult.stackHash?.toString() || "";
 						returnTraceId = stringifiedStackHash.startsWith("-")
 							? stringifiedBrowserStackHash

--- a/shared/agent/src/providers/newrelic/errors/observabilityErrorsProvider.ts
+++ b/shared/agent/src/providers/newrelic/errors/observabilityErrorsProvider.ts
@@ -447,8 +447,8 @@ export class ObservabilityErrorsProvider {
 					if (errorTraceResult.id) {
 						returnTraceId = errorTraceResult.id;
 					} else {
-						let stringifiedBrowserStackHash = errorTraceResult.stackTrace?.toString() || "";
-						let stringifiedStackHash = errorTraceResult.stackTrace?.toString() || "";
+						let stringifiedBrowserStackHash = errorTraceResult.stackHash?.toString() || "";
+						let stringifiedStackHash = errorTraceResult.stackHash?.toString() || "";
 						returnTraceId = stringifiedStackHash.startsWith("-")
 							? stringifiedBrowserStackHash
 							: stringifiedStackHash;

--- a/shared/agent/src/providers/newrelic/nrContainer.ts
+++ b/shared/agent/src/providers/newrelic/nrContainer.ts
@@ -106,7 +106,8 @@ export async function injectNR(sessionServiceContainer: SessionServiceContainer)
 	const observabilityErrorsProvider = new ObservabilityErrorsProvider(
 		reposProvider,
 		newRelicGraphqlClient,
-		nrApiConfig
+		nrApiConfig,
+		newRelicProviderInfo,
 	);
 
 	const entityProvider = new EntityProvider(newRelicGraphqlClient);

--- a/shared/agent/src/providers/newrelic/repos/reposProvider.ts
+++ b/shared/agent/src/providers/newrelic/repos/reposProvider.ts
@@ -164,11 +164,12 @@ export class ReposProvider implements Disposable {
 					const entitiesReponse = await this.findRelatedEntityByRepositoryGuids(
 						repositoryEntitiesResponse?.entities?.map(_ => _.guid)
 					);
-					// find the APPLICATION entities themselves
+					// find the APPLICATION, SERVICE (otel), and AWSLAMBDA entities themselves
 					applicationAssociations = entitiesReponse?.actor?.entities?.filter(
 						_ =>
-							_?.relatedEntities?.results?.filter(r => r.source?.entity?.type === "APPLICATION")
-								.length
+							_?.relatedEntities?.results?.filter(
+								r => r.source?.entity?.type === "APPLICATION" || "SERVICE" || "AWSLAMBDAFUNCTION"
+							).length
 					);
 					hasRepoAssociation = applicationAssociations?.length > 0;
 
@@ -212,7 +213,10 @@ export class ReposProvider implements Disposable {
 
 						for (const relatedResult of entity.relatedEntities.results) {
 							if (
-								relatedResult?.source?.entity?.type === "APPLICATION" &&
+								relatedResult?.source?.entity?.type &&
+								["APPLICATION", "SERVICE", "AWSLAMBDAFUNCTION"].includes(
+									relatedResult?.source?.entity?.type
+								) &&
 								relatedResult?.target?.entity?.type === "REPOSITORY"
 							) {
 								// we can't use the target.tags.account since the Repo entity might have been

--- a/shared/agent/test/unit/providers/newrelic/observabilityErrorsProvider.spec.ts
+++ b/shared/agent/test/unit/providers/newrelic/observabilityErrorsProvider.spec.ts
@@ -3,6 +3,7 @@ import { ReposProvider } from "../../../../src/providers/newrelic/repos/reposPro
 import { NewRelicGraphqlClient } from "../../../../src/providers/newrelic/newRelicGraphqlClient";
 import { NrApiConfig } from "../../../../src/providers/newrelic/nrApiConfig";
 import { describe, expect, it } from "@jest/globals";
+import { CSNewRelicProviderInfo } from "@codestream/protocols/api";
 
 describe("ObservabilityErrorsProvider", () => {
 	it("tryFormatStack", async () => {
@@ -104,11 +105,13 @@ describe("ObservabilityErrorsProvider", () => {
 		const mockReposProvider = {} as ReposProvider;
 		const mockNewRelicGraphqlClient = {} as NewRelicGraphqlClient;
 		const mockNrApiConfig = {} as NrApiConfig;
+		const mockNewRelicProviderInfo = {} as CSNewRelicProviderInfo;
 
 		const observabilityErrorsProvider = new ObservabilityErrorsProvider(
 			mockReposProvider,
 			mockNewRelicGraphqlClient,
-			mockNrApiConfig
+			mockNrApiConfig,
+			mockNewRelicProviderInfo,
 		);
 
 		const results = observabilityErrorsProvider.tryFormatStack(data.entityType, data.exception);

--- a/shared/ui/Stream/CodeError/index.tsx
+++ b/shared/ui/Stream/CodeError/index.tsx
@@ -1180,7 +1180,7 @@ const BaseCodeError = (props: BaseCodeErrorProps) => {
 		};
 	}, shallowEqual);
 	const renderedFooter = props.renderFooter && props.renderFooter(CardFooter, ComposeWrapper);
-	const { codeError, errorGroup } = derivedState;
+	const { codeError, errorGroup, currentCodeErrorData } = derivedState;
 	const isPostThreadsLoading: boolean | undefined = useAppSelector(
 		state => state.posts.postThreadsLoading[codeError.postId]
 	);

--- a/shared/ui/Stream/CodeErrorNav.tsx
+++ b/shared/ui/Stream/CodeErrorNav.tsx
@@ -515,6 +515,7 @@ export function CodeErrorNav(props: Props) {
 				if (!refToUse && errorGroupResult?.errorGroup) {
 					refToUse = errorGroupResult.errorGroup.commit || errorGroupResult.errorGroup.releaseTag;
 				}
+
 				if (stack) {
 					stackInfo = (await resolveStackTrace(
 						errorGroupGuidToUse!,
@@ -522,7 +523,8 @@ export function CodeErrorNav(props: Props) {
 						refToUse!,
 						occurrenceIdToUse!,
 						stack!,
-						derivedState.currentCodeErrorId!
+						derivedState.currentCodeErrorId!,
+						derivedState.currentCodeErrorData.stackSourceMap
 					)) as ResolveStackTraceResponse;
 				}
 			}

--- a/shared/ui/Stream/EntityAssociator.tsx
+++ b/shared/ui/Stream/EntityAssociator.tsx
@@ -77,6 +77,10 @@ export const EntityAssociator = React.memo((props: PropsWithChildren<EntityAssoc
 						return "Browser";
 					case "MOBILE_APPLICATION_ENTITY":
 						return "Mobile";
+					case "THIRD_PARTY_SERVICE_ENTITY":
+						return "OTEL";
+					case "INFRASTRUCTURE_AWS_LAMBDA_FUNCTION_ENTITY":
+						return "Lambda";
 					default:
 						return "APM";
 				}

--- a/shared/ui/Stream/MethodLevelTelemetry/MethodLevelTelemetryPanel.tsx
+++ b/shared/ui/Stream/MethodLevelTelemetry/MethodLevelTelemetryPanel.tsx
@@ -431,6 +431,7 @@ export const MethodLevelTelemetryPanel = () => {
 																			pendingErrorGroupGuid: _.errorGroupGuid,
 																			openType: "CLM Details",
 																			remote: _?.remote || undefined,
+																			stackSourceMap: response?.stackSourceMap,
 																		})
 																	);
 																} catch (ex) {

--- a/shared/ui/Stream/MethodLevelTelemetry/ObservabilityAnomalyPanel.tsx
+++ b/shared/ui/Stream/MethodLevelTelemetry/ObservabilityAnomalyPanel.tsx
@@ -352,6 +352,7 @@ export const ObservabilityAnomalyPanel = () => {
 																			pendingErrorGroupGuid: _.errorGroupGuid,
 																			openType: "CLM Details",
 																			remote: _?.remote || undefined,
+																			stackSourceMap: response?.stackSourceMap,
 																		})
 																	);
 																} catch (ex) {

--- a/shared/ui/Stream/Observability.tsx
+++ b/shared/ui/Stream/Observability.tsx
@@ -252,6 +252,8 @@ export const ErrorRow = (props: {
 	);
 };
 
+// EXT for Otel, INFRA for AWSLambda
+const ALLOWED_ENTITY_ACCOUNT_DOMAINS_FOR_ERRORS = ["APM", "BROWSER"];
 const EMPTY_ARRAY = [];
 
 export const Observability = React.memo((props: Props) => {
@@ -1189,6 +1191,9 @@ export const Observability = React.memo((props: Props) => {
 																	});
 																const isSelectedCLM =
 																	ea.entityGuid === currentObservabilityRepoEntity?.entityGuid;
+																const showErrors = ea?.domain
+																	? ALLOWED_ENTITY_ACCOUNT_DOMAINS_FOR_ERRORS.includes(ea.domain)
+																	: false;
 																return (
 																	<>
 																		<PaneNodeName
@@ -1271,12 +1276,13 @@ export const Observability = React.memo((props: Props) => {
 																								recentIssues={recentIssues ? recentIssues : {}}
 																								entityGuid={ea.entityGuid}
 																							/>
-																							{hasServiceLevelObjectives && (
-																								<ObservabilityServiceLevelObjectives
-																									serviceLevelObjectives={serviceLevelObjectives}
-																									errorMsg={serviceLevelObjectiveError}
-																								/>
-																							)}
+																							{hasServiceLevelObjectives &&
+																								ea?.domain !== "INFRA" && (
+																									<ObservabilityServiceLevelObjectives
+																										serviceLevelObjectives={serviceLevelObjectives}
+																										errorMsg={serviceLevelObjectiveError}
+																									/>
+																								)}
 																							{anomalyDetectionSupported && (
 																								<ObservabilityAnomaliesWrapper
 																									observabilityAnomalies={observabilityAnomalies}
@@ -1293,7 +1299,7 @@ export const Observability = React.memo((props: Props) => {
 																								/>
 																							)}
 
-																							{ea.domain === "APM" && (
+																							{showErrors && (
 																								<>
 																									{observabilityErrors?.find(
 																										oe => oe?.repoId === _observabilityRepo?.repoId
@@ -1314,7 +1320,7 @@ export const Observability = React.memo((props: Props) => {
 																									)}
 																								</>
 																							)}
-																							{currentRepoId && (
+																							{currentRepoId && ea?.domain === "APM" && (
 																								<SecurityIssuesWrapper
 																									currentRepoId={currentRepoId}
 																									entityGuid={ea.entityGuid}
@@ -1322,7 +1328,7 @@ export const Observability = React.memo((props: Props) => {
 																									setHasVulnerabilities={setIsVulnPresent}
 																								/>
 																							)}
-																							{currentRepoId && (
+																							{currentRepoId && ea?.domain !== "INFRA" && (
 																								<ObservabilityRelatedWrapper
 																									currentRepoId={currentRepoId}
 																									entityGuid={ea.entityGuid}

--- a/shared/ui/Stream/ObservabilityAssignmentsDropdown.tsx
+++ b/shared/ui/Stream/ObservabilityAssignmentsDropdown.tsx
@@ -101,6 +101,7 @@ export const ObservabilityAssignmentsDropdown = React.memo((props: Props) => {
 															pendingErrorGroupGuid: _.errorGroupGuid,
 															openType: "Observability Section",
 															remote: _?.remote || undefined,
+															stackSourceMap: response?.stackSourceMap,
 														})
 													);
 												} else {

--- a/shared/ui/Stream/ObservabilityErrorDropdown.tsx
+++ b/shared/ui/Stream/ObservabilityErrorDropdown.tsx
@@ -140,6 +140,7 @@ export const ObservabilityErrorDropdown = React.memo((props: Props) => {
 															pendingErrorGroupGuid: err.errorGroupGuid,
 															openType: "Observability Section",
 															remote: err?.remote || undefined,
+															stackSourceMap: response?.stackSourceMap,
 														})
 													);
 												} catch (ex) {

--- a/shared/ui/index.tsx
+++ b/shared/ui/index.tsx
@@ -654,6 +654,7 @@ function listenForEvents(store) {
 								pendingErrorGroupGuid: definedQuery.query.errorGroupGuid,
 								openType: "Open in IDE Flow",
 								environment: definedQuery.query.env,
+								stackSourceMap: response?.stackSourceMap,
 							})
 						);
 						break;

--- a/shared/ui/store/codeErrors/actions.ts
+++ b/shared/ui/store/codeErrors/actions.ts
@@ -123,7 +123,8 @@ export const resolveStackTrace = (
 	ref: string,
 	occurrenceId: string,
 	stackTrace: string[],
-	codeErrorId: string
+	codeErrorId: string,
+	stackSourceMap: any
 ) => {
 	return HostApi.instance.send(ResolveStackTraceRequestType, {
 		errorGroupGuid,
@@ -132,6 +133,7 @@ export const resolveStackTrace = (
 		ref,
 		occurrenceId,
 		codeErrorId,
+		stackSourceMap,
 	});
 };
 

--- a/shared/util/src/protocol/agent/agent.protocol.nr.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.nr.ts
@@ -30,11 +30,23 @@ export interface ResolveStackTraceRequest {
 	repoId: string;
 	ref: string;
 	codeErrorId: string;
+	stackSourceMap: any;
 }
 
 export interface WarningOrError {
 	message: string;
 	helpUrl?: string;
+}
+
+export interface SourceMapEntry {
+	original: {
+		fileName: string;
+	};
+	mapped?: {
+		fileName: string;
+		columnNumber: number;
+		lineNumber: number;
+	};
 }
 
 export interface ResolveStackTraceResponse {

--- a/shared/util/src/protocol/agent/agent.protocol.providers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.providers.ts
@@ -1586,6 +1586,7 @@ export interface GetObservabilityErrorGroupMetadataResponse {
 	entityId?: string;
 	remote?: string;
 	relatedRepos: RelatedRepository;
+	stackSourceMap?: any;
 }
 
 export const GetObservabilityErrorGroupMetadataRequestType = new RequestType<
@@ -1929,6 +1930,7 @@ export type EntityType =
 	| "APM_DATABASE_INSTANCE_ENTITY"
 	| "APM_EXTERNAL_SERVICE_ENTITY"
 	| "BROWSER_APPLICATION_ENTITY"
+	| "THIRD_PARTY_SERVICE_ENTITY"
 	| "DASHBOARD_ENTITY"
 	| "EXTERNAL_ENTITY"
 	| "GENERIC_ENTITY"


### PR DESCRIPTION
fix for browser error stacktraces for traceId mapping to correct occuurenceId

fix to display browser errors

code and comment cleanup, typescript

working browser errors with minified files and source mapping

supression of various funcitons for lambda and otel

undo nr integration panel option hack

code cleanup

awslambda finished integration

work on lambda functions

show errors for otel browser mobile

initial setup to allow otel to appear in entity search