### PR TITLE
NR-84070 - Leverage commit SHA collected by agent to handle Node anon…

### DIFF
--- a/jb/src/main/kotlin/agent/AgentService.kt
+++ b/jb/src/main/kotlin/agent/AgentService.kt
@@ -11,6 +11,8 @@ import com.codestream.gson
 import com.codestream.protocols.agent.CSUser
 import com.codestream.protocols.agent.ClmParams
 import com.codestream.protocols.agent.ClmResult
+import com.codestream.protocols.agent.ComputeCurrentLocationsRequest
+import com.codestream.protocols.agent.ComputeCurrentLocationsResult
 import com.codestream.protocols.agent.CreatePermalinkParams
 import com.codestream.protocols.agent.CreatePermalinkResult
 import com.codestream.protocols.agent.CreateShareableCodemarkParams
@@ -546,6 +548,14 @@ class AgentService(private val project: Project) : Disposable {
             project.workspaceFolders,
             project.telemetryService?.telemetryOptions?.agentOptions() != null
         )
+    }
+
+    suspend fun computeCurrentLocations(request: ComputeCurrentLocationsRequest): ComputeCurrentLocationsResult {
+        val json = remoteEndpoint
+            .request("codestream/textDocument/currentLocation", request)
+            .await() as JsonObject
+        val result = gson.fromJson<ComputeCurrentLocationsResult>(json)
+        return result
     }
 
     suspend fun documentMarkers(params: DocumentMarkersParams): DocumentMarkersResult {

--- a/jb/src/main/kotlin/clm/CLMCSharpComponent.kt
+++ b/jb/src/main/kotlin/clm/CLMCSharpComponent.kt
@@ -86,6 +86,10 @@ class CSharpSymbolResolver : SymbolResolver {
         return null
     }
 
+    override fun findParentFunction(psiElement: PsiElement): PsiElement? {
+       return findParentOfPredicate(psiElement, ::isFunction)
+    }
+
     private fun traverseForElementsOfType(element: PsiElement, elementType: String): List<PsiElement> {
         return element.descendants(true).filter { it.elementType.toString() == elementType }.toList()
     }
@@ -226,6 +230,18 @@ class CSharpSymbolResolver : SymbolResolver {
             searchNode = searchNode?.parent
         } while (searchNode != null && searchNode !is PsiFile && !searchElements.contains(searchNode.elementType.toString()))
         return if (searchElements.contains(searchNode.elementType.toString())) {
+            searchNode
+        } else {
+            null
+        }
+    }
+
+    private fun findParentOfPredicate(element: PsiElement, predicate: (element: PsiElement) -> Boolean): PsiElement? {
+        var searchNode: PsiElement? = element
+        do {
+            searchNode = searchNode?.parent
+        } while (searchNode != null && searchNode !is PsiFile && !predicate(searchNode))
+        return if (searchNode != null && predicate(searchNode)) {
             searchNode
         } else {
             null

--- a/jb/src/main/kotlin/clm/CLMGoComponent.kt
+++ b/jb/src/main/kotlin/clm/CLMGoComponent.kt
@@ -12,7 +12,7 @@ import com.intellij.psi.NavigatablePsiElement
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.search.GlobalSearchScope
-import com.intellij.psi.stubs.StringStubIndexExtension
+import com.intellij.psi.util.findParentOfType
 
 
 class CLMGoComponent(project: Project) :
@@ -68,6 +68,10 @@ class GoSymbolResolver : SymbolResolver {
         if (psiFile !is GoFile) return null
         val function = psiFile.children.find { it is GoFunctionDeclaration && it.name == functionName }
         return function
+    }
+
+    override fun findParentFunction(psiElement: PsiElement): PsiElement? {
+        return psiElement.findParentOfType<GoFunctionDeclaration>()
     }
 
     override fun clmElements(psiFile: PsiFile, clmResult: ClmResult?): List<ClmElements> {

--- a/jb/src/main/kotlin/clm/CLMInlayPresentation.kt
+++ b/jb/src/main/kotlin/clm/CLMInlayPresentation.kt
@@ -1,0 +1,39 @@
+package com.codestream.clm
+
+import com.intellij.codeInsight.hints.InlayPresentationFactory
+import com.intellij.codeInsight.hints.presentation.InlayPresentation
+import com.intellij.codeInsight.hints.presentation.StaticDelegatePresentation
+import com.intellij.openapi.editor.impl.EditorImpl
+import java.awt.Cursor
+import java.awt.Point
+import java.awt.event.MouseEvent
+
+class CLMInlayPresentation(
+    private val editor: EditorImpl,
+    presentation: InlayPresentation,
+    private val clickListener: InlayPresentationFactory.ClickListener,
+    private val onHoverListener: InlayPresentationFactory.HoverListener,
+) : StaticDelegatePresentation(presentation) {
+    private var hovering: Boolean = false
+
+    override fun mouseClicked(event: MouseEvent, translated: Point) {
+        super.mouseClicked(event, translated)
+        clickListener.onClick(event, translated)
+    }
+
+    override fun mouseMoved(event: MouseEvent, translated: Point) {
+        super.mouseMoved(event, translated)
+        if (hovering) return
+        val handCursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+        editor.setCustomCursor(this, handCursor)
+        onHoverListener.onHover(event, translated)
+        hovering = true
+    }
+
+    override fun mouseExited() {
+        super.mouseExited()
+        hovering = false
+        editor.setCustomCursor(this, null)
+        onHoverListener.onHoverFinished()
+    }
+}

--- a/jb/src/main/kotlin/clm/CLMJavaComponent.kt
+++ b/jb/src/main/kotlin/clm/CLMJavaComponent.kt
@@ -12,11 +12,11 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.PsiMethod
 import com.intellij.psi.impl.source.PsiJavaFileImpl
 import com.intellij.psi.impl.source.tree.java.PsiMethodCallExpressionImpl
 import com.intellij.psi.search.GlobalSearchScope
-import org.jetbrains.kotlin.idea.core.util.range
-import org.jetbrains.kotlin.idea.editor.fixers.range
+import com.intellij.psi.util.findParentOfType
 
 class CLMJavaComponent(project: Project) :
     CLMLanguageComponent<CLMJavaEditorManager>(
@@ -85,6 +85,9 @@ class JavaSymbolResolver : SymbolResolver {
         return null
     }
 
+    override fun findParentFunction(psiElement: PsiElement): PsiElement? {
+        return psiElement.findParentOfType<PsiMethod>()
+    }
     private val clmElementsProviders: List<CLMElementsProvider> = listOf(
         CLMJavaSpringDatastore()
     )

--- a/jb/src/main/kotlin/clm/CLMKotlinComponent.kt
+++ b/jb/src/main/kotlin/clm/CLMKotlinComponent.kt
@@ -5,7 +5,9 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.NavigatablePsiElement
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.util.findParentOfType
 import org.jetbrains.kotlin.asJava.elements.KtLightMethodImpl
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
@@ -68,6 +70,10 @@ class KotlinSymbolResolver : SymbolResolver {
             return result2
         }
         return null
+    }
+
+    override fun findParentFunction(psiElement: PsiElement): PsiElement? {
+        return  psiElement.findParentOfType<KtLightMethodImpl>() ?: psiElement.findParentOfType<KtFunction>()
     }
 
     override fun clmElements(psiFile: PsiFile, clmResult: ClmResult?): List<ClmElements> {

--- a/jb/src/main/kotlin/clm/CLMLanguageComponent.kt
+++ b/jb/src/main/kotlin/clm/CLMLanguageComponent.kt
@@ -55,6 +55,7 @@ interface SymbolResolver {
     ): PsiElement?
 
     fun findTopLevelFunction(psiFile: PsiFile, functionName: String): PsiElement?
+    fun findParentFunction(psiElement: PsiElement): PsiElement?
     fun clmElements(psiFile: PsiFile, clmResult: ClmResult?): List<ClmElements>
 }
 

--- a/jb/src/main/kotlin/clm/CLMNodeComponent.kt
+++ b/jb/src/main/kotlin/clm/CLMNodeComponent.kt
@@ -4,14 +4,15 @@ import com.codestream.protocols.agent.ClmResult
 import com.intellij.lang.javascript.psi.JSFile
 import com.intellij.lang.javascript.psi.JSFunction
 import com.intellij.lang.javascript.psi.ecmal4.JSClass
+import com.intellij.lang.javascript.psi.impl.JSFunctionExpressionImpl
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.NavigatablePsiElement
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.descendantsOfType
-
-val httpMethods = arrayOf("post", "patch", "put", "get", "delete")
+import com.intellij.psi.util.findParentOfType
 
 class CLMNodeComponent(project: Project) :
     CLMLanguageComponent<CLMNodeEditorManager>(
@@ -36,25 +37,6 @@ class NodeSymbolResolver : SymbolResolver {
 
     override fun getLookupSpanSuffixes(psiFile: PsiFile): List<String>? {
         return null
-//        if (psiFile !is JSFile) return null
-//        val callExpressions = psiFile.collectDescendantsOfType<JSCallExpression>()
-//
-//        return callExpressions.mapNotNull { exp ->
-//            val ref = exp.findDescendantOfType<JSReferenceExpression>()
-//            val httpMethod = getHttpMethod(ref?.text)
-//            if (httpMethod != null) {
-//                val args = exp.findDescendantOfType<JSArgumentList>()
-//                val firstArg = args?.findDescendantOfType<JSLiteralExpression>()
-//                if (firstArg != null) {
-//                    "$httpMethod ${firstArg.text}"
-//                } else {
-//                    null
-//                }
-//            } else {
-//                null
-//            }
-//
-//        }
     }
 
     override fun findClassFunctionFromFile(
@@ -67,18 +49,6 @@ class NodeSymbolResolver : SymbolResolver {
         val clazz = psiFile.children.filterIsInstance<JSClass>().filter { it.node.text == className }
         val result = clazz.filterIsInstance<JSFunction>().find { it.name == functionName }
         return result
-    }
-
-    private fun getHttpMethod(arg: String?): String? {
-        if (arg == null) {
-            return null
-        }
-        for (method in httpMethods) {
-            if (arg.endsWith(".${method}")) {
-                return method.uppercase()
-            }
-        }
-        return null
     }
 
     override fun findTopLevelFunction(psiFile: PsiFile, functionName: String): NavigatablePsiElement? {
@@ -95,6 +65,10 @@ class NodeSymbolResolver : SymbolResolver {
 
     override fun clmElements(psiFile: PsiFile, clmResult: ClmResult?): List<ClmElements> {
         return listOf()
+    }
+
+    override fun findParentFunction(psiElement: PsiElement): PsiElement? {
+        return psiElement.findParentOfType<JSFunctionExpressionImpl<*>>()
     }
 }
 

--- a/jb/src/main/kotlin/clm/CLMPhpComponent.kt
+++ b/jb/src/main/kotlin/clm/CLMPhpComponent.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.NavigatablePsiElement
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.FilenameIndex
@@ -103,6 +104,10 @@ class PhpSymbolResolver : SymbolResolver {
         if (psiFile !is PhpFileImpl) return null
         val entry = psiFile.topLevelDefs.entrySet().find { it.key.substring(1) == functionName && it.value.any { it is FunctionImpl } } ?: return null
         return entry.value.find { it is FunctionImpl }
+    }
+
+    override fun findParentFunction(psiElement: PsiElement): PsiElement? {
+        return null
     }
 
     override fun clmElements(psiFile: PsiFile, clmResult: ClmResult?): List<ClmElements> {

--- a/jb/src/main/kotlin/clm/CLMPythonComponent.kt
+++ b/jb/src/main/kotlin/clm/CLMPythonComponent.kt
@@ -6,11 +6,14 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.NavigatablePsiElement
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.findParentOfType
 import com.jetbrains.python.psi.PyFile
+import com.jetbrains.python.psi.PyFunction
 
 class CLMPythonComponent(project: Project) :
     CLMLanguageComponent<CLMPythonEditorManager>(
@@ -94,6 +97,10 @@ class PythonSymbolResolver : SymbolResolver {
     override fun findTopLevelFunction(psiFile: PsiFile, functionName: String): NavigatablePsiElement? {
         if (psiFile !is PyFile) return null
         return psiFile.findTopLevelFunction(functionName)
+    }
+
+    override fun findParentFunction(psiElement: PsiElement): PsiElement? {
+        return psiElement.findParentOfType<PyFunction>()
     }
 
     override fun clmElements(psiFile: PsiFile, clmResult: ClmResult?): List<ClmElements> {

--- a/jb/src/main/kotlin/clm/CLMRubyComponent.kt
+++ b/jb/src/main/kotlin/clm/CLMRubyComponent.kt
@@ -104,6 +104,10 @@ class RubySymbolResolver : SymbolResolver {
         return findAnyFunction(psiFile, justFunctionName)
     }
 
+    override fun findParentFunction(psiElement: PsiElement): PsiElement? {
+        return psiElement.findParentOfType<RMethodImpl>()
+    }
+
     override fun clmElements(psiFile: PsiFile, clmResult: ClmResult?): List<ClmElements> {
         if (psiFile !is RFileImpl) return listOf()
         if (clmResult == null) return listOf()

--- a/jb/src/main/kotlin/clm/MetricsByLocationManager.kt
+++ b/jb/src/main/kotlin/clm/MetricsByLocationManager.kt
@@ -1,0 +1,206 @@
+package com.codestream.clm
+
+import com.codestream.agentService
+import com.codestream.extensions.prettyRange
+import com.codestream.extensions.startWithName
+import com.codestream.extensions.stats
+import com.codestream.extensions.toRangeIgnoreColumn
+import com.codestream.protocols.agent.CSReferenceLocation
+import com.codestream.protocols.agent.ComputeCurrentLocationsRequest
+import com.codestream.protocols.agent.ComputeCurrentLocationsResult
+import com.codestream.protocols.agent.FileLevelTelemetryResult
+import com.codestream.protocols.agent.Markerish
+import com.codestream.protocols.agent.MethodLevelTelemetryAverageDuration
+import com.codestream.protocols.agent.MethodLevelTelemetryErrorRate
+import com.codestream.protocols.agent.MethodLevelTelemetrySampleSize
+import com.codestream.system.LRUMap
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.toImmutableMap
+
+class MetricsByLocationManager {
+    private val logger = Logger.getInstance(MetricsByLocationManager::class.java)
+    private val currentLocationCache = LRUMap<String, ComputeCurrentLocationsResult>(250)
+
+    suspend fun getMetricsByLocation(fileLevelTelemetry: FileLevelTelemetryResult,
+                                     uri: String,
+                                     modificationStamp: Long,
+                                     project: Project): ImmutableMap<MetricSource, MetricLocation> {
+        val updatedMetricsByLocation = mutableMapOf<MetricSource, MetricLocation>()
+        val metricsByLocationCalculationsStopwatch = startWithName("metricsByLocationCalculations")
+        if (fileLevelTelemetry.errorRate != null) {
+            processErrorRate(fileLevelTelemetry.errorRate, uri, modificationStamp, project, updatedMetricsByLocation, fileLevelTelemetry.deploymentCommit)
+        }
+        if (fileLevelTelemetry.averageDuration != null) {
+            processAverageDuration(fileLevelTelemetry.averageDuration, uri, modificationStamp, project, updatedMetricsByLocation, fileLevelTelemetry.deploymentCommit)
+        }
+        if (fileLevelTelemetry.sampleSize != null) {
+            processSampleSize(fileLevelTelemetry.sampleSize, uri, updatedMetricsByLocation)
+        }
+        metricsByLocationCalculationsStopwatch.stop()
+        logger.debug(metricsByLocationCalculationsStopwatch.stats())
+        return updatedMetricsByLocation.toImmutableMap()
+    }
+
+    private suspend fun processErrorRate(
+        errorRates: List<MethodLevelTelemetryErrorRate>,
+        uri: String,
+        modificationStamp: Long,
+        project: Project,
+        updatedMetricsByLocation: MutableMap<MetricSource, MetricLocation>,
+        deploymentCommit: String?) {
+        for (errorRate in errorRates) {
+            val theCommit = errorRate.commit ?: deploymentCommit
+            if (errorRate.functionName == "(anonymous)" && errorRate.column != null &&
+                errorRate.lineno != null && theCommit != null) {
+                val currentLocations = computeCurrentLocationsResult(
+                    errorRate.lineno,
+                    errorRate.column,
+                    theCommit,
+                    errorRate.functionName,
+                    uri,
+                    modificationStamp,
+                    project)
+                if (currentLocations != null &&
+                    currentLocations.locations.isNotEmpty() &&
+                    currentLocations.locations.entries.first().value.meta?.entirelyDeleted != true) {
+                    // currentLocations.locations.entries.first().value.meta?.startWasDeleted != true) {
+                    // TODO multiple results
+                    val location = currentLocations.locations.entries.first()
+                    val range = location.value.toRangeIgnoreColumn()
+                    val metricSource = MetricSource(errorRate.lineno,
+                        errorRate.column,
+                        theCommit,
+                        errorRate.functionName,
+                        uri)
+                    val metricLocation = updatedMetricsByLocation.getOrPut(metricSource) {
+                        MetricLocation(Metrics(), range)
+                    }
+                    metricLocation.metrics.errorRate = errorRate
+                    logger.debug("added anonymous errorRate $errorRate to ${range.prettyRange()}")
+                } else {
+                    logger.debug("no currentLocations for anonymous errorRate $errorRate")
+                }
+            }
+        }
+    }
+
+    private suspend fun processAverageDuration(
+        averageDurations: List<MethodLevelTelemetryAverageDuration>,
+        uri: String,
+        modificationStamp: Long,
+        project: Project,
+        updatedMetricsByLocation: MutableMap<MetricSource, MetricLocation>,
+        deploymentCommit: String?
+    ) {
+        for (averageDuration in averageDurations) {
+            val theCommit = averageDuration.commit ?: deploymentCommit
+            if (averageDuration.functionName == "(anonymous)" && averageDuration.column != null
+                && averageDuration.lineno != null && theCommit != null) {
+                val currentLocations = computeCurrentLocationsResult(
+                    averageDuration.lineno,
+                    averageDuration.column,
+                    theCommit,
+                    averageDuration.functionName,
+                    uri,
+                    modificationStamp,
+                    project)
+                if (currentLocations != null &&
+                    currentLocations.locations.isNotEmpty() &&
+                    currentLocations.locations.entries.first().value.meta?.entirelyDeleted != true)// &&
+                // currentLocations.locations.entries.first().value.meta?.startWasDeleted != true)
+                {
+                    // val startOffset = editor.logicalPositionToOffset(LogicalPosition(it.value.lineStart, it.value.colStart))
+                    // val endOffset = editor.logicalPositionToOffset(LogicalPosition(it.value.lineEnd, it.value.colEnd))
+                    val location = currentLocations.locations.entries.first()
+                    val range = location.value.toRangeIgnoreColumn()
+                    // TODO multiple per same line? (map to array)
+                    val metricSource = MetricSource(averageDuration.lineno,
+                        averageDuration.column,
+                        theCommit,
+                        averageDuration.functionName,
+                        uri)
+                    val metricLocation = updatedMetricsByLocation.getOrPut(metricSource) {
+                        MetricLocation(Metrics(), range)
+                    }
+                    metricLocation.metrics.averageDuration = averageDuration
+                    logger.debug("added anonymous averageDuration $averageDuration to ${range.prettyRange()}")
+                } else {
+                    logger.debug("no currentLocations for anonymous averageDuration $averageDuration")
+                }
+            }
+        }
+    }
+
+    private fun processSampleSize(
+        sampleSizes: List<MethodLevelTelemetrySampleSize>,
+        uri: String,
+        updatedMetricsByLocation: MutableMap<MetricSource, MetricLocation>
+    ) {
+        for (sampleSize in sampleSizes) {
+            if (sampleSize.functionName == "(anonymous)" && sampleSize.column != null
+                && sampleSize.lineno != null && sampleSize.commit != null) {
+                val metricSource = MetricSource(sampleSize.lineno,
+                    sampleSize.column,
+                    sampleSize.commit,
+                    sampleSize.functionName,
+                    uri)
+                val metricLocation = updatedMetricsByLocation.get(metricSource)
+                if (metricLocation != null) {
+                    metricLocation.metrics.sampleSize = sampleSize
+                    logger.debug("added anonymous sampleSize $sampleSize to ${metricLocation.range.prettyRange()}")
+                } else {
+                    logger.debug("no metricLocation for anonymous sampleSize $sampleSize")
+                }
+            }
+        }
+    }
+
+    private suspend fun computeCurrentLocationsResult(
+        lineno: Int,
+        column: Int,
+        commit: String,
+        functionName: String,
+        uri: String,
+        modificationStamp: Long,
+        project: Project): ComputeCurrentLocationsResult? {
+        val id = "$uri|$modificationStamp|$lineno|$commit|$functionName"
+        val computeCurrentLocationsStopwatch = startWithName("computeCurrentLocations $id")
+        val cached = currentLocationCache[id]
+        if (cached != null) {
+            computeCurrentLocationsStopwatch.stop()
+            logger.debug(computeCurrentLocationsStopwatch.stats())
+            return cached
+        }
+        val currentLocations = project.agentService?.computeCurrentLocations(
+            ComputeCurrentLocationsRequest(
+                uri,
+                commit,
+                arrayOf(
+                    Markerish(
+                        id,
+                        arrayOf(
+                            CSReferenceLocation(
+                                commit,
+                                // lineStart, colStart, lineEnd, colEnd, meta
+                                arrayOf(
+                                    lineno,
+                                    0, //averageDuration.column,
+                                    lineno, // lineno + 1,
+                                    0,
+                                    null)
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        if (currentLocations != null) {
+            currentLocationCache[id] = currentLocations
+        }
+        computeCurrentLocationsStopwatch.stop()
+        logger.debug(computeCurrentLocationsStopwatch.stats())
+        return currentLocations
+    }
+}

--- a/jb/src/main/kotlin/extensions/CSMarkerLocation.kt
+++ b/jb/src/main/kotlin/extensions/CSMarkerLocation.kt
@@ -1,0 +1,13 @@
+package com.codestream.extensions
+
+import com.codestream.protocols.agent.CSMarkerLocation
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
+
+// Convert a CSMarkerLocation to an LSP4J Range but using beginning of line (column 0)
+fun CSMarkerLocation.toRangeIgnoreColumn(): Range {
+    return Range(
+        Position(lineStart - 1, 0),
+        Position(lineEnd - 1, 0)
+    )
+}

--- a/jb/src/main/kotlin/extensions/Range.kt
+++ b/jb/src/main/kotlin/extensions/Range.kt
@@ -1,0 +1,7 @@
+package com.codestream.extensions
+
+import org.eclipse.lsp4j.Range
+
+fun Range.prettyRange(): String {
+    return "${this.start.line}:${this.start.character}-${this.end.line}:${this.end.character}"
+}

--- a/jb/src/main/kotlin/extensions/Stopwatch.kt
+++ b/jb/src/main/kotlin/extensions/Stopwatch.kt
@@ -1,0 +1,13 @@
+package com.codestream.extensions
+
+import org.apache.commons.lang3.time.StopWatch
+
+fun StopWatch.stats(): String {
+    return "=-> ${this.message} ${this.time}ms"
+}
+
+fun startWithName(name: String): StopWatch {
+    val sw = StopWatch(name)
+    sw.start()
+    return sw
+}

--- a/jb/src/main/kotlin/protocols/agent/AgentProtocol.kt
+++ b/jb/src/main/kotlin/protocols/agent/AgentProtocol.kt
@@ -27,7 +27,7 @@ class InitializationOptions(
     val traceLevel: String,
     val gitPath: String?,
     val workspaceFolders: Set<WorkspaceFolder>,
-    val newRelicTelemetryEnabled : Boolean?,
+    val newRelicTelemetryEnabled: Boolean?,
     val recordRequests: Boolean = RECORD_REQUESTS
 )
 
@@ -106,7 +106,7 @@ class UserLoggedIn(
             val avatarUrl = "https://www.gravatar.com/avatar/$emailHash.png?s=$size&d=identicon"
             val bytes: ByteArray = HttpRequests.request(avatarUrl).readBytes(null)
             ImageIcon(bytes)
-        } catch(ignore: Exception) {
+        } catch (ignore: Exception) {
             null
         }
     }
@@ -118,6 +118,7 @@ class EnvironmentHost(
     val publicApiUrl: String,
     val shortName: String
 )
+
 class EnvironmentInfo(
     val environment: String,
     val isOnPrem: Boolean,
@@ -209,6 +210,43 @@ enum class TraceLevel(val value: String) {
 class ReviewCoverageParams(val textDocument: TextDocument)
 
 class ReviewCoverageResult(val reviewIds: List<String?>)
+
+data class CSLocationMeta(
+    val createdAtCurrentCommit: Boolean?,
+    val startWasDeleted: Boolean?,
+    val endWasDeleted: Boolean?,
+    val entirelyDeleted: Boolean?,
+    val contentChanged: Boolean?,
+    val isAncestor: Boolean?,
+    val isDescendant: Boolean?,
+    val canonicalCommitDoesNotExist: Boolean?)
+
+
+//class CSLocation(val coordinates: Array<Int>, val locationMeta: CSLocationMeta?)
+
+// location coordinates: lineStart, colStart, lineEnd, colEnd, CSLocationMeta
+class CSReferenceLocation(val commitHash: String?, val location: Array<*>)
+
+data class Markerish(val id: String, val referenceLocations: Array<CSReferenceLocation>)
+
+data class CSMarkerLocation(
+    val id: String,
+    val lineStart: Int,
+    val colStart: Int,
+    val lineEnd: Int,
+    val colEnd: Int,
+    val meta: CSLocationMeta?,
+)
+
+typealias MarkerLocationsById = Map<String, CSMarkerLocation>
+
+data class ComputeCurrentLocationsRequest(val uri: String, val commit: String, val markers: Array<Markerish>)
+
+data class ComputeCurrentLocationsResult(val locations: MarkerLocationsById) {
+    override fun toString(): String {
+        return locations.toString()
+    }
+}
 
 class DocumentMarkersParams(val textDocument: TextDocument, val gitSha: String?, val applyFilters: Boolean)
 
@@ -559,11 +597,14 @@ class ResponseTime(
     val name: String,
     val value: Float
 )
+
 class ResponseTimesResult(
     val responseTimes: List<ResponseTime>
 )
 
 data class MethodLevelTelemetrySymbolIdentifier(
+    val lineno: Int?,
+    val column: Int?,
     val namespace: String?,
     val className: String?,
     val functionName: String?
@@ -594,39 +635,55 @@ open class MethodLevelTelemetryData(
     val className: String?,
     val functionName: String?,
     val metricTimesliceName: String,
-    val anomaly: ObservabilityAnomaly?
+    val anomaly: ObservabilityAnomaly?,
+    val lineno: Int?,
+    val column: Int?,
+    val commit: String?,
 ) {
     val symbolIdentifier: MethodLevelTelemetrySymbolIdentifier
-        get() = MethodLevelTelemetrySymbolIdentifier(namespace, className, functionName)
+        get() = MethodLevelTelemetrySymbolIdentifier(lineno, column, namespace, className, functionName)
 }
 
-class MethodLevelTelemetrySampleSize (
+class MethodLevelTelemetrySampleSize(
     namespace: String?,
     className: String?,
     functionName: String,
+    lineno: Int?,
+    column: Int?,
+    commit: String?,
     metricTimesliceName: String,
     anomaly: ObservabilityAnomaly?,
     val sampleSize: Int,
     val source: String
-) : MethodLevelTelemetryData(namespace, className, functionName, metricTimesliceName, anomaly)
+) : MethodLevelTelemetryData(namespace, className, functionName, metricTimesliceName, anomaly, lineno, column, commit)
 
 class MethodLevelTelemetryAverageDuration(
     namespace: String?,
     className: String?,
     functionName: String,
+    lineno: Int?,
+    column: Int?,
+    commit: String?,
     metricTimesliceName: String,
     anomaly: ObservabilityAnomaly?,
     val averageDuration: Float
-) : MethodLevelTelemetryData(namespace, className, functionName, metricTimesliceName, anomaly)
+) : MethodLevelTelemetryData(namespace, className, functionName, metricTimesliceName, anomaly, lineno, column, commit) {
+    override fun toString(): String {
+        return "MethodLevelTelemetryAverageDuration(namespace=$namespace, className=$className, functionName=$functionName, lineno=$lineno, column=$column, commit=$commit, metricTimesliceName=$metricTimesliceName, anomaly=$anomaly, averageDuration=$averageDuration)"
+    }
+}
 
 class MethodLevelTelemetryErrorRate(
     namespace: String?,
     className: String?,
     functionName: String,
+    lineno: Int?,
+    column: Int?,
+    commit: String?,
     metricTimesliceName: String,
     anomaly: ObservabilityAnomaly?,
     val errorRate: Float
-) : MethodLevelTelemetryData(namespace, className, functionName, metricTimesliceName, anomaly)
+) : MethodLevelTelemetryData(namespace, className, functionName, metricTimesliceName, anomaly, lineno, column, commit)
 
 class FileLevelTelemetryResult(
     var error: FileLevelTelemetryResultError?,
@@ -643,7 +700,8 @@ class FileLevelTelemetryResult(
     val newRelicUrl: String?,
     // val newRelicEntityAccounts: EntityAccount[];
     val codeNamespace: String?,
-    val relativeFilePath: String?
+    val relativeFilePath: String?,
+    val deploymentCommit: String?,
 )
 
 class ClmParams(
@@ -710,6 +768,7 @@ class ScmRangeInfoResultScm(
     val remotes: List<GitRemote>,
     val branch: String?
 )
+
 class BlameAuthor()
 class GitRemote(
     val name: String,

--- a/jb/src/main/kotlin/settings/CodeStreamConfigurable.kt
+++ b/jb/src/main/kotlin/settings/CodeStreamConfigurable.kt
@@ -1,11 +1,8 @@
 package com.codestream.settings
 
-import com.codestream.agentService
-import com.codestream.protocols.agent.TelemetryParams
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.options.SearchableConfigurable
-import com.intellij.openapi.project.ProjectManager
 import javax.swing.JComponent
 
 data class RestartOpts(
@@ -32,7 +29,6 @@ class CodeStreamConfigurable : SearchableConfigurable {
     }
 
     override fun apply() {
-        val state = settingsService.state
         val gui = _gui
         gui?.let {
             val serverUrl =

--- a/jb/src/main/kotlin/system/LRUMap.kt
+++ b/jb/src/main/kotlin/system/LRUMap.kt
@@ -1,0 +1,9 @@
+package com.codestream.system
+
+// Credit: gpt-4-32k
+class LRUMap<K, V>(private val maxSize: Int) : LinkedHashMap<K, V>(maxSize, 0.75f, true) {
+
+    override fun removeEldestEntry(eldest: MutableMap.MutableEntry<K, V>?): Boolean {
+        return this.size > maxSize
+    }
+}

--- a/jb/src/test/kotlin/clm/CLMLanguageComponentTest.kt
+++ b/jb/src/test/kotlin/clm/CLMLanguageComponentTest.kt
@@ -30,10 +30,9 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import org.junit.BeforeClass
 
-    @Suppress("UnstableApiUsage")
-    @TestDataPath("csTestData/simple")
+@Suppress("UnstableApiUsage")
+@TestDataPath("csTestData/simple")
 class CLMLanguageComponentTest : BasePlatformTestCase() {
     val mockAgentService = mockk<AgentService>(relaxed = true)
     val mockJxBrowserEngineService = mockk<JxBrowserEngineService>(relaxed = true)
@@ -91,6 +90,9 @@ class CLMLanguageComponentTest : BasePlatformTestCase() {
                     functionName = "hello_world",
                     metricTimesliceName = "d",
                     averageDuration = 3.333f,
+                    lineno = null,
+                    column = null,
+                    commit = null,
                     anomaly = null,
                 ),
             ),
@@ -101,6 +103,9 @@ class CLMLanguageComponentTest : BasePlatformTestCase() {
                 metricTimesliceName = "t",
                 sampleSize = 5,
                 source = "span",
+                lineno = null,
+                column = null,
+                commit = null,
                 anomaly = null,
             )),
             errorRate = null,
@@ -114,6 +119,7 @@ class CLMLanguageComponentTest : BasePlatformTestCase() {
             sinceDateFormatted = null,
             newRelicEntityName = null,
             newRelicUrl = null,
+            deploymentCommit = null,
         )
 
         coEvery { mockAgentService.fileLevelTelemetry(any()) } coAnswers {
@@ -149,16 +155,22 @@ class CLMLanguageComponentTest : BasePlatformTestCase() {
                     sampleSize = 100,
                     namespace = null,
                     source = "span",
+                    lineno = null,
+                    column = null,
+                    commit = null,
                     anomaly = null,
                 ), MethodLevelTelemetrySampleSize(
-                    className = "Controller",
-                    functionName = "postSomething",
-                    metricTimesliceName = "t",
-                    sampleSize = 150,
-                    namespace = null,
-                    source = "span",
+                className = "Controller",
+                functionName = "postSomething",
+                metricTimesliceName = "t",
+                sampleSize = 150,
+                namespace = null,
+                source = "span",
+                lineno = null,
+                column = null,
+                commit = null,
                 anomaly = null,
-                )
+            )
             ),
             averageDuration = listOf(
                 MethodLevelTelemetryAverageDuration(
@@ -167,15 +179,21 @@ class CLMLanguageComponentTest : BasePlatformTestCase() {
                     metricTimesliceName = "d",
                     averageDuration = 200.0f,
                     namespace = null,
+                    lineno = null,
+                    column = null,
+                    commit = null,
                     anomaly = null,
                 ), MethodLevelTelemetryAverageDuration(
-                    namespace = null,
-                    className = "Controller",
-                    functionName = "postSomething",
-                    metricTimesliceName = "d",
-                    averageDuration = 220.0f,
-                    anomaly = null,
-                )
+                namespace = null,
+                className = "Controller",
+                functionName = "postSomething",
+                metricTimesliceName = "d",
+                averageDuration = 220.0f,
+                lineno = null,
+                column = null,
+                commit = null,
+                anomaly = null,
+            )
             ),
             errorRate = null,
             newRelicEntityGuid = "abcd-1234",
@@ -187,7 +205,8 @@ class CLMLanguageComponentTest : BasePlatformTestCase() {
             sinceDateFormatted = null,
             newRelicEntityName = null,
             newRelicUrl = null,
-            relativeFilePath = null
+            relativeFilePath = null,
+            deploymentCommit = null,
         )
 
         coEvery { mockAgentService.fileLevelTelemetry(any()) } coAnswers {

--- a/shared/agent/src/api/extensions.ts
+++ b/shared/agent/src/api/extensions.ts
@@ -99,10 +99,10 @@ export namespace MarkerLocation {
 	): MarkerLocationsById {
 		if (markerLocations == null || markerLocations.locations == null) return {};
 
-		return Object.entries(markerLocations.locations).reduce((m, [id, array]) => {
-			m[id] = fromArray(array, id);
-			return m;
-		}, Object.create(null));
+		return Object.entries(markerLocations.locations).reduce((markerLocations, [id, csLocation]) => {
+			markerLocations[id] = fromArray(csLocation, id);
+			return markerLocations;
+		}, {} as MarkerLocationsById);
 	}
 
 	export function toRange(location: CSMarkerLocation): Range {
@@ -128,7 +128,7 @@ const remoteProviders: [
 	string,
 	string,
 	RegExp,
-	(remote: string, ref: string, file: string, start: number, end: number) => string
+	(remote: string, ref: string, file: string, start: number, end: number) => string,
 ][] = [
 	[
 		"github",

--- a/shared/agent/src/managers/baseManager.ts
+++ b/shared/agent/src/managers/baseManager.ts
@@ -166,7 +166,7 @@ export abstract class ManagerBase<T> {
 			entities = entities.filter(e => e && !isDirective(e));
 			manager.cache.set(entities);
 		} catch (ex) {
-			Logger.warn("Error caching response entities: " + ex.message);
+			Logger.warn(`Error caching response entities: ${ex.message}\n${ex.stack}`);
 		}
 	}
 

--- a/shared/agent/src/managers/documentMarkerManager.ts
+++ b/shared/agent/src/managers/documentMarkerManager.ts
@@ -6,6 +6,9 @@ import {
 	CalculateNonLocalRangesRequestType,
 	CalculateNonLocalRangesResponse,
 	CodeStreamDiffUriData,
+	ComputeCurrentLocationResponse,
+	ComputeCurrentLocationsRequest,
+	ComputeCurrentLocationsRequestType,
 	CreateDocumentMarkerPermalinkRequest,
 	CreateDocumentMarkerPermalinkRequestType,
 	CreateDocumentMarkerPermalinkResponse,
@@ -50,7 +53,7 @@ import {
 import { Functions, log, lsp, lspHandler } from "../system";
 import * as csUri from "../system/uri";
 import { xfs } from "../xfs";
-import { GetLocationsResult } from "./markerLocationManager";
+import { GetLocationsResult, MarkerLocationManager } from "./markerLocationManager";
 import { compareRemotes } from "./markersBuilder";
 import { ReviewsManager } from "./reviewsManager";
 
@@ -250,6 +253,18 @@ export class DocumentMarkerManager {
 		// telemetry.track({ eventName: "Permalink Created", properties: payload });
 
 		return { linkUrl: response.permalink! };
+	}
+
+	@log()
+	@lspHandler(ComputeCurrentLocationsRequestType)
+	async computeCurrentLocations(
+		request: ComputeCurrentLocationsRequest
+	): Promise<ComputeCurrentLocationResponse> {
+		return MarkerLocationManager.computeCurrentLocations(
+			URI.parse(request.uri),
+			request.commit,
+			request.markers
+		);
 	}
 
 	@log()

--- a/shared/agent/src/markerLocation/calculator.ts
+++ b/shared/agent/src/markerLocation/calculator.ts
@@ -6,13 +6,14 @@ import * as diffMatchPatch from "diff-match-patch";
 import { compareTwoStrings, findBestMatch, Rating } from "string-similarity";
 import { Range } from "vscode-languageserver";
 
-import { MarkerLocation, MarkerLocationsById } from "../api/extensions";
+import { MarkerLocation } from "../api/extensions";
 import { Logger } from "../logger";
 import { Id } from "../managers/entityManager";
 import { buildChangeset, Change, Changeset } from "./changeset";
 
 import fromRange = MarkerLocation.fromRange;
 import toRange = MarkerLocation.toRange;
+import { MarkerLocationsById } from "@codestream/protocols/agent";
 
 export const MAX_RANGE_VALUE = 2147483647;
 const LINE_SIMILARITY_THRESHOLD = 0.5;
@@ -620,6 +621,7 @@ class Calculation {
 // 1st attempt: " bar)" => found, with mid "r" at columns 19 and 36
 //
 // Therefore, since specificIndex is 1, newCol = 36
+// TODO pass boolean beginning or end
 function calculateColumn(oldCol: number, oldContent: string, newContent: string) {
 	if (!oldContent || !newContent || oldContent === newContent) {
 		return oldCol;

--- a/shared/agent/src/providers/newrelic/clm/FLTNameInferenceStrategy.ts
+++ b/shared/agent/src/providers/newrelic/clm/FLTNameInferenceStrategy.ts
@@ -139,7 +139,7 @@ export abstract class FLTNameInferenceStrategy implements FLTStrategy {
 		return {
 			...symbol,
 			averageDuration: record.value,
-			metricTimesliceName: record.name,
+			facet: [record.name], // facet is [metricTimesliceName, lineno, colno]
 		};
 	}
 
@@ -172,14 +172,12 @@ export abstract class FLTNameInferenceStrategy implements FLTStrategy {
 		sampleSizes: FileLevelTelemetrySampleSize[]
 	): FileLevelTelemetryErrorRate {
 		const symbol = this.extractSymbol(record.name);
-		const sampleSize = sampleSizes.find(_ =>
-			this.extractSymbol(_.metricTimesliceName).equals(symbol)
-		);
+		const sampleSize = sampleSizes.find(_ => this.extractSymbol(_.facet[0]).equals(symbol));
 		const errorRate = sampleSize ? record.value / sampleSize.sampleSize : 0;
 		return {
 			...symbol,
 			errorRate,
-			metricTimesliceName: record.name,
+			facet: [record.name], // facet is [metricTimesliceName, lineno, colno]
 		};
 	}
 
@@ -207,7 +205,7 @@ export abstract class FLTNameInferenceStrategy implements FLTStrategy {
 		return {
 			...symbol,
 			sampleSize: record.value,
-			metricTimesliceName: record.name,
+			facet: [record.name], // facet is [metricTimesliceName, lineno, colno]
 			source,
 		};
 	}

--- a/shared/agent/src/providers/newrelic/clm/FLTStrategy.ts
+++ b/shared/agent/src/providers/newrelic/clm/FLTStrategy.ts
@@ -12,12 +12,14 @@ import { FLTCodeAttributeStrategy } from "./FLTCodeAttributeStrategy";
 import { FLTNameInferenceKotlinStrategy } from "./FLTNameInferenceKotlinStrategy";
 import { NewRelicGraphqlClient } from "../newRelicGraphqlClient";
 
+export type FLTResponse = {
+	averageDuration: FileLevelTelemetryAverageDuration[];
+	errorRate: FileLevelTelemetryErrorRate[];
+	sampleSize: FileLevelTelemetrySampleSize[];
+};
+
 export interface FLTStrategy {
-	execute(): Promise<{
-		averageDuration: FileLevelTelemetryAverageDuration[];
-		errorRate: FileLevelTelemetryErrorRate[];
-		sampleSize: FileLevelTelemetrySampleSize[];
-	}>;
+	execute(): Promise<FLTResponse>;
 }
 
 export class FLTStrategyFactory {

--- a/shared/agent/src/providers/newrelic/deployments/deploymentsProvider.ts
+++ b/shared/agent/src/providers/newrelic/deployments/deploymentsProvider.ts
@@ -2,7 +2,7 @@ import { lsp, lspHandler } from "../../../system/decorators/lsp";
 import {
 	GetDeploymentsRequest,
 	GetDeploymentsRequestType,
-	GetDeploymentsResponse,
+	GetDeploymentsResponse, GetLatestDeploymentRequest, GetLatestDeploymentResponse
 } from "@codestream/protocols/agent";
 import { log } from "../../../system/decorators/log";
 import { NewRelicGraphqlClient } from "../newRelicGraphqlClient";
@@ -11,6 +11,32 @@ import { parseId } from "../utils";
 @lsp
 export class DeploymentsProvider {
 	constructor(private graphqlClient: NewRelicGraphqlClient) {}
+
+	@log({ timed: true })
+	public async getLatestDeployment(
+		request: GetLatestDeploymentRequest
+	): Promise<GetLatestDeploymentResponse | undefined> {
+		const { entityGuid } = request;
+		const parsedId = parseId(entityGuid)!;
+		const query = `SELECT timestamp, commit, entity.name FROM Deployment WHERE entity.guid='${entityGuid}' AND timestamp = (SELECT latest(timestamp) from Deployment WHERE entity.guid='${entityGuid}') SINCE 1 year ago`;
+		const result = await this.graphqlClient.runNrql<{
+			timestamp: number;
+			version: string;
+			commit: string;
+		}>(parsedId.accountId, query, 400);
+
+		const deployments = result.map(_ => ({
+			seconds: Math.round(_.timestamp / 1000),
+			version: _.version,
+			commit: _.commit,
+		}));
+		if (deployments.length === 0) {
+			return undefined;
+		}
+		return {
+			deployment: deployments[0],
+		};
+	}
 
 	@lspHandler(GetDeploymentsRequestType)
 	@log({ timed: true })
@@ -24,11 +50,13 @@ export class DeploymentsProvider {
 		const result = await this.graphqlClient.runNrql<{
 			timestamp: number;
 			version: string;
+			commit: string;
 		}>(parsedId.accountId, query, 400);
 
 		const deployments = result.map(_ => ({
 			seconds: Math.round(_.timestamp / 1000),
 			version: _.version,
+			commit: _.commit,
 		}));
 		return {
 			deployments,

--- a/shared/agent/src/providers/newrelic/errors/observabilityErrorsProvider.ts
+++ b/shared/agent/src/providers/newrelic/errors/observabilityErrorsProvider.ts
@@ -249,6 +249,8 @@ export class ObservabilityErrorsProvider {
 	@log({ timed: true })
 	async getErrorGroupFromNameMessageEntity(name: string, message: string, entityGuid: string) {
 		try {
+
+
 			return this.graphqlClient.query(
 				`query getErrorGroupGuid($name: String!, $message:String!, $entityGuid:EntityGuid!) {
 				actor {

--- a/shared/agent/src/providers/newrelic/methodAverageDurationQuery.ts
+++ b/shared/agent/src/providers/newrelic/methodAverageDurationQuery.ts
@@ -1,5 +1,6 @@
 import { escapeNrql } from "./newRelicGraphqlClient";
 import { LanguageId } from "./clm/clmManager";
+import { getLanguageFilter } from "./metricsLanguageNrqlFilter";
 
 function mapRubyTimesliceName(name: string): string {
 	if (name.startsWith("Nested/Controller")) {
@@ -29,7 +30,8 @@ export function generateMethodAverageDurationQuery(
 	const spansLookup = mappedTimesliceNames?.length
 		? `name in (${mappedTimesliceNames.map(metric => `'${metric}'`).join(",")})`
 		: `name LIKE '${codeNamespace}%'`;
-	const spansQuery = `SELECT average(duration) * 1000 AS 'averageDuration' FROM Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${spansLookup} FACET name as metricTimesliceName SINCE 30 minutes AGO LIMIT 100`;
+	const languageExtra = getLanguageFilter(languageId);
+	const spansQuery = `SELECT average(duration) * 1000 AS 'averageDuration' FROM Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' ${languageExtra} AND ${spansLookup} FACET name, code.lineno, code.column as metricTimesliceName SINCE 30 minutes AGO LIMIT 100`;
 	const metricsLookup = mappedTimesliceNames?.length
 		? `metricTimesliceName in (${mappedTimesliceNames.map(metric => `'${metric}'`).join(",")})`
 		: `metricTimesliceName LIKE '${codeNamespace}%'`;

--- a/shared/agent/src/providers/newrelic/methodSampleSizeQuery.ts
+++ b/shared/agent/src/providers/newrelic/methodSampleSizeQuery.ts
@@ -1,5 +1,6 @@
 import { escapeNrql } from "./newRelicGraphqlClient";
 import { LanguageId } from "./clm/clmManager";
+import { getLanguageFilter } from "./metricsLanguageNrqlFilter";
 
 export function generateMethodSampleSizeQuery(
 	languageId: LanguageId,
@@ -10,7 +11,8 @@ export function generateMethodSampleSizeQuery(
 	const spansLookup = metricTimesliceNames?.length
 		? `name in (${metricTimesliceNames.map(metric => `'${metric}'`).join(",")})`
 		: `name LIKE '${codeNamespace}%'`;
-	const spansQuery = `FROM Span SELECT count(*) AS 'sampleSize' WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${spansLookup} FACET name AS metricTimesliceName SINCE 30 minutes AGO LIMIT 100`;
+	const languageExtra = getLanguageFilter(languageId);
+	const spansQuery = `FROM Span SELECT count(*) AS 'sampleSize' WHERE \`entity.guid\` = '${newRelicEntityGuid}' ${languageExtra} AND ${spansLookup} FACET name, code.lineno, code.column as metricTimesliceName SINCE 30 minutes AGO LIMIT 100`;
 	const metricsLookup = metricTimesliceNames?.length
 		? `(metricTimesliceName in ( ${metricTimesliceNames
 				.map(mtsn => `'${mtsn}'`)

--- a/shared/agent/src/providers/newrelic/metricsLanguageNrqlFilter.ts
+++ b/shared/agent/src/providers/newrelic/metricsLanguageNrqlFilter.ts
@@ -1,0 +1,10 @@
+"use strict";
+import { LanguageId } from "./clm/clmManager";
+
+const languageFilters: Map<LanguageId, string> = new Map([
+	["python", " AND code.function != '__call__' "],
+]);
+
+export function getLanguageFilter(languageId: LanguageId) {
+	return languageFilters.get(languageId) ?? "";
+}

--- a/shared/agent/src/providers/newrelic/newrelic.types.ts
+++ b/shared/agent/src/providers/newrelic/newrelic.types.ts
@@ -15,18 +15,23 @@ export interface NewRelicId {
 }
 
 export interface MetricTimeslice {
-	facet: string;
-	metricTimesliceName: string;
+	facet: string[];
+	// metricTimesliceName: string;
 	averageDuration?: number;
-	requestsPerMinute?: number;
+	errorRate?: number; // TODO WHY
+	sampleSize?: number;
+	source?: "metric" | "span";
+	// requestsPerMinute?: number;
 }
 
 export interface AdditionalMetadataInfo {
 	traceId?: string;
 	"code.lineno"?: string;
+	"code.column"?: string;
 	transactionId?: string;
 	"code.namespace"?: string;
 	"code.function"?: string;
+	"tags.commit"?: string;
 }
 
 export class AccessTokenError extends Error {
@@ -44,7 +49,9 @@ export interface Span {
 	"code.function"?: string | null;
 	"code.namespace"?: string | null;
 	"code.lineno"?: number | string | null;
+	"code.column"?: number | string | null;
 	"transaction.name"?: string | null;
+	"tags.commit"?: string | null;
 	name?: string;
 	traceId?: string;
 	transactionId?: string;
@@ -94,6 +101,9 @@ export interface FunctionInfo {
 	namespace?: string;
 	className?: string;
 	functionName?: string;
+	lineno?: number;
+	column?: number;
+	commit?: string;
 }
 
 export type ResolutionMethod = "filePath" | "locator" | "hybrid";

--- a/shared/agent/src/providers/newrelic/nrContainer.ts
+++ b/shared/agent/src/providers/newrelic/nrContainer.ts
@@ -154,7 +154,8 @@ export async function injectNR(sessionServiceContainer: SessionServiceContainer)
 		sessionServiceContainer,
 		nrApiConfig,
 		newRelicGraphqlClient,
-		entityAccountResolver
+		entityAccountResolver,
+		deploymentsProvider,
 	);
 
 	disposables.push(clmManager);

--- a/shared/agent/src/providers/newrelic/spanQuery.ts
+++ b/shared/agent/src/providers/newrelic/spanQuery.ts
@@ -39,7 +39,7 @@ function functionLocatorQuery(
 			equalsQueryParts.push(`code.function='${functionLocator.functionName}'`);
 		}
 		const innerQueryEqualsClause = equalsQueryParts.join(" AND ");
-		query = `SELECT name,\`transaction.name\`,code.lineno,code.namespace,code.function,traceId,transactionId from Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${innerQueryEqualsClause} SINCE 30 minutes AGO LIMIT ${LIMIT}`;
+		query = `SELECT name, \`transaction.name\`, code.lineno, code.column, tags.commit, code.namespace, code.function, traceId, transactionId from Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${innerQueryEqualsClause} SINCE 30 minutes AGO LIMIT ${LIMIT}`;
 	} else {
 		const likeQueryParts: string[] = [];
 		if (functionLocator.namespaces) {
@@ -53,7 +53,7 @@ function functionLocatorQuery(
 			likeQueryParts.push(`code.function like '${functionLocator.functionName}%'`);
 		}
 		const innerQueryLikeClause = likeQueryParts.join(" AND ");
-		query = `SELECT name,\`transaction.name\`,code.lineno,code.namespace,code.function,traceId,transactionId from Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${innerQueryLikeClause} SINCE 30 minutes AGO LIMIT ${LIMIT}`;
+		query = `SELECT name, \`transaction.name\`, code.lineno, code.column, tags.commit, code.namespace, code.function, traceId, transactionId from Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${innerQueryLikeClause} SINCE 30 minutes AGO LIMIT ${LIMIT}`;
 	}
 	return `query GetSpans($accountId:Int!) {
 			actor {
@@ -91,7 +91,7 @@ function hybridQuery(
 		} else {
 			searchClause = `code.filepath='${codeFilePath}'`;
 		}
-		query = `SELECT name,\`transaction.name\`,code.lineno,code.namespace,code.function,traceId,transactionId from Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${searchClause} SINCE 30 minutes AGO LIMIT ${LIMIT}`;
+		query = `SELECT name, \`transaction.name\`, code.lineno, code.column, tags.commit, code.namespace, code.function, traceId, transactionId from Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${searchClause} SINCE 30 minutes AGO LIMIT ${LIMIT}`;
 	} else {
 		let searchClause;
 		if (functionLocator) {
@@ -112,7 +112,7 @@ function hybridQuery(
 		} else {
 			searchClause = `code.filepath='${codeFilePath}'`;
 		}
-		query = `SELECT name,\`transaction.name\`,code.lineno,code.namespace,code.function,traceId,transactionId from Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${searchClause} SINCE 30 minutes AGO LIMIT ${LIMIT}`;
+		query = `SELECT name, \`transaction.name\`, code.lineno, code.column, tags.commit, code.namespace, code.function, traceId, transactionId from Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${searchClause} SINCE 30 minutes AGO LIMIT ${LIMIT}`;
 	}
 	return `query GetSpans($accountId:Int!) {
 			actor {
@@ -162,12 +162,12 @@ export function generateSpanQuery(
 	switch (spanQueryType) {
 		case "equals": {
 			const equalsLookup = `code.filepath='${codeFilePath}'`;
-			query = `SELECT name,\`transaction.name\`,code.lineno,code.namespace,code.function,traceId,transactionId from Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${equalsLookup}  SINCE 30 minutes AGO LIMIT ${LIMIT}`;
+			query = `SELECT name, \`transaction.name\`, code.lineno, code.column, tags.commit, code.namespace, code.function, traceId, transactionId from Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${equalsLookup}  SINCE 30 minutes AGO LIMIT ${LIMIT}`;
 			break;
 		}
 		case "like": {
 			const likeLookup = `code.filepath like '%${codeFilePath}'`;
-			query = `SELECT name,\`transaction.name\`,code.lineno,code.namespace,code.function,traceId,transactionId from Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${likeLookup}  SINCE 30 minutes AGO LIMIT ${LIMIT}`;
+			query = `SELECT name, \`transaction.name\`, code.lineno, code.column, tags.commit, code.namespace, code.function, traceId, transactionId from Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${likeLookup}  SINCE 30 minutes AGO LIMIT ${LIMIT}`;
 			break;
 		}
 		case "fuzzy": {
@@ -179,7 +179,7 @@ export function generateSpanQuery(
 				}
 			}
 			const fuzzyLookup = `code.filepath like '%${codeFilePath.split("/").slice(-2).join("/")}%'`;
-			query = `SELECT name, \`transaction.name\`, code.lineno, code.namespace, code.function, traceId, transactionId from Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${fuzzyLookup} SINCE 30 minutes AGO LIMIT ${LIMIT}`;
+			query = `SELECT name, \`transaction.name\`, code.lineno, code.column, tags.commit, code.namespace, code.function, traceId, transactionId from Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${fuzzyLookup} SINCE 30 minutes AGO LIMIT ${LIMIT}`;
 			break;
 		}
 
@@ -192,7 +192,7 @@ export function generateSpanQuery(
 				}
 			}
 			const fuzzierLookup = `code.filepath like '%${codeFilePath.split("/").slice(-1).join("/")}%'`;
-			query = `SELECT name, \`transaction.name\`, code.lineno, code.namespace, code.function, traceId, transactionId from Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${fuzzierLookup} SINCE 30 minutes AGO LIMIT ${LIMIT}`;
+			query = `SELECT name, \`transaction.name\`, code.lineno,code.column,tags.commit, code.namespace, code.function, traceId, transactionId from Span WHERE \`entity.guid\` = '${newRelicEntityGuid}' AND ${fuzzierLookup} SINCE 30 minutes AGO LIMIT ${LIMIT}`;
 			break;
 		}
 	}

--- a/shared/agent/test/unit/providers/newrelic/clm/FLTCodeAttributeStrategy.spec.ts
+++ b/shared/agent/test/unit/providers/newrelic/clm/FLTCodeAttributeStrategy.spec.ts
@@ -33,7 +33,7 @@ describe("FLTCodeAttributeStrategy", () => {
 			);
 			const results = strategy.addMethodName(
 				{
-					"Function/routes.app:hello_world": [
+					"Function/routes.app:hello_world|1|null": [
 						{
 							traceId: "123",
 							transactionId: "abc",
@@ -43,7 +43,7 @@ describe("FLTCodeAttributeStrategy", () => {
 							"code.function": "hello_world",
 						},
 					],
-					"Function/routes.app:MyClass.my_method": [
+					"Function/routes.app:MyClass.my_method|4|null": [
 						{
 							traceId: "456",
 							transactionId: "def",
@@ -56,14 +56,14 @@ describe("FLTCodeAttributeStrategy", () => {
 				},
 				[
 					{
-						facet: "Function/routes.app:hello_world",
+						facet: ["Function/routes.app:hello_world", "1"],
 						averageDuration: 3.2,
-						metricTimesliceName: "Function/routes.app:hello_world",
+						// metricTimesliceName: "Function/routes.app:hello_world",
 					},
 					{
-						facet: "Function/routes.app:MyClass.my_method",
+						facet: ["Function/routes.app:MyClass.my_method", "4"],
 						averageDuration: 3.2,
-						metricTimesliceName: "Function/routes.app:MyClass.my_method",
+						// metricTimesliceName: "Function/routes.app:MyClass.my_method",
 					},
 				]
 			);
@@ -72,30 +72,38 @@ describe("FLTCodeAttributeStrategy", () => {
 				{
 					averageDuration: 3.2,
 					className: undefined,
-					facet: "Function/routes.app:hello_world",
-					metricTimesliceName: "Function/routes.app:hello_world",
+					facet: ["Function/routes.app:hello_world", "1"],
+					lineno: undefined,
+					column: undefined,
+					commit: undefined,
 					namespace: null,
+					functionName: "hello_world",
 					metadata: {
 						"code.lineno": 1,
+						"code.column": undefined,
 						traceId: "123",
 						transactionId: "abc",
 						"code.namespace": null,
 						"code.function": "hello_world",
+						"tags.commit": undefined,
 					},
-					functionName: "hello_world",
 				},
 				{
 					averageDuration: 3.2,
-					facet: "Function/routes.app:MyClass.my_method",
+					facet: ["Function/routes.app:MyClass.my_method", "4"],
 					className: "MyClass",
-					metricTimesliceName: "Function/routes.app:MyClass.my_method",
+					column: undefined,
+					commit: undefined,
+					lineno: undefined,
 					namespace: null,
 					metadata: {
 						"code.lineno": 4,
+						"column.column": undefined,
 						traceId: "456",
 						transactionId: "def",
 						"code.namespace": null,
 						"code.function": "my_method",
+						"tags.commit": undefined,
 					},
 					functionName: "my_method",
 				},
@@ -117,7 +125,7 @@ describe("FLTCodeAttributeStrategy", () => {
 			);
 			const results = strategy.addMethodName(
 				{
-					"Carrot/foo_bar.system.tasks.bill_credit_payment_item": [
+					"Carrot/foo_bar.system.tasks.bill_credit_payment_item|27|null": [
 						{
 							"code.filepath": "/app/foo_bar/system/tasks.py",
 							"code.function": "bill_credit_payment_item",
@@ -129,10 +137,10 @@ describe("FLTCodeAttributeStrategy", () => {
 				},
 				[
 					{
-						facet: "OtherTransaction/Carrot/foo_bar.system.tasks.bill_credit_payment_item",
+						facet: ["OtherTransaction/Carrot/foo_bar.system.tasks.bill_credit_payment_item", "27"],
 						averageDuration: 3.2,
-						metricTimesliceName:
-							"OtherTransaction/Carrot/foo_bar.system.tasks.bill_credit_payment_item",
+						// metricTimesliceName:
+						// 	"OtherTransaction/Carrot/foo_bar.system.tasks.bill_credit_payment_item",
 					},
 				]
 			);
@@ -141,12 +149,12 @@ describe("FLTCodeAttributeStrategy", () => {
 				{
 					averageDuration: 3.2,
 					className: undefined,
-					facet: "OtherTransaction/Carrot/foo_bar.system.tasks.bill_credit_payment_item",
-					metricTimesliceName:
-						"OtherTransaction/Carrot/foo_bar.system.tasks.bill_credit_payment_item",
+					facet: ["OtherTransaction/Carrot/foo_bar.system.tasks.bill_credit_payment_item", "27"],
 					namespace: "foo_bar.system.tasks",
 					metadata: {
 						"code.lineno": 27,
+						"code.column": undefined,
+						"tags.commit": undefined,
 						"code.namespace": "foo_bar.system.tasks",
 						traceId: undefined,
 						transactionId: undefined,
@@ -171,7 +179,7 @@ describe("FLTCodeAttributeStrategy", () => {
 				mockNewRelicGraphqlClient
 			);
 			const groupedByTransactionName = {
-				"Controller/agents/show": [
+				"Controller/agents/show|16|null": [
 					{
 						"code.lineno": 16,
 						"code.namespace": "AgentsController",
@@ -183,7 +191,7 @@ describe("FLTCodeAttributeStrategy", () => {
 						transactionId: "5195e0f31cf1fce4",
 					},
 				],
-				"Controller/agents/create": [
+				"Controller/agents/create|16|null": [
 					{
 						"code.lineno": 16,
 						"code.namespace": "AgentsController",
@@ -195,7 +203,7 @@ describe("FLTCodeAttributeStrategy", () => {
 						transactionId: "2ac9f995b004df82",
 					},
 				],
-				"Controller/agents/destroy": [
+				"Controller/agents/destroy|55|null": [
 					{
 						"code.lineno": 55,
 						"code.namespace": "AgentsController",
@@ -211,19 +219,19 @@ describe("FLTCodeAttributeStrategy", () => {
 
 			const metricTimesliceNames: MetricTimeslice[] = [
 				{
-					facet: "Controller/agents/create",
-					metricTimesliceName: "Controller/agents/create",
-					requestsPerMinute: 22.2,
+					facet: ["Controller/agents/create", "16"],
+					// metricTimesliceName: "Controller/agents/create",
+					// requestsPerMinute: 22.2,
 				},
 				{
-					facet: "Controller/agents/show",
-					metricTimesliceName: "Controller/agents/show",
-					requestsPerMinute: 22.2,
+					facet: ["Controller/agents/show", "16"],
+					// metricTimesliceName: "Controller/agents/show",
+					// requestsPerMinute: 22.2,
 				},
 				{
-					facet: "Controller/agents/destroy",
-					metricTimesliceName: "Controller/agents/destroy",
-					requestsPerMinute: 22.23,
+					facet: ["Controller/agents/destroy", "55"],
+					// metricTimesliceName: "Controller/agents/destroy",
+					// requestsPerMinute: 22.23,
 				},
 			];
 
@@ -231,10 +239,10 @@ describe("FLTCodeAttributeStrategy", () => {
 			expect(results).toEqual([
 				{
 					className: "AgentsController",
-					facet: "Controller/agents/create",
-					metricTimesliceName: "Controller/agents/create",
+					facet: ["Controller/agents/create", "16"],
+					// metricTimesliceName: "Controller/agents/create",
 					namespace: "AgentsController",
-					requestsPerMinute: 22.2,
+					// requestsPerMinute: 22.2,
 					metadata: {
 						"code.lineno": 16,
 						traceId: "67e121ac35ff1cbe191fd1da94e50012",
@@ -246,9 +254,8 @@ describe("FLTCodeAttributeStrategy", () => {
 				},
 				{
 					className: "AgentsController",
-					facet: "Controller/agents/show",
-					metricTimesliceName: "Controller/agents/show",
-					requestsPerMinute: 22.2,
+					facet: ["Controller/agents/show", "16"],
+					// requestsPerMinute: 22.2,
 					namespace: "AgentsController",
 					metadata: {
 						"code.lineno": 16,
@@ -261,9 +268,8 @@ describe("FLTCodeAttributeStrategy", () => {
 				},
 				{
 					className: "AgentsController",
-					facet: "Controller/agents/destroy",
-					metricTimesliceName: "Controller/agents/destroy",
-					requestsPerMinute: 22.23,
+					facet: ["Controller/agents/destroy", "55"],
+					// requestsPerMinute: 22.23,
 					namespace: "AgentsController",
 					metadata: {
 						"code.lineno": 55,
@@ -292,7 +298,7 @@ describe("FLTCodeAttributeStrategy", () => {
 				mockNewRelicGraphqlClient
 			);
 			const groupedByTransactionName = {
-				"MessageBroker/ActiveJob::Async/Queue/Produce/Named/default": [
+				"MessageBroker/ActiveJob::Async/Queue/Produce/Named/default|8|null": [
 					{
 						"code.filepath": "/usr/src/app/app/jobs/notifier_job.rb",
 						"code.function": "perform",
@@ -305,7 +311,7 @@ describe("FLTCodeAttributeStrategy", () => {
 						transactionId: "5154409dd464aad1",
 					},
 					{
-						"code.filepath": "/usr/src/app/app/jobs/notifier_job.rb",
+						"code.filepath": "/usr/src/app/app/jobs/notifier_job.rb|8|null",
 						"code.function": "perform",
 						"code.lineno": 8,
 						"code.namespace": "NotifierJob",
@@ -320,9 +326,9 @@ describe("FLTCodeAttributeStrategy", () => {
 
 			const metricTimesliceNames: MetricTimeslice[] = [
 				{
-					facet: "MessageBroker/ActiveJob::Async/Queue/Produce/Named/default",
-					requestsPerMinute: 24.1,
-					metricTimesliceName: "MessageBroker/ActiveJob::Async/Queue/Produce/Named/default",
+					facet: ["MessageBroker/ActiveJob::Async/Queue/Produce/Named/default", "8"],
+					// requestsPerMinute: 24.1,
+					// metricTimesliceName: "MessageBroker/ActiveJob::Async/Queue/Produce/Named/default",
 				},
 			];
 
@@ -330,10 +336,9 @@ describe("FLTCodeAttributeStrategy", () => {
 			expect(results).toEqual([
 				{
 					className: "NotifierJob",
-					facet: "MessageBroker/ActiveJob::Async/Queue/Produce/Named/default",
-					metricTimesliceName: "MessageBroker/ActiveJob::Async/Queue/Produce/Named/default",
+					facet: ["MessageBroker/ActiveJob::Async/Queue/Produce/Named/default", "8"],
 					namespace: "NotifierJob",
-					requestsPerMinute: 24.1,
+					// requestsPerMinute: 24.1,
 					metadata: {
 						"code.lineno": 8,
 						traceId: "2d2a1cfae193394b121427ff11df5fc5",
@@ -360,7 +365,7 @@ describe("FLTCodeAttributeStrategy", () => {
 				mockNewRelicGraphqlClient
 			);
 			const groupedByTransactionName: Dictionary<Span[]> = {
-				"Nested/OtherTransaction/Background/Custom::Helpers/custom_class_method": [
+				"Nested/OtherTransaction/Background/Custom::Helpers/custom_class_method|11|null": [
 					{
 						"code.lineno": "11",
 						"code.namespace": "Custom::Helpers",
@@ -382,7 +387,7 @@ describe("FLTCodeAttributeStrategy", () => {
 						transactionId: "a0627ed02eb626c0",
 					},
 				],
-				"Custom/CLMtesting/InstanceMethod": [
+				"Custom/CLMtesting/InstanceMethod|33|null": [
 					{
 						"code.lineno": 33,
 						"code.namespace": "Custom::Helpers",
@@ -404,7 +409,7 @@ describe("FLTCodeAttributeStrategy", () => {
 						transactionId: "2e1a7d60f6a4400d",
 					},
 				],
-				"Nested/OtherTransaction/Background/Custom::Helpers/custom_instance_method": [
+				"Nested/OtherTransaction/Background/Custom::Helpers/custom_instance_method|27|null": [
 					{
 						"code.lineno": "27",
 						"code.namespace": "Custom::Helpers",
@@ -426,7 +431,7 @@ describe("FLTCodeAttributeStrategy", () => {
 						transactionId: "2e1a7d60f6a4400d",
 					},
 				],
-				"Custom/CLMtesting/ClassMethod": [
+				"Custom/CLMtesting/ClassMethod|16|null": [
 					{
 						"code.lineno": 16,
 						"code.namespace": "Custom::Helpers",
@@ -452,26 +457,29 @@ describe("FLTCodeAttributeStrategy", () => {
 
 			const metricTimesliceNames: MetricTimeslice[] = [
 				{
-					facet: "Nested/OtherTransaction/Background/Custom::Helpers/custom_class_method",
+					facet: ["Nested/OtherTransaction/Background/Custom::Helpers/custom_class_method", "11"],
 					averageDuration: 1.1,
-					metricTimesliceName:
-						"Nested/OtherTransaction/Background/Custom::Helpers/custom_class_method",
+					// metricTimesliceName:
+					// 	"Nested/OtherTransaction/Background/Custom::Helpers/custom_class_method",
 				},
 				{
-					facet: "Nested/OtherTransaction/Background/Custom::Helpers/custom_instance_method",
-					averageDuration: 1.2,
-					metricTimesliceName:
+					facet: [
 						"Nested/OtherTransaction/Background/Custom::Helpers/custom_instance_method",
+						"27",
+					],
+					averageDuration: 1.2,
+					// metricTimesliceName:
+					// 	"Nested/OtherTransaction/Background/Custom::Helpers/custom_instance_method",
 				},
 				{
-					facet: "Custom/CLMtesting/ClassMethod",
+					facet: ["Custom/CLMtesting/ClassMethod", "16"],
 					averageDuration: 1.3,
-					metricTimesliceName: "Custom/CLMtesting/ClassMethod",
+					// metricTimesliceName: "Custom/CLMtesting/ClassMethod",
 				},
 				{
-					facet: "Custom/CLMtesting/InstanceMethod",
+					facet: ["Custom/CLMtesting/InstanceMethod", "33"],
 					averageDuration: 1.4,
-					metricTimesliceName: "Custom/CLMtesting/InstanceMethod",
+					// metricTimesliceName: "Custom/CLMtesting/InstanceMethod",
 				},
 			];
 
@@ -480,9 +488,7 @@ describe("FLTCodeAttributeStrategy", () => {
 			expect(results).toEqual([
 				{
 					className: "Helpers",
-					facet: "Nested/OtherTransaction/Background/Custom::Helpers/custom_class_method",
-					metricTimesliceName:
-						"Nested/OtherTransaction/Background/Custom::Helpers/custom_class_method",
+					facet: ["Nested/OtherTransaction/Background/Custom::Helpers/custom_class_method", "11"],
 					averageDuration: 1.1,
 					namespace: "Custom",
 					metadata: {
@@ -496,9 +502,10 @@ describe("FLTCodeAttributeStrategy", () => {
 				},
 				{
 					className: "Helpers",
-					facet: "Nested/OtherTransaction/Background/Custom::Helpers/custom_instance_method",
-					metricTimesliceName:
+					facet: [
 						"Nested/OtherTransaction/Background/Custom::Helpers/custom_instance_method",
+						"27",
+					],
 					averageDuration: 1.2,
 					namespace: "Custom",
 					metadata: {
@@ -511,11 +518,10 @@ describe("FLTCodeAttributeStrategy", () => {
 					functionName: "custom_instance_method",
 				},
 				{
-					facet: "Custom/CLMtesting/ClassMethod",
+					facet: ["Custom/CLMtesting/ClassMethod", "16"],
 					averageDuration: 1.3,
 					className: "Helpers",
 					functionName: "self.custom_class_method_too",
-					metricTimesliceName: "Custom/CLMtesting/ClassMethod",
 					namespace: "Custom",
 					metadata: {
 						"code.lineno": 16,
@@ -526,11 +532,10 @@ describe("FLTCodeAttributeStrategy", () => {
 					},
 				},
 				{
-					facet: "Custom/CLMtesting/InstanceMethod",
+					facet: ["Custom/CLMtesting/InstanceMethod", "33"],
 					averageDuration: 1.4,
 					className: "Helpers",
 					functionName: "custom_instance_method_too",
-					metricTimesliceName: "Custom/CLMtesting/InstanceMethod",
 					namespace: "Custom",
 					metadata: {
 						"code.lineno": 33,
@@ -557,7 +562,7 @@ describe("FLTCodeAttributeStrategy", () => {
 				mockNewRelicGraphqlClient
 			);
 			const groupedByTransactionName: Dictionary<Span[]> = {
-				"Nested/OtherTransaction/Background/WhichIsWhich/samename": [
+				"Nested/OtherTransaction/Background/WhichIsWhich/samename|20|null": [
 					{
 						"code.filepath": "/usr/src/app/lib/which_is_which.rb",
 						"code.function": "samename",
@@ -569,6 +574,8 @@ describe("FLTCodeAttributeStrategy", () => {
 						"transaction.name": null,
 						transactionId: "90b4cb9daa96f88b",
 					},
+				],
+				"Nested/OtherTransaction/Background/WhichIsWhich/samename|9|null": [
 					{
 						"code.filepath": "/usr/src/app/lib/which_is_which.rb",
 						"code.function": "self.samename",
@@ -585,14 +592,13 @@ describe("FLTCodeAttributeStrategy", () => {
 
 			const metricTimesliceNames: MetricTimeslice[] = [
 				{
-					facet: "Nested/OtherTransaction/Background/WhichIsWhich/samename",
+					facet: ["Nested/OtherTransaction/Background/WhichIsWhich/samename", "20"],
 					averageDuration: 1.1,
-					metricTimesliceName: "Nested/OtherTransaction/Background/WhichIsWhich/samename",
 				},
 				{
-					facet: "Nested/OtherTransaction/Background/WhichIsWhich/samename",
+					facet: ["Nested/OtherTransaction/Background/WhichIsWhich/samename", "9"],
 					averageDuration: 1.2,
-					metricTimesliceName: "Nested/OtherTransaction/Background/WhichIsWhich/samename",
+					// metricTimesliceName: "Nested/OtherTransaction/Background/WhichIsWhich/samename",
 				},
 			];
 
@@ -601,8 +607,7 @@ describe("FLTCodeAttributeStrategy", () => {
 			expect(results).toEqual([
 				{
 					className: "WhichIsWhich",
-					facet: "Nested/OtherTransaction/Background/WhichIsWhich/samename",
-					metricTimesliceName: "Nested/OtherTransaction/Background/WhichIsWhich/samename",
+					facet: ["Nested/OtherTransaction/Background/WhichIsWhich/samename", "20"],
 					averageDuration: 1.1,
 					namespace: "WhichIsWhich",
 					metadata: {
@@ -616,18 +621,17 @@ describe("FLTCodeAttributeStrategy", () => {
 				},
 				{
 					className: "WhichIsWhich",
-					facet: "Nested/OtherTransaction/Background/WhichIsWhich/samename",
-					metricTimesliceName: "Nested/OtherTransaction/Background/WhichIsWhich/samename",
+					facet: ["Nested/OtherTransaction/Background/WhichIsWhich/samename", "9"],
 					averageDuration: 1.2,
 					namespace: "WhichIsWhich",
 					metadata: {
-						"code.function": "samename",
-						"code.lineno": "20",
+						"code.function": "self.samename", // TODO is this right?
+						"code.lineno": "9",
 						traceId: "8c39f01c9e867d5d7179a6a5152a8f8e",
 						transactionId: "90b4cb9daa96f88b",
 						"code.namespace": "WhichIsWhich",
 					},
-					functionName: "samename",
+					functionName: "self.samename", // TODO is this right?
 				},
 			]);
 		});
@@ -648,7 +652,7 @@ describe("FLTCodeAttributeStrategy", () => {
 
 			const results = await strategy.addMethodName(
 				{
-					"Function/apis.v2.superheros:superheros_superhero_by_slug": [
+					"Function/apis.v2.superheros:superheros_superhero_by_slug|null|null": [
 						{
 							"code.filepath": "/superheros/apis/v2/superheroes.py",
 							"code.function": "SuperheroBySlug",
@@ -660,9 +664,9 @@ describe("FLTCodeAttributeStrategy", () => {
 				},
 				[
 					{
-						facet: "Function/apis.v2.superheros:superheros_superhero_by_slug",
+						facet: ["Function/apis.v2.superheros:superheros_superhero_by_slug"],
 						averageDuration: 0.0025880090121565193,
-						metricTimesliceName: "Function/apis.v2.superheros:superheros_superhero_by_slug",
+						// metricTimesliceName: "Function/apis.v2.superheros:superheros_superhero_by_slug",
 					},
 				]
 			);

--- a/shared/agent/test/unit/providers/newrelic/newrelic.clm.queries.spec.ts
+++ b/shared/agent/test/unit/providers/newrelic/newrelic.clm.queries.spec.ts
@@ -9,7 +9,7 @@ describe("clm query generation", () => {
 				"Nested/Controller/agents/update",
 			]);
 			expect(query).toContain(
-				"metricTimesliceName in ('Controller/agents/show','Controller/agents/update')",
+				"metricTimesliceName in ('Controller/agents/show','Controller/agents/update')"
 			);
 		});
 
@@ -19,7 +19,7 @@ describe("clm query generation", () => {
 				"Function/routes.app:some_call",
 			]);
 			expect(query).toContain(
-				"metricTimesliceName in ('WebTransaction/Function/routes.app:db_call','WebTransaction/Function/routes.app:some_call')",
+				"metricTimesliceName in ('WebTransaction/Function/routes.app:db_call','WebTransaction/Function/routes.app:some_call')"
 			);
 		});
 
@@ -29,7 +29,7 @@ describe("clm query generation", () => {
 				"Nested/OtherTransaction/Background/Custom::Helpers/custom_class_method2",
 			]);
 			expect(query).toContain(
-				"metricTimesliceName in ('Nested/OtherTransaction/Background/Custom::Helpers/custom_class_method','Nested/OtherTransaction/Background/Custom::Helpers/custom_class_method2')",
+				"metricTimesliceName in ('Nested/OtherTransaction/Background/Custom::Helpers/custom_class_method','Nested/OtherTransaction/Background/Custom::Helpers/custom_class_method2')"
 			);
 		});
 	});
@@ -38,7 +38,7 @@ describe("clm query generation", () => {
 			const response = generateSpanQuery("nrGuid", "filePath", "equals", "python", "my/file.py");
 			// console.log(response);
 			expect(response).toContain(
-				"nrql(query: \"SELECT name,`transaction.name`,code.lineno,code.namespace,code.function,traceId,transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.filepath='my/file.py'  SINCE 30 minutes AGO LIMIT 250\", timeout: 60)",
+				"nrql(query: \"SELECT name, `transaction.name`, code.lineno, code.column, tags.commit, code.namespace, code.function, traceId, transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.filepath='my/file.py'  SINCE 30 minutes AGO LIMIT 250\", timeout: 60)"
 			);
 		});
 
@@ -46,7 +46,7 @@ describe("clm query generation", () => {
 			const response = generateSpanQuery("nrGuid", "filePath", "like", "python", "my/file.py");
 			// console.log(response);
 			expect(response).toContain(
-				"nrql(query: \"SELECT name,`transaction.name`,code.lineno,code.namespace,code.function,traceId,transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.filepath like '%my/file.py'  SINCE 30 minutes AGO LIMIT 250\"",
+				"nrql(query: \"SELECT name, `transaction.name`, code.lineno, code.column, tags.commit, code.namespace, code.function, traceId, transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.filepath like '%my/file.py'  SINCE 30 minutes AGO LIMIT 250\""
 			);
 		});
 
@@ -54,7 +54,7 @@ describe("clm query generation", () => {
 			const response = generateSpanQuery("nrGuid", "filePath", "fuzzy", "python", "my/file.py");
 			// console.log(response);
 			expect(response).toContain(
-				"nrql(query: \"SELECT name, `transaction.name`, code.lineno, code.namespace, code.function, traceId, transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.filepath like '%my/file.py%' SINCE 30 minutes AGO LIMIT 250\", timeout: 60)",
+				"nrql(query: \"SELECT name, `transaction.name`, code.lineno, code.column, tags.commit, code.namespace, code.function, traceId, transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.filepath like '%my/file.py%' SINCE 30 minutes AGO LIMIT 250\", timeout: 60)"
 			);
 		});
 
@@ -64,7 +64,7 @@ describe("clm query generation", () => {
 			});
 			// console.log(response);
 			expect(response).toContain(
-				"nrql(query: \"SELECT name,`transaction.name`,code.lineno,code.namespace,code.function,traceId,transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.namespace='blah' SINCE 30 minutes AGO LIMIT 250\", timeout: 60)",
+				"nrql(query: \"SELECT name, `transaction.name`, code.lineno, code.column, tags.commit, code.namespace, code.function, traceId, transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.namespace='blah' SINCE 30 minutes AGO LIMIT 250\", timeout: 60)"
 			);
 		});
 
@@ -74,7 +74,7 @@ describe("clm query generation", () => {
 			});
 			// console.log(response);
 			expect(response).toContain(
-				"nrql(query: \"SELECT name,`transaction.name`,code.lineno,code.namespace,code.function,traceId,transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.namespace like 'blah%' SINCE 30 minutes AGO LIMIT 250\", timeout: 60)",
+				"nrql(query: \"SELECT name, `transaction.name`, code.lineno, code.column, tags.commit, code.namespace, code.function, traceId, transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.namespace like 'blah%' SINCE 30 minutes AGO LIMIT 250\", timeout: 60)"
 			);
 		});
 
@@ -85,7 +85,7 @@ describe("clm query generation", () => {
 			});
 			// console.log(response);
 			expect(response).toContain(
-				"nrql(query: \"SELECT name,`transaction.name`,code.lineno,code.namespace,code.function,traceId,transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.namespace='blah' AND code.function='foo' SINCE 30 minutes AGO LIMIT 250\", timeout: 60)",
+				"nrql(query: \"SELECT name, `transaction.name`, code.lineno, code.column, tags.commit, code.namespace, code.function, traceId, transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.namespace='blah' AND code.function='foo' SINCE 30 minutes AGO LIMIT 250\", timeout: 60)"
 			);
 		});
 
@@ -96,7 +96,7 @@ describe("clm query generation", () => {
 			});
 			// console.log(response);
 			expect(response).toContain(
-				"nrql(query: \"SELECT name,`transaction.name`,code.lineno,code.namespace,code.function,traceId,transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.namespace like 'blah%' AND code.function like 'foo%' SINCE 30 minutes AGO LIMIT 250\", timeout: 60)",
+				"nrql(query: \"SELECT name, `transaction.name`, code.lineno, code.column, tags.commit, code.namespace, code.function, traceId, transactionId from Span WHERE `entity.guid` = 'nrGuid' AND code.namespace like 'blah%' AND code.function like 'foo%' SINCE 30 minutes AGO LIMIT 250\", timeout: 60)"
 			);
 		});
 	});

--- a/shared/util/src/protocol/agent/agent.protocol.documentMarkers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.documentMarkers.ts
@@ -12,6 +12,7 @@ import {
 	CSMarker,
 	CSMarkerIdentifier,
 	CSMarkerLocation,
+	CSReferenceLocation,
 } from "./api.protocol";
 
 export interface CreateDocumentMarkerPermalinkRequest {
@@ -106,6 +107,33 @@ export interface FetchDocumentMarkersResponse {
 	markers: DocumentMarker[];
 	markersNotLocated: MarkerNotLocated[];
 }
+
+export type Markerish = {
+	id: string;
+	referenceLocations: CSReferenceLocation[];
+};
+
+export type ComputeCurrentLocationsRequest = {
+	uri: string;
+	commit: string;
+	markers: Markerish[];
+};
+
+export type MarkerLocationsById = {
+	[id: string]: CSMarkerLocation;
+};
+
+export type ComputeCurrentLocationResponse = {
+	locations: MarkerLocationsById;
+};
+
+export const ComputeCurrentLocationsRequestType = new RequestType<
+	ComputeCurrentLocationsRequest,
+	ComputeCurrentLocationResponse,
+	void,
+	void
+>("codestream/textDocument/currentLocation");
+
 export const FetchDocumentMarkersRequestType = new RequestType<
 	FetchDocumentMarkersRequest,
 	FetchDocumentMarkersResponse | undefined,

--- a/shared/util/src/protocol/agent/agent.protocol.providers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.providers.ts
@@ -1753,24 +1753,28 @@ export type MetricTimesliceNameMapping = {
 };
 
 export interface FileLevelTelemetryMetric {
-	metricTimesliceName: string;
+	// metricTimesliceName: string;
+	facet: string[];
 	namespace?: string;
 	className?: string;
+	lineno?: number;
+	column?: number;
+	commit?: string;
 	functionName?: string;
 	anomaly?: ObservabilityAnomaly;
 }
 
 export interface FileLevelTelemetryAverageDuration extends FileLevelTelemetryMetric {
-	averageDuration: any;
+	averageDuration: number;
 }
 
 export interface FileLevelTelemetrySampleSize extends FileLevelTelemetryMetric {
-	sampleSize: any;
+	sampleSize: number;
 	source: string;
 }
 
 export interface FileLevelTelemetryErrorRate extends FileLevelTelemetryMetric {
-	errorRate: any;
+	errorRate: number;
 }
 
 export interface GetFileLevelTelemetryResponse {
@@ -1794,6 +1798,7 @@ export interface GetFileLevelTelemetryResponse {
 	newRelicAlertSeverity?: string;
 	codeNamespace?: string;
 	relativeFilePath: string;
+	deploymentCommit?: string;
 	error?: {
 		message?: string;
 		type?: "NOT_CONNECTED" | "NOT_ASSOCIATED";
@@ -1896,6 +1901,7 @@ export const GetSpanChartDataRequestType = new RequestType<
 export interface Deployment {
 	seconds: number;
 	version: string;
+	commit?: string;
 }
 
 export interface GetDeploymentsRequest {
@@ -1913,6 +1919,15 @@ export const GetDeploymentsRequestType = new RequestType<
 	void,
 	void
 >("codestream/newrelic/deployments");
+
+// Not yet LSP but might be someday
+export interface GetLatestDeploymentRequest {
+	entityGuid: string;
+}
+
+export interface GetLatestDeploymentResponse {
+	deployment: Deployment;
+}
 
 export const GetFileLevelTelemetryRequestType = new RequestType<
 	GetFileLevelTelemetryRequest,

--- a/shared/util/src/utils/system/stopwatch.ts
+++ b/shared/util/src/utils/system/stopwatch.ts
@@ -1,0 +1,39 @@
+export class Stopwatch {
+	private _start: [number, number] | undefined;
+	private _stop: [number, number] | undefined;
+
+	constructor(private readonly _name: string) {
+
+	}
+
+	static createAndStart(name: string): Stopwatch {
+		const stopwatch = new Stopwatch(name);
+		stopwatch.start();
+		return stopwatch;
+	}
+
+	start(): void {
+		this._start = process.hrtime();
+	}
+
+	stop(): void {
+		if (!this._start) {
+			throw new Error("Stopwatch not started");
+		}
+		this._stop = process.hrtime(this._start);
+	}
+
+	report(): string {
+		if (!this._start) {
+			throw new Error("Stopwatch not started");
+		}
+
+		if (!this._stop) {
+			this.stop();
+		}
+
+		const [seconds, nanoseconds] = this._stop!;
+		const milliseconds = seconds * 1000 + nanoseconds / 1000000;
+		return `${this._name}: ${milliseconds.toFixed(2)}ms`;
+	}
+}

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "codestream",
-	"version": "15.1.2",
+	"version": "15.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "codestream",
-			"version": "15.1.2",
+			"version": "15.2.1",
 			"hasInstallScript": true,
 			"license": "UNLICENSED",
 			"dependencies": {
@@ -17,6 +17,7 @@
 				"node-abort-controller": "3.0.1",
 				"node-fetch": "2.6.7",
 				"source-map-support": "0.5.21",
+				"timed-cache": "2.0.0",
 				"uuid": "3.3.2",
 				"vscode-languageclient": "5.2.1"
 			},
@@ -30,6 +31,7 @@
 				"@types/node": "18",
 				"@types/node-fetch": "2.6.1",
 				"@types/sinon": "10.0.11",
+				"@types/timed-cache": "2.0.2",
 				"@types/uuid": "3.4.5",
 				"@types/vscode": "1.73.1",
 				"@typescript-eslint/eslint-plugin": "6.19.1",
@@ -3622,6 +3624,12 @@
 			"integrity": "sha512-n4sx2bqL0mW1tvDf/loQ+aMX7GQD3lc3fkCMC55VFNDu/vBOabO+LTIeXKM14xK0ppk5TUGcWRjiSpIlUpghKw==",
 			"dev": true,
 			"peer": true
+		},
+		"node_modules/@types/timed-cache": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/timed-cache/-/timed-cache-2.0.2.tgz",
+			"integrity": "sha512-yIyQO/uaUBfXJkfLFY9Tr07izzJjaN2A8rOU63Jr7sJlvWjPlyiqfWDEoGqCrGR8NxsQJbuz1kDCSW22R4YCug==",
+			"dev": true
 		},
 		"node_modules/@types/uuid": {
 			"version": "3.4.5",
@@ -11204,6 +11212,11 @@
 			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
 			"dev": true
 		},
+		"node_modules/timed-cache": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/timed-cache/-/timed-cache-2.0.0.tgz",
+			"integrity": "sha512-9owe3VtDCtZKo8bfk5bSC4tSzIRP65doXI0i2oFWNP4VjQDwoRIsADynZQZz6XXK7exL7bOuI3HExFQ9LGi3tQ=="
+		},
 		"node_modules/tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -15206,6 +15219,12 @@
 			"integrity": "sha512-n4sx2bqL0mW1tvDf/loQ+aMX7GQD3lc3fkCMC55VFNDu/vBOabO+LTIeXKM14xK0ppk5TUGcWRjiSpIlUpghKw==",
 			"dev": true,
 			"peer": true
+		},
+		"@types/timed-cache": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/timed-cache/-/timed-cache-2.0.2.tgz",
+			"integrity": "sha512-yIyQO/uaUBfXJkfLFY9Tr07izzJjaN2A8rOU63Jr7sJlvWjPlyiqfWDEoGqCrGR8NxsQJbuz1kDCSW22R4YCug==",
+			"dev": true
 		},
 		"@types/uuid": {
 			"version": "3.4.5",
@@ -20809,6 +20828,11 @@
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
 			"dev": true
+		},
+		"timed-cache": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/timed-cache/-/timed-cache-2.0.0.tgz",
+			"integrity": "sha512-9owe3VtDCtZKo8bfk5bSC4tSzIRP65doXI0i2oFWNP4VjQDwoRIsADynZQZz6XXK7exL7bOuI3HExFQ9LGi3tQ=="
 		},
 		"tmp": {
 			"version": "0.0.33",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -396,6 +396,7 @@
 		"node-abort-controller": "3.0.1",
 		"node-fetch": "2.6.7",
 		"source-map-support": "0.5.21",
+		"timed-cache": "2.0.0",
 		"uuid": "3.3.2",
 		"vscode-languageclient": "5.2.1"
 	},
@@ -409,6 +410,7 @@
 		"@types/node": "18",
 		"@types/node-fetch": "2.6.1",
 		"@types/sinon": "10.0.11",
+		"@types/timed-cache": "2.0.2",
 		"@types/uuid": "3.4.5",
 		"@types/vscode": "1.73.1",
 		"@typescript-eslint/eslint-plugin": "6.19.1",

--- a/vscode/src/__test__/suite/InstrumentationCodeLensProvider.test.ts
+++ b/vscode/src/__test__/suite/InstrumentationCodeLensProvider.test.ts
@@ -7,6 +7,7 @@ import sinon from "sinon";
 import * as vscode from "vscode";
 import { CancellationTokenSource } from "vscode-languageclient";
 import {
+	ComputeCurrentLocationResponse,
 	FileLevelTelemetryRequestOptions,
 	FunctionLocator,
 	GetFileLevelTelemetryResponse
@@ -18,6 +19,20 @@ import {
 	SymboslLocated
 } from "../../providers/symbolLocator";
 import { InstrumentationCodeLensProvider } from "../../providers/instrumentationCodeLensProvider";
+import { IObservabilityService } from "../../agent/ObservabilityService";
+
+const stubComputeCurrentLocation = (
+	id: string,
+	lineno: number,
+	column: number,
+	commit: string,
+	functionName: string,
+	uri: string
+): Promise<ComputeCurrentLocationResponse> => {
+	return new Promise(resolve => {
+		return resolve({} as ComputeCurrentLocationResponse);
+	});
+};
 
 class MockSymbolLocator implements ISymbolLocator {
 	locate(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<SymboslLocated> {
@@ -64,7 +79,8 @@ suite("InstrumentationCodeLensProvider Test Suite", () => {
 	});
 
 	test("Smoke test", async () => {
-		const observabilityService = {
+		const observabilityService: IObservabilityService = {
+			computeCurrentLocation: stubComputeCurrentLocation,
 			getFileLevelTelemetry: function (
 				filePath: string,
 				languageId: string,
@@ -88,7 +104,7 @@ suite("InstrumentationCodeLensProvider Test Suite", () => {
 							{
 								functionName: "hello_world",
 								averageDuration: 3.333,
-								metricTimesliceName: "d"
+								facet: ["d"]
 							}
 						]
 					} as GetFileLevelTelemetryResponse);
@@ -119,7 +135,8 @@ suite("InstrumentationCodeLensProvider Test Suite", () => {
 	});
 
 	test("NOT_ASSOCIATED", async () => {
-		const observabilityService = {
+		const observabilityService: IObservabilityService = {
+			computeCurrentLocation: stubComputeCurrentLocation,
 			getFileLevelTelemetry: function (
 				filePath: string,
 				languageId: string,
@@ -174,7 +191,8 @@ suite("InstrumentationCodeLensProvider Test Suite", () => {
 	});
 
 	test("NO_PYTHON_VSCODE_EXTENSION", async () => {
-		const observabilityService = {
+		const observabilityService: IObservabilityService = {
+			computeCurrentLocation: stubComputeCurrentLocation,
 			getFileLevelTelemetry: function (
 				filePath: string,
 				languageId: string,
@@ -211,7 +229,8 @@ suite("InstrumentationCodeLensProvider Test Suite", () => {
 	});
 
 	test("NO_CSHARP_VSCODE_EXTENSION", async () => {
-		const observabilityService = {
+		const observabilityService: IObservabilityService = {
+			computeCurrentLocation: stubComputeCurrentLocation,
 			getFileLevelTelemetry: function (
 				filePath: string,
 				languageId: string,
@@ -248,7 +267,8 @@ suite("InstrumentationCodeLensProvider Test Suite", () => {
 	});
 
 	test("NO_RUBY_VSCODE_EXTENSION", async () => {
-		const observabilityService = {
+		const observabilityService: IObservabilityService = {
+			computeCurrentLocation: stubComputeCurrentLocation,
 			getFileLevelTelemetry: function (
 				filePath: string,
 				languageId: string,
@@ -285,7 +305,8 @@ suite("InstrumentationCodeLensProvider Test Suite", () => {
 	});
 
 	test("RUBY_PLUGIN_NO_LANGUAGE_SERVER", async () => {
-		const observabilityService = {
+		const observabilityService: IObservabilityService = {
+			computeCurrentLocation: stubComputeCurrentLocation,
 			getFileLevelTelemetry: function (
 				filePath: string,
 				languageId: string,
@@ -347,6 +368,18 @@ suite("InstrumentationCodeLensProvider Test Suite", () => {
 				return new Promise(resolve => {
 					return resolve({} as GetFileLevelTelemetryResponse);
 				});
+			},
+			computeCurrentLocation: function (
+				id: string,
+				lineno: number,
+				column: number,
+				commit: string,
+				functionName: string,
+				uri: string
+			): Promise<ComputeCurrentLocationResponse> {
+				return new Promise(resolve => {
+					return resolve({} as ComputeCurrentLocationResponse);
+				});
 			}
 		};
 
@@ -373,7 +406,8 @@ suite("InstrumentationCodeLensProvider Test Suite", () => {
 	});
 
 	test("NO_GO_VSCODE_EXTENSION", async () => {
-		const observabilityService = {
+		const observabilityService: IObservabilityService = {
+			computeCurrentLocation: stubComputeCurrentLocation,
 			getFileLevelTelemetry: function (
 				filePath: string,
 				languageId: string,
@@ -410,7 +444,8 @@ suite("InstrumentationCodeLensProvider Test Suite", () => {
 	});
 
 	test("NO_SPANS", async () => {
-		const observabilityService = {
+		const observabilityService: IObservabilityService = {
+			computeCurrentLocation: stubComputeCurrentLocation,
 			getFileLevelTelemetry: function (
 				filePath: string,
 				languageId: string,

--- a/vscode/src/agent/ObservabilityService.ts
+++ b/vscode/src/agent/ObservabilityService.ts
@@ -1,0 +1,73 @@
+import {
+	ComputeCurrentLocationResponse,
+	ComputeCurrentLocationsRequestType,
+	FileLevelTelemetryRequestOptions,
+	FunctionLocator,
+	GetFileLevelTelemetryRequestType,
+	GetFileLevelTelemetryResponse
+} from "@codestream/protocols/agent";
+import { Container } from "../container";
+
+export interface IObservabilityService {
+	getFileLevelTelemetry(
+		fileUri: string,
+		languageId: string,
+		resetCache?: boolean,
+		locator?: FunctionLocator,
+		options?: FileLevelTelemetryRequestOptions | undefined
+	): Promise<GetFileLevelTelemetryResponse>;
+
+	computeCurrentLocation(
+		id: string,
+		lineno: number,
+		column: number,
+		commit: string,
+		functionName: string,
+		uri: string
+	): Promise<ComputeCurrentLocationResponse>;
+}
+
+class ObservabilityService implements IObservabilityService {
+	getFileLevelTelemetry(
+		fileUri: string,
+		languageId: string,
+		resetCache: boolean,
+		locator?: FunctionLocator,
+		options?: FileLevelTelemetryRequestOptions
+	) {
+		return Container.agent.sendRequest(GetFileLevelTelemetryRequestType, {
+			fileUri,
+			languageId,
+			resetCache,
+			locator,
+			options
+		});
+	}
+
+	computeCurrentLocation(
+		id: string,
+		lineno: number,
+		column: number,
+		commit: string,
+		functionName: string,
+		uri: string
+	): Promise<ComputeCurrentLocationResponse> {
+		return Container.agent.sendRequest(ComputeCurrentLocationsRequestType, {
+			uri,
+			commit,
+			markers: [
+				{
+					id,
+					referenceLocations: [
+						{
+							commitHash: commit,
+							location: [lineno, 0, lineno, 0, undefined]
+						}
+					]
+				}
+			]
+		});
+	}
+}
+
+export const observabilityService = new ObservabilityService();

--- a/vscode/src/agent/agentConnection.ts
+++ b/vscode/src/agent/agentConnection.ts
@@ -98,15 +98,12 @@ import {
 	FetchTeamsRequestType,
 	FetchUnreadStreamsRequestType,
 	FetchUsersRequestType,
-	FileLevelTelemetryRequestOptions,
-	FunctionLocator,
 	GetDocumentFromKeyBindingRequestType,
 	GetDocumentFromKeyBindingResponse,
 	GetDocumentFromMarkerRequestType,
 	GetDocumentFromMarkerResponse,
 	GetFileContentsAtRevisionRequestType,
 	GetFileContentsAtRevisionResponse,
-	GetFileLevelTelemetryRequestType,
 	GetFileScmInfoRequestType,
 	GetFileStreamRequestType,
 	GetFileStreamResponse,
@@ -1009,29 +1006,6 @@ export class CodeStreamAgentConnection implements Disposable {
 
 		preferences() {
 			return this._connection.sendRequest(GetPreferencesRequestType, undefined);
-		}
-	})(this);
-
-	get observability() {
-		return this._observability;
-	}
-	private readonly _observability = new (class {
-		constructor(private readonly _connection: CodeStreamAgentConnection) {}
-
-		getFileLevelTelemetry(
-			fileUri: string,
-			languageId: string,
-			resetCache: boolean,
-			locator?: FunctionLocator,
-			options?: FileLevelTelemetryRequestOptions
-		) {
-			return this._connection.sendRequest(GetFileLevelTelemetryRequestType, {
-				fileUri,
-				languageId,
-				resetCache,
-				locator,
-				options
-			});
 		}
 	})(this);
 

--- a/vscode/src/container.ts
+++ b/vscode/src/container.ts
@@ -25,6 +25,7 @@ import { EditorController } from "./controllers/editorController";
 import { NrqlCodeLensController } from "./controllers/nrqlCodeLensController";
 import { PanelController } from "./controllers/panelController";
 import { NrqlDocumentSymbolProvider } from "./providers/nrqlDocumentSymbolProvider";
+import { CodeStreamInlayHintsProvider } from "providers/inlayHintProvider";
 
 export class Container {
 	static telemetryOptions?: TelemetryOptions;
@@ -61,7 +62,7 @@ export class Container {
 		context.subscriptions.push(
 			(this._instrumentableCodeLensController = new InstrumentableCodeLensController())
 		);
-
+		context.subscriptions.push((this._inlayHintsProvider = new CodeStreamInlayHintsProvider()));
 		context.subscriptions.push(new CodemarkPatchContentProvider());
 		context.subscriptions.push((this._statusBar = new StatusBarController()));
 
@@ -170,6 +171,11 @@ export class Container {
 	private static _agent: CodeStreamAgentConnection;
 	static get agent() {
 		return this._agent;
+	}
+
+	private static _inlayHintsProvider: CodeStreamInlayHintsProvider;
+	static get inlayHintsProvider() {
+		return this._inlayHintsProvider;
 	}
 
 	private static _codeActions: CodeStreamCodeActionProvider;

--- a/vscode/src/controllers/instrumentableCodeLensController.ts
+++ b/vscode/src/controllers/instrumentableCodeLensController.ts
@@ -1,4 +1,3 @@
-"use strict";
 import { ConfigurationChangeEvent, Disposable, languages, workspace } from "vscode";
 
 import { SymbolLocator } from "../providers/symbolLocator";
@@ -6,12 +5,13 @@ import { Container } from "../container";
 import { configuration } from "../configuration";
 import { InstrumentationCodeLensProvider } from "../providers/instrumentationCodeLensProvider";
 import { SessionStatus, SessionStatusChangedEvent } from "../api/session";
+import { observabilityService } from "../agent/ObservabilityService";
 
 export class InstrumentableCodeLensController implements Disposable {
 	private _disposable: Disposable | undefined;
 	private _provider: InstrumentationCodeLensProvider | undefined;
 	private _providerDisposable: Disposable | undefined;
-	private _status: any;
+	private _status: SessionStatus | undefined = undefined;
 
 	constructor() {
 		this._disposable = Disposable.from(
@@ -33,7 +33,7 @@ export class InstrumentableCodeLensController implements Disposable {
 	}
 
 	private onAnyChanged() {
-		const cfg = configuration.get<Boolean>(configuration.name("goldenSignalsInEditor").value);
+		const cfg = configuration.get<boolean>(configuration.name("goldenSignalsInEditor").value);
 		if (cfg) {
 			if (this._status === SessionStatus.SignedIn) {
 				this.ensureProvider();
@@ -91,7 +91,7 @@ export class InstrumentableCodeLensController implements Disposable {
 		this._provider = new InstrumentationCodeLensProvider(
 			template,
 			new SymbolLocator(),
-			Container.agent.observability!,
+			observabilityService,
 			Container.agent.telemetry!
 		);
 		this._providerDisposable = Disposable.from(

--- a/vscode/src/controllers/notificationsController.ts
+++ b/vscode/src/controllers/notificationsController.ts
@@ -3,152 +3,152 @@ import { Disposable, MessageItem, window } from "vscode";
 import { Post, PostsChangedEvent } from "../api/session";
 import { Container } from "../container";
 import {
-	CodemarkPlus,
-	DidDetectObservabilityAnomaliesNotification,
-	ReviewPlus
+  CodemarkPlus,
+  DidDetectObservabilityAnomaliesNotification,
+  ReviewPlus
 } from "@codestream/protocols/agent";
 import { Functions } from "../system";
 
 type ToastType = "PR" | "Review" | "Codemark";
 
 export class NotificationsController implements Disposable {
-	private _disposable: Disposable;
+  private _disposable: Disposable;
 
-	constructor() {
-		this._disposable = Disposable.from(
-			Container.session.onDidChangePosts(this.onSessionPostsReceived, this),
-			Container.agent.onDidDetectObservabilityAnomalies(this.onObservabilityAnomaliesDetected, this)
-		);
-	}
+  constructor() {
+    this._disposable = Disposable.from(
+      Container.session.onDidChangePosts(this.onSessionPostsReceived, this),
+      Container.agent.onDidDetectObservabilityAnomalies(this.onObservabilityAnomaliesDetected, this)
+    );
+  }
 
-	dispose() {
-		this._disposable && this._disposable.dispose();
-	}
+  dispose() {
+    this._disposable && this._disposable.dispose();
+  }
 
-	private async onSessionPostsReceived(e: PostsChangedEvent) {
-		const { user } = Container.session;
-		const { activeStreamThread: activeStream, visible: streamVisible } = Container.sidebar;
+  private async onSessionPostsReceived(e: PostsChangedEvent) {
+    const { user } = Container.session;
+    const { activeStreamThread: activeStream, visible: streamVisible } = Container.sidebar;
 
-		if (!user.wantsToastNotifications()) return;
+    if (!user.wantsToastNotifications()) return;
 
-		// Don't show notifications for deleted, edited (if edited it isn't the first time its been seen),
-		// has replies (same as edited), has reactions, or was posted by the current user
-		const items = Functions.uniqueBy(e.items(), (_: Post) => _.id).filter(
-			_ => _.senderId !== user.id && _.isNew()
-		);
-		for (const post of items) {
-			let codemark;
-			let review;
-			const parentPost = await post.parentPost();
-			if (parentPost) {
-				codemark = parentPost.codemark;
-				review = parentPost.review;
-				if (!codemark && !review) {
-					const grandparentPost = await parentPost.parentPost();
-					if (grandparentPost) {
-						review = grandparentPost.review;
-					}
-				}
-			} else {
-				codemark = post.codemark;
-				review = post.review;
-			}
+    // Don't show notifications for deleted, edited (if edited it isn't the first time its been seen),
+    // has replies (same as edited), has reactions, or was posted by the current user
+    const items = Functions.uniqueBy(e.items(), (_: Post) => _.id).filter(
+      _ => _.senderId !== user.id && _.isNew()
+    );
+    for (const post of items) {
+      let codemark;
+      let review;
+      const parentPost = await post.parentPost();
+      if (parentPost) {
+        codemark = parentPost.codemark;
+        review = parentPost.review;
+        if (!codemark && !review) {
+          const grandparentPost = await parentPost.parentPost();
+          if (grandparentPost) {
+            review = grandparentPost.review;
+          }
+        }
+      } else {
+        codemark = post.codemark;
+        review = post.review;
+      }
 
-			if (!codemark && !review) continue;
+      if (!codemark && !review) continue;
 
-			const mentioned = post.mentioned(user.id);
-			// If we are muted and not mentioned, skip it
-			if (user.hasMutedChannel(post.streamId) && !mentioned) continue;
+      const mentioned = post.mentioned(user.id);
+      // If we are muted and not mentioned, skip it
+      if (user.hasMutedChannel(post.streamId) && !mentioned) continue;
 
-			const isPostStreamVisible =
-				streamVisible && !(activeStream === undefined || activeStream.streamId !== post.streamId);
+      const isPostStreamVisible =
+        streamVisible && !(activeStream === undefined || activeStream.streamId !== post.streamId);
 
-			const followerIds = codemark ? codemark.followerIds : review!.followerIds;
-			const isUserFollowing = (followerIds || []).includes(user.id);
-			if (isUserFollowing && (!isPostStreamVisible || mentioned)) {
-				this.showNotification(post, codemark, review);
-			}
-		}
-	}
+      const followerIds = codemark ? codemark.followerIds : review!.followerIds;
+      const isUserFollowing = (followerIds || []).includes(user.id);
+      if (isUserFollowing && (!isPostStreamVisible || mentioned)) {
+        this.showNotification(post, codemark, review);
+      }
+    }
+  }
 
-	private async onObservabilityAnomaliesDetected(
-		notification: DidDetectObservabilityAnomaliesNotification
-	) {
-		const actions: MessageItem[] = [
-			{ title: "Details" },
-			{ title: "Ignore", isCloseAffordance: true }
-		];
-		const { duration, errorRate } = notification;
+  private async onObservabilityAnomaliesDetected(
+    notification: DidDetectObservabilityAnomaliesNotification
+  ) {
+    const actions: MessageItem[] = [
+      { title: "Details" },
+      { title: "Ignore", isCloseAffordance: true }
+    ];
+    const { duration, errorRate } = notification;
 
 		Container.agent.telemetry.track("codestream/toast displayed", {
 			meta_data: `content: anomaly`,
 			event_type: "state_load"
 		});
-		const count = duration.length + errorRate.length;
-		const title = count === 1 ? "Performance issue found" : `${count} performance issues found`;
-		const allAnomalies = [...duration, ...errorRate].sort((a, b) => b.ratio - a.ratio);
-		const firstAnomaly = allAnomalies[0];
-		const message =
-			count === 1
-				? `${title} - ${firstAnomaly.notificationText} (${firstAnomaly.entityName})`
-				: `${title} - #1: ${firstAnomaly.notificationText} (${firstAnomaly.entityName})`;
-		const result = await window.showInformationMessage(message, ...actions);
+    const count = duration.length + errorRate.length;
+    const title = count === 1 ? "Performance issue found" : `${count} performance issues found`;
+    const allAnomalies = [...duration, ...errorRate].sort((a, b) => b.ratio - a.ratio);
+    const firstAnomaly = allAnomalies[0];
+    const message =
+      count === 1
+        ? `${title} - ${firstAnomaly.notificationText} (${firstAnomaly.entityName})`
+        : `${title} - #1: ${firstAnomaly.notificationText} (${firstAnomaly.entityName})`;
+    const result = await window.showInformationMessage(message, ...actions);
 
-		if (result === actions[0]) {
+    if (result === actions[0]) {
 			Container.agent.telemetry.track("codestream/toast clicked", {
 				meta_data: `content: anomaly`,
 				target: "toast",
 				event_type: "click"
 			});
-			Container.sidebar.viewAnomaly({
-				anomaly: firstAnomaly,
-				entityGuid: notification.entityGuid
-			});
-			if (firstAnomaly.codeAttrs) {
-				Container.sidebar.goToClassMethodDefinition(
-					firstAnomaly.codeAttrs.codeFilepath,
-					firstAnomaly.codeAttrs.codeNamespace,
-					firstAnomaly.codeAttrs.codeFunction,
-					firstAnomaly.language
-				);
-			}
-		}
-	}
+      Container.sidebar.viewAnomaly({
+        anomaly: firstAnomaly,
+        entityGuid: notification.entityGuid
+      });
+      if (firstAnomaly.codeAttrs) {
+        Container.sidebar.goToClassMethodDefinition(
+          firstAnomaly.codeAttrs.codeFilepath,
+          firstAnomaly.codeAttrs.codeNamespace,
+          firstAnomaly.codeAttrs.codeFunction,
+          firstAnomaly.language
+        );
+      }
+    }
+  }
 
-	async showNotification(post: Post, codemark?: CodemarkPlus, review?: ReviewPlus) {
-		const sender = await post.sender();
+  async showNotification(post: Post, codemark?: CodemarkPlus, review?: ReviewPlus) {
+    const sender = await post.sender();
 
-		const emote = post.text.startsWith("/me ");
-		const colon = emote ? "" : ":";
-		let text = post.text.replace(/^\/me /, "");
-		text = review ? text.replace(/(approved|rejected) this/i, `$1 ${review.title}`) : text;
+    const emote = post.text.startsWith("/me ");
+    const colon = emote ? "" : ":";
+    let text = post.text.replace(/^\/me /, "");
+    text = review ? text.replace(/(approved|rejected) this/i, `$1 ${review.title}`) : text;
 
-		// TODO: Need to better deal with formatted text for notifications
-		const actions: MessageItem[] = [{ title: "Open" }];
+    // TODO: Need to better deal with formatted text for notifications
+    const actions: MessageItem[] = [{ title: "Open" }];
 
-		const toastContentType: ToastType = codemark ? "Codemark" : "Review";
+    const toastContentType: ToastType = codemark ? "Codemark" : "Review";
 
 		Container.agent.telemetry.track("codestream/toast displayed", {
 			meta_data: `content: ${toastContentType === "Codemark" ? "codemark" : ""}`,
 			event_type: "state_load"
 		});
 
-		const result = await window.showInformationMessage(
-			`${sender !== undefined ? sender.name : "Someone"}${colon} ${text}`,
-			...actions
-		);
+    const result = await window.showInformationMessage(
+      `${sender !== undefined ? sender.name : "Someone"}${colon} ${text}`,
+      ...actions
+    );
 
-		if (result === actions[0]) {
-			if (codemark) {
-				Container.sidebar.openCodemark(codemark.id);
-			} else if (review) {
-				Container.sidebar.openReview(review.id);
-			}
+    if (result === actions[0]) {
+      if (codemark) {
+        Container.sidebar.openCodemark(codemark.id);
+      } else if (review) {
+        Container.sidebar.openReview(review.id);
+      }
 			Container.agent.telemetry.track("codestream/toast clicked", {
 				meta_data: `content: ${toastContentType === "Codemark" ? "codemark" : ""}`,
 				target: "toast",
 				event_type: "click"
 			});
-		}
-	}
+    }
+  }
 }

--- a/vscode/src/providers/inlayHintProvider.ts
+++ b/vscode/src/providers/inlayHintProvider.ts
@@ -1,0 +1,316 @@
+import {
+	CancellationToken,
+	Disposable,
+	DocumentSelector,
+	InlayHint,
+	InlayHintKind,
+	InlayHintLabelPart,
+	InlayHintsProvider,
+	languages,
+	Position,
+	Range,
+	TextDocument
+} from "vscode";
+import { SessionStatus, SessionStatusChangedEvent } from "../api/session";
+import { Container } from "../container";
+import { Logger } from "logger";
+import { Strings } from "../system";
+import {
+	FileLevelTelemetryMetric,
+	FileLevelTelemetryRequestOptions
+} from "@codestream/protocols/agent";
+import { ISymbolLocator, SymbolLocator } from "./symbolLocator";
+import { IObservabilityService, observabilityService } from "agent/ObservabilityService";
+import {
+	CollatedMetric,
+	InstrumentableSymbolCommand,
+	isFileLevelTelemetryAverageDuration,
+	isFileLevelTelemetryErrorRate,
+	isFileLevelTelemetrySampleSize
+} from "./instrumentationCodeLensProvider";
+import { configuration } from "configuration";
+import { ViewMethodLevelTelemetryCommandArgs } from "commands";
+import { Stopwatch } from "@codestream/utils/system/stopwatch";
+import Cache from "timed-cache";
+
+export class CodeStreamInlayHintsProvider implements InlayHintsProvider, Disposable {
+	// TODO limit to languages we support?
+	static selector: DocumentSelector = [{ scheme: "file" }, { scheme: "untitled" }];
+
+	private readonly _disposable: Disposable;
+	private readonly codeLensTemplate: string;
+	private _disposableSignedIn: Disposable | undefined;
+	private _cache = new Cache<Map<string, CollatedMetric>>();
+
+	constructor(
+		private symbolLocator: ISymbolLocator = new SymbolLocator(),
+		private _observabilityService: IObservabilityService = observabilityService
+	) {
+		this._disposable = Disposable.from(
+			Container.session.onDidChangeSessionStatus(this.onSessionStatusChanged, this)
+		);
+
+		// TODO handle null
+		this.codeLensTemplate = configuration.get<string>(
+			configuration.name("goldenSignalsInEditorFormat").value
+		);
+	}
+
+	dispose() {
+		this._disposable && this._disposable.dispose();
+	}
+
+	private async onSessionStatusChanged(e: SessionStatusChangedEvent) {
+		const status = e.getStatus();
+		switch (status) {
+			case SessionStatus.SignedOut:
+				this._disposableSignedIn && this._disposableSignedIn.dispose();
+				break;
+
+			case SessionStatus.SignedIn:
+				this._disposableSignedIn = languages.registerInlayHintsProvider(
+					CodeStreamInlayHintsProvider.selector,
+					this
+				);
+				break;
+		}
+	}
+
+	// The symbol provider has doesn't differentiate between anonymous functions and named functions via the kind field
+	// and it pretty much returns random crap for the "name" of an anonymous function. So we can hopefully detect
+	// anonymous functions by the fact that they are invalid javascript variable names
+	private isValidJavascriptFunctionName(functionName: string): boolean {
+		return functionName.match(/^[a-zA-Z_$][0-9a-zA-Z_$]*$/) != null;
+	}
+
+	public async provideInlayHints(
+		document: TextDocument,
+		range: Range,
+		token: CancellationToken
+	): Promise<InlayHint[]> {
+		const overallStopwatch = Stopwatch.createAndStart("provideInlayHints total");
+		Logger.debug(
+			`provideInlayHints called with ${document.fileName} ${range.start.line}:${range.start.character} ${range.end.line}:${range.end.character}`
+		);
+
+		const methodLevelTelemetryRequestOptions: FileLevelTelemetryRequestOptions = {
+			includeAverageDuration: this.codeLensTemplate.includes("${averageDuration}"),
+			includeThroughput: this.codeLensTemplate.includes("${sampleSize}"),
+			includeErrorRate: this.codeLensTemplate.includes("${errorRate}")
+		};
+
+		const fileLevelTelemetryStopwatch = Stopwatch.createAndStart("getFileLevelTelemetry");
+		const fileLevelTelemetryResponse = await this._observabilityService.getFileLevelTelemetry(
+			document.uri.toString(),
+			document.languageId,
+			false,
+			undefined,
+			methodLevelTelemetryRequestOptions
+		);
+		// this.resetCache = false;
+		fileLevelTelemetryStopwatch.stop();
+		Logger.debug(`provideInlayHints ${fileLevelTelemetryStopwatch.report()}`);
+
+		if (fileLevelTelemetryResponse == null) {
+			Logger.log("provideCodeLenses no response", {
+				fileName: document.fileName,
+				languageId: document.languageId,
+				methodLevelTelemetryRequestOptions
+			});
+			return [];
+		}
+
+		if (!fileLevelTelemetryResponse.repo) {
+			Logger.warn("provideCodeLenses missing repo");
+			return [];
+		}
+
+		if (fileLevelTelemetryResponse.error) {
+			Logger.warn("provideCodeLenses error", {
+				error: fileLevelTelemetryResponse.error
+			});
+			return [];
+		}
+
+		const allValidAnonymousMetrics: FileLevelTelemetryMetric[] = [
+			...(fileLevelTelemetryResponse.averageDuration ?? []),
+			...(fileLevelTelemetryResponse.errorRate ?? []),
+			...(fileLevelTelemetryResponse.sampleSize ?? [])
+		].filter(_ => _.functionName === "(anonymous)" && _.lineno && _.column);
+
+		const date = fileLevelTelemetryResponse.lastUpdateDate
+			? new Date(fileLevelTelemetryResponse.lastUpdateDate).toLocaleString()
+			: "";
+
+		if (allValidAnonymousMetrics.length === 0) {
+			Logger.log("provideCodeLenses no valid anonymous metrics");
+			return [];
+		}
+
+		const computeLoopStopwatch = Stopwatch.createAndStart("computeCurrentLocationLoop");
+		let loopCount = 0;
+		const locationMapKey = `${document.uri.toString()}:${document.version}`;
+		let locationLensMap = this._cache.get(locationMapKey) ?? new Map<string, CollatedMetric>();
+		if (!this._cache.get(locationMapKey)) {
+			for (const metric of allValidAnonymousMetrics) {
+				const commit = metric.commit ?? fileLevelTelemetryResponse.deploymentCommit;
+				if (!commit) {
+					continue;
+				}
+				const id = `${document.uri.toString()}|${metric.lineno}|${metric.column}|${commit}|${
+					metric.functionName
+				}`;
+
+				let collatedMetric = locationLensMap.get(id);
+				if (!collatedMetric && metric.lineno && metric.column) {
+					const currentLocationStopwatch = Stopwatch.createAndStart(
+						`computeCurrentLocation ${loopCount++}`
+					);
+					const currentLocation = await this._observabilityService.computeCurrentLocation(
+						id,
+						metric.lineno,
+						metric.column,
+						commit,
+						metric.functionName ?? "(anonymous)",
+						document.uri.toString()
+					);
+					currentLocationStopwatch.stop();
+					Logger.debug(`provideInlayHints ${currentLocationStopwatch.report()}`);
+					for (const [_key, value] of Object.entries(currentLocation.locations)) {
+						Logger.debug(`currentLocation ${value.lineStart} / ${value.colStart}`);
+						// Not the currentLocation column - we'd have to get the symbols from the commit sha but that is too
+						// expensive But the column does give us the order of anonymous functions on the same line so we can find
+						// anonymous functions with symbol provider and put them in the same order (assuming user didn't refactor
+						// the code too much)
+						const currentLocation = new Range(
+							new Position(value.lineStart - 1, metric.column),
+							new Position(value.lineStart - 1, metric.column)
+						);
+						collatedMetric = { currentLocation };
+						locationLensMap.set(id, collatedMetric);
+					}
+				}
+
+				if (collatedMetric) {
+					if (isFileLevelTelemetryAverageDuration(metric)) {
+						collatedMetric.duration = metric;
+					} else if (isFileLevelTelemetrySampleSize(metric)) {
+						collatedMetric.sampleSize = metric;
+					} else if (isFileLevelTelemetryErrorRate(metric)) {
+						collatedMetric.errorRate = metric;
+					}
+				}
+			}
+			// Remove entries that have more than one metrics per lineno
+			const finalLocationLensMap = new Map<string, CollatedMetric>();
+			const keyArray = Array.from(locationLensMap.keys());
+			for (const key of keyArray) {
+				// [0] is the document uri, [1] is the line number
+				const lineCount = keyArray.filter(_ => _.split("|")[1] === key.split("|")[1]).length;
+				if (lineCount > 1) {
+					// lineCount === 1 handled in instrumentationCodeLensProvider
+					// TODO did I just realize there can be multiple named functions on the same line?
+					Logger.debug(`adding ${key} to finalLocationLensMap`);
+					finalLocationLensMap.set(key, locationLensMap.get(key)!);
+				}
+			}
+			locationLensMap = finalLocationLensMap;
+			this._cache.put(locationMapKey, locationLensMap);
+		} else {
+			Logger.debug(`provideInlayHints cache hit ${locationMapKey}`);
+		}
+		computeLoopStopwatch.stop();
+		Logger.debug(`provideInlayHints ${computeLoopStopwatch.report()}`);
+
+		const computePhaseStopwatch = Stopwatch.createAndStart("computePhase");
+		const inlayHints: InlayHint[] = [];
+		const symbolLocatorStopwatch = Stopwatch.createAndStart("symbolLocator");
+		const symbols = await this.symbolLocator.locate(document, token);
+		symbolLocatorStopwatch.stop();
+		Logger.debug(`provideInlayHints ${symbolLocatorStopwatch.report()}`);
+
+		const sortedKeys: string[] = Array.from(locationLensMap.entries())
+			.sort((a, b) => {
+				const aLine = a[1].currentLocation.start.line;
+				const bLine = b[1].currentLocation.start.line;
+				if (aLine === bLine) {
+					return a[1].currentLocation.start.character - b[1].currentLocation.start.character;
+				}
+				return aLine - bLine;
+			})
+			.map(_ => _[0]);
+		// Count of inlay hints per line
+		const lineTracker = new Map<number, number>();
+		for (const key of sortedKeys) {
+			const lineLevelMetric = locationLensMap.get(key);
+			if (!lineLevelMetric) {
+				continue;
+			}
+			const { currentLocation, duration, sampleSize, errorRate } = lineLevelMetric;
+			const { start } = currentLocation;
+			const symbolsForLine = symbols.allSymbols
+				.filter(_ => _.range.start.line === start.line)
+				.filter(_ => !this.isValidJavascriptFunctionName(_.name));
+			const lineCount = lineTracker.get(start.line) ?? 0;
+			lineTracker.set(start.line, lineCount + 1);
+			const symbol = symbolsForLine[lineCount];
+			// symbolsForLine.forEach(_ => {
+			// 	Logger.debug(`symbol for line ${JSON.stringify(_)}`);
+			// });
+
+			const viewCommandArgs: ViewMethodLevelTelemetryCommandArgs = {
+				repo: fileLevelTelemetryResponse.repo,
+				codeNamespace: fileLevelTelemetryResponse.codeNamespace!,
+				metricTimesliceNameMapping: {
+					sampleSize: lineLevelMetric.sampleSize ? lineLevelMetric.sampleSize.facet[0] : "",
+					duration: lineLevelMetric.duration ? lineLevelMetric.duration.facet[0] : "",
+					errorRate: lineLevelMetric.errorRate ? lineLevelMetric.errorRate.facet[0] : "",
+					source: lineLevelMetric.sampleSize ? lineLevelMetric.sampleSize.source : ""
+				},
+				filePath: document.fileName,
+				relativeFilePath: fileLevelTelemetryResponse.relativeFilePath,
+				languageId: document.languageId,
+				range: lineLevelMetric.currentLocation,
+				functionName: "(anonymous)",
+				newRelicAccountId: fileLevelTelemetryResponse.newRelicAccountId,
+				newRelicEntityGuid: fileLevelTelemetryResponse.newRelicEntityGuid,
+				methodLevelTelemetryRequestOptions: methodLevelTelemetryRequestOptions
+				// TODO anomaly?
+			};
+
+			const text = Strings.interpolate(this.codeLensTemplate, {
+				averageDuration:
+					duration && duration.averageDuration
+						? `${duration.averageDuration.toFixed(3) || "0.00"}ms`
+						: "n/a",
+				sampleSize: sampleSize && sampleSize.sampleSize ? `${sampleSize.sampleSize}` : "n/a",
+				errorRate:
+					errorRate && errorRate.errorRate ? `${(errorRate.errorRate * 100).toFixed(2)}%` : "0.00%",
+				since: fileLevelTelemetryResponse.sinceDateFormatted,
+				date: date
+			});
+			const inlayHintLabelPart = new InlayHintLabelPart("(stats)");
+			inlayHintLabelPart.command = new InstrumentableSymbolCommand(
+				"show telemetry details",
+				"codestream.viewMethodLevelTelemetry",
+				undefined,
+				[JSON.stringify(viewCommandArgs)]
+			);
+			inlayHintLabelPart.tooltip = text;
+			const inlayHint = new InlayHint(symbol.range.start, [inlayHintLabelPart], InlayHintKind.Type);
+			// Logger.debug(`inlayHint ${inlayHint.position.line}:${inlayHint.position.character}`);
+			inlayHints.push(inlayHint);
+		}
+		computePhaseStopwatch.stop();
+		Logger.debug(`provideInlayHints ${computePhaseStopwatch.report()}`);
+		overallStopwatch.stop();
+		Logger.debug(`provideInlayHints ${overallStopwatch.report()}`);
+		return inlayHints;
+
+		// if (currentLocation[id]) {
+		// 	Logger.log(
+		// 		`*** currentLocation ${currentLocation.locations[0].lineStart} ${currentLocation.locations[0].colStart}`
+		// 	);
+		// }
+	}
+}


### PR DESCRIPTION
… functions

- Clarity on the stopwatch api

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Handle removed / heavily refactored code

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Handle optional functionName
- Deduplicate logic in extra language filters
- Cleanup

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Cache currentLocation

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Cache currentLocation

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Cleanup logging and rebase

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Don't recalculate currentLocation if document hasn't changed - based on document.version provided by vscode

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Refactor ObservabilityService.ts

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Basic inlay hints

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- WIP

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Ugly tooltips

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- vscode basics

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Use change tracking to get commit sha if commit sha not in clm result

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Code cleanup from PR comments

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Undo testing query

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Fix tests

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Fix double metrics in python
- Fix Rider 2023.2

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Pause to baseline

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Undo refactor of CSLocation
- Fix tests

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- 🔥highly demoable
- Fix tests

TODO
No commit sha scenario
Possibly recommend get commit sha
Caching / batching
Dark theme look and feel
Clickly to get graphs

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Extract logic, simplify

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions

- Basic highlighting as long as you don't edit file

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions

- Working for javascript anonymous methods
- Broke tests
- Might have broken other languages

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Kind of barely working

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Pass those tests

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- Rebase recovery

NR-84070 - Leverage commit SHA collected by agent to handle Node anon functions
- WIP