### PR TITLE
Link to NR GTS

### DIFF
--- a/jb/docs/description.html
+++ b/jb/docs/description.html
@@ -40,4 +40,4 @@
 <br/>
 
 <h1 id="helpfeedback">Help &amp; Feedback</h1>
-<p>Check out the <a href="https://docs.newrelic.com/docs/codestream/">user guide</a> for more information on getting started with New Relic CodeStream. Please follow <a href="https://twitter.com/newrelic">@newrelic</a> for product updates and to share feedback and questions. You can also email us at codestream@newrelic.com.</p>
+<p>Check out the <a href="https://docs.newrelic.com/docs/codestream/">user guide</a> for more information on getting started with New Relic CodeStream. Please follow <a href="https://twitter.com/newrelic">@newrelic</a> for product updates and to share feedback and questions. You can also <a href="https://support.newrelic.com">contact support</a>.</p>

--- a/shared/ui/Stream/EllipsisMenu.tsx
+++ b/shared/ui/Stream/EllipsisMenu.tsx
@@ -368,20 +368,20 @@ export function EllipsisMenu(props: EllipsisMenuProps) {
 					key: "documentation",
 					action: () => openUrl("https://docs.newrelic.com/docs/codestream"),
 				},
-				{
-					label: "Keybindings",
-					key: "keybindings",
-					action: () => dispatch(openModal(WebviewModals.Keybindings)),
-				},
+				//{
+				//	label: "Keybindings",
+				//	key: "keybindings",
+				//	action: () => dispatch(openModal(WebviewModals.Keybindings)),
+				//},
 				// {
 				// 	label: "Getting Started Guide",
 				// 	key: "getting-started",
 				// 	action: () => dispatch(openPanel(WebviewPanels.GettingStarted))
 				// },
 				{
-					label: "Report an Issue",
+					label: "Support",
 					key: "issue",
-					action: () => openUrl("https://github.com/TeamCodeStream/codestream/issues"),
+					action: () => openUrl("https://one.newrelic.com/help-xp"),
 				},
 			],
 		},


### PR DESCRIPTION
Under the Help menu, ditch the keyboard bindings popup and change other link to Support that points to GTS.