### PR TITLE
Refactor "Find in Logs" 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -89,17 +89,6 @@
 		{
 			"type": "node",
 			"request": "attach",
-			"name": "Attach to Agent (Atom)",
-			"port": 6012,
-			"cwd": "${workspaceFolder}/vscode",
-			"outFiles": ["${workspaceFolder}/vscode/dist/agent-pkg.js"],
-			"skipFiles": ["<node_internals>/**", "**/node_modules/**"],
-			"smartStep": true,
-			"sourceMaps": true
-		},
-		{
-			"type": "node",
-			"request": "attach",
 			"name": "Attach to Agent (debug node_modules)",
 			"port": 6009,
 			"cwd": "${workspaceFolder}/vscode",
@@ -116,6 +105,45 @@
 			"outFiles": ["${workspaceFolder}/vscode/dist/agent.js"],
 			"smartStep": true,
 			"sourceMaps": true
+		},
+		{
+			"name": "Debug/Watch Current File Jest Tests",
+			"type": "node",
+			"request": "launch",
+			"cwd": "${workspaceFolder}/shared/ui",
+			"program": "./node_modules/.bin/jest",
+			"args": [
+				"--runInBand",
+				"--watch",
+				"${file}"
+			],
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen"
+		},
+		{
+			"name": "Debug/Watch All Jest Tests",
+			"type": "node",
+			"request": "launch",
+			"cwd": "${workspaceFolder}/shared/ui",
+			"program": "./node_modules/.bin/jest",
+			"args": [
+				"--runInBand",
+				"--watch",
+			],
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen"
+		},
+		{
+			"name": "Debug UI Jest Tests",
+			"type": "node",
+			"request": "launch",
+			"cwd": "${workspaceFolder}/shared/ui",
+			"program": "./node_modules/.bin/jest",
+			"args": [
+				"--runInBand",
+			],
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen"
 		}
 	]
 }

--- a/shared/ui/Stream/EllipsisMenu.tsx
+++ b/shared/ui/Stream/EllipsisMenu.tsx
@@ -376,7 +376,6 @@ export function EllipsisMenu(props: EllipsisMenuProps) {
 							panel: "whatsnew",
 							title: "What's New",
 							entryPoint: "profile",
-							entityAccounts: [],
 							ide: {
 								name: derivedState.ide.name,
 							},

--- a/shared/ui/Stream/GlobalNav.tsx
+++ b/shared/ui/Stream/GlobalNav.tsx
@@ -108,7 +108,6 @@ export function GlobalNav() {
 			entryPoint: "global_nav",
 			accountId: parseId(derivedState.currentEntityGuid || "")?.accountId,
 			entityGuid: derivedState.currentEntityGuid!,
-			entityAccounts: derivedState.entityAccounts,
 			ide: {
 				name: derivedState.ideName,
 			},
@@ -120,7 +119,6 @@ export function GlobalNav() {
 			panel: "logs",
 			title: "Logs",
 			entryPoint: "global_nav",
-			entityAccounts: derivedState.entityAccounts,
 			entityGuid: derivedState.currentEntityGuid,
 			ide: {
 				name: derivedState.ideName,

--- a/shared/ui/Stream/Observability.tsx
+++ b/shared/ui/Stream/Observability.tsx
@@ -349,7 +349,6 @@ export const Observability = React.memo((props: Props) => {
 	const [currentEntityAccounts, setCurrentEntityAccounts] = useState<EntityAccount[] | undefined>(
 		[]
 	);
-	const [allEntityAccounts, setAllEntityAccounts] = useState<EntityAccount[]>([]);
 	const [currentObsRepo, setCurrentObsRepo] = useState<ObservabilityRepo | undefined>();
 	const [recentIssues, setRecentIssues] = useState<GetIssuesResponse | undefined>();
 	const [recentIssuesError, setRecentIssuesError] = useState<string>();
@@ -1075,7 +1074,6 @@ export const Observability = React.memo((props: Props) => {
 			return or.entityAccounts;
 		});
 		dispatch(setEntityAccounts(entityAccounts));
-		setAllEntityAccounts(entityAccounts);
 	}, [observabilityRepos]);
 
 	useEffect(() => {
@@ -1402,7 +1400,6 @@ export const Observability = React.memo((props: Props) => {
 																													panel: "logs",
 																													title: "Logs",
 																													entityGuid: ea.entityGuid,
-																													entityAccounts: allEntityAccounts,
 																													entryPoint: "tree_view",
 																													ide: {
 																														name: derivedState.ideName,

--- a/shared/ui/index.tsx
+++ b/shared/ui/index.tsx
@@ -998,7 +998,7 @@ function listenForEvents(store) {
 	});
 
 	api.on(InitiateLogSearchNotificationType, params => {
-		const { session, users, context, ide } = store.getState() as CodeStreamState;
+		const { session, users, ide } = store.getState() as CodeStreamState;
 		const currentUser = session.userId ? (users[session.userId] as CSMe) : null;
 		const currentRepoId = currentUser?.preferences?.currentO11yRepoId;
 
@@ -1009,7 +1009,6 @@ function listenForEvents(store) {
 		const props: OpenEditorViewNotification = {
 			panelLocation: ViewColumn.Active,
 			entityGuid: currentEntityGuid!,
-			entityAccounts: context.entityAccounts || [],
 			panel: "logs",
 			title: "Logs",
 			query: params.query,
@@ -1023,7 +1022,7 @@ function listenForEvents(store) {
 	});
 
 	api.on(InitiateNrqlExecutionNotificationType, params => {
-		const { session, users, context, ide } = store.getState() as CodeStreamState;
+		const { session, users, ide } = store.getState() as CodeStreamState;
 		const currentUser = session.userId ? (users[session.userId] as CSMe) : null;
 		const currentRepoId = currentUser?.preferences?.currentO11yRepoId;
 
@@ -1035,7 +1034,6 @@ function listenForEvents(store) {
 			panelLocation: ViewColumn.Beside,
 			accountId: parseId(currentEntityGuid || "")?.accountId,
 			entityGuid: currentEntityGuid!,
-			entityAccounts: context.entityAccounts || [],
 			panel: "nrql",
 			title: "NRQL",
 			query: params.query,

--- a/shared/ui/ipc/host.protocol.ts
+++ b/shared/ui/ipc/host.protocol.ts
@@ -2,7 +2,6 @@ import {
 	ApiVersionCompatibility,
 	Capabilities,
 	CodeStreamEnvironmentInfo,
-	EntityAccount,
 	ThirdPartyProviders,
 	Unreads,
 	VersionCompatibility,
@@ -321,9 +320,6 @@ export enum ViewColumn {
 export interface OpenEditorViewNotification {
 	panel: "logs" | "nrql" | "whatsnew";
 	title: string;
-	accountId?: number;
-
-	entityAccounts: EntityAccount[];
 	entryPoint: // logs
 	| "global_nav"
 		| "context_menu"
@@ -335,14 +331,15 @@ export interface OpenEditorViewNotification {
 		// other
 		| "notification"
 		| "profile";
+	ide: {
+		name?: "VSC" | "VS" | "JETBRAINS";
+	};
 
+	accountId?: number;
 	panelLocation?: ViewColumn;
 	entityGuid?: string;
 	query?: string;
 	hash?: string;
-	ide: {
-		name?: "VSC" | "VS" | "JETBRAINS";
-	};
 }
 
 export const OpenEditorViewNotificationType = new NotificationType<

--- a/shared/webviews/editor/App.tsx
+++ b/shared/webviews/editor/App.tsx
@@ -23,7 +23,6 @@ export function App() {
 				<ModalRoot />
 				{codestreamProps.panel === "logs" && (
 					<APMLogSearchPanel
-						entityAccounts={codestreamProps.entityAccounts!}
 						entityGuid={codestreamProps.entityGuid}
 						suppliedQuery={codestreamProps.query}
 						entryPoint={codestreamProps.entryPoint}

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -663,7 +663,6 @@ export class Commands implements Disposable {
 				// UI can get the accountId based on the entityGuid (parsed)
 				accountId: undefined,
 				entityGuid: currentEntityGuid!,
-				entityAccounts: [],
 				panel: "nrql",
 				title: "NRQL",
 				query: nrqlQuery,
@@ -700,9 +699,25 @@ export class Commands implements Disposable {
 				"We were unable to determine the search criteria from your selection or line of code.",
 				"Dismiss"
 			);
-		} else {
-			await Container.sidebar.logSearch({ query: searchTerm, entryPoint: "context_menu" });
+			return;
 		}
+
+		const currentRepoId = Container.session.user?.preferences?.currentO11yRepoId;
+		const currentEntityGuid = currentRepoId
+			? (Container.session?.user?.preferences?.activeO11y?.[currentRepoId] as string)
+			: undefined;
+
+		Container.panel.initializeOrShowEditor({
+			panelLocation: ViewColumn.Active,
+			entityGuid: currentEntityGuid!,
+			panel: "logs",
+			title: "Logs",
+			query: searchTerm,
+			entryPoint: "context_menu",
+			ide: {
+				name: "VSC"
+			}
+		});
 	}
 
 	private extractStringsFromLine(document: TextDocument, lineNumber: number): string {

--- a/vscode/src/controllers/sidebarController.ts
+++ b/vscode/src/controllers/sidebarController.ts
@@ -543,7 +543,6 @@ export class SidebarController implements Disposable {
 		this._sidebar!.notify(OpenEditorViewNotificationType, {
 			panel: "whatsnew",
 			title: "Whats New",
-			entityAccounts: [],
 			entryPoint: "notification",
 			ide: {
 				name: "VSC"


### PR DESCRIPTION
Refactor "Find in Logs" so that it doesn't need the sidebar opened, now delegates to panel directly. Required querying for EntityAccounts directly in LogPanel / removal of request/notification property. Fixed tests. Added new launch profiles for Jest tests