### PR TITLE
Rethrow exceptions after max retries

### DIFF
--- a/shared/agent/src/providers/newrelic/directives/nrDirectives.ts
+++ b/shared/agent/src/providers/newrelic/directives/nrDirectives.ts
@@ -92,8 +92,8 @@ export class NrDirectives {
 			}
 
 			const repoEntityId =
-				response.referenceEntityCreateOrUpdateRepository.updated[0] ||
-				response.referenceEntityCreateOrUpdateRepository.created[0];
+				response?.referenceEntityCreateOrUpdateRepository.updated[0] ||
+				response?.referenceEntityCreateOrUpdateRepository.created[0];
 
 			if (!repoEntityId) {
 				ContextLogger.warn(


### PR DESCRIPTION
Reason: Now that we have places where actual NRQL queries can have user input, it is possible to input a bad query. Previously, even though `query` had a retry limit, the inner portions of `clientRequestWrap` weren't throwing and were in a traditional `while` loop that would never end.

1. Pass retries from `query` down to `clientRequestWrap`
2. Make `clientRequestWrap` only retry the specified number of times
3. Every time through the loop; capture the exception
4. If we have no response but do have an exception at the end, throw it.