### PR TITLE
Back to browser esm import for csv-stringify since it shims and break…

### DIFF
--- a/shared/ui/Stream/GenerateCsvFunction.tsx
+++ b/shared/ui/Stream/GenerateCsvFunction.tsx
@@ -1,4 +1,4 @@
-import { stringify } from "csv-stringify/sync";
+import { stringify } from "csv-stringify/browser/esm/sync";
 import { useAppSelector } from "../utilities/hooks";
 import { CodeStreamState } from "../store";
 import { mapFilter } from "../utils";

--- a/shared/ui/jest.config.js
+++ b/shared/ui/jest.config.js
@@ -17,6 +17,7 @@ module.exports = {
 		"^react-native$": "react-native-web",
 		"^.+\\.module\\.(css|sass|scss)$": "identity-obj-proxy",
 		"^lodash-es$": "lodash",
+		"^csv-stringify/browser/esm/sync$": "csv-stringify/sync",
 		"@codestream/webview/Stream/Markdowner": "<rootDir>/Stream/Markdowner.ts",
 		"@codestream/webview/logger": ["<rootDir>/logger.ts"],
 		"^@codestream/protocols/agent$": "<rootDir>../util/src/protocol/agent/agent.protocol.ts",


### PR DESCRIPTION
…s EVERYTHING THAT EXISTS IN NODE. Add workaround for jest to include the non-browser version.