### PR TITLE
NR-227255 Jetbrains - nrql query stuck on infinite loading when Use JCEF Webview not enabled

### DIFF
--- a/jb/src/main/kotlin/webview/JxBrowserEngineService.kt
+++ b/jb/src/main/kotlin/webview/JxBrowserEngineService.kt
@@ -78,6 +78,13 @@ class JxBrowserEngineService : Disposable {
                         if (it.urlRequest().resourceType() == ResourceType.IMAGE
                             || it.urlRequest().url().startsWith("file://")
                             || it.urlRequest().url().contains("/dns-query")
+                            || it.urlRequest().url().equals("https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/loader.js")
+                            || it.urlRequest().url().equals("https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/editor/editor.main.js")
+                            || it.urlRequest().url().equals("https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/editor/editor.main.css")
+                            || it.urlRequest().url().equals("https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/editor/editor.main.nls.js")
+                            || it.urlRequest().url().equals("https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/base/worker/workerMain.js")
+                            || it.urlRequest().url().equals("https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/base/common/worker/simpleWorker.nls.js")
+                            || it.urlRequest().url().equals("https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/base/browser/ui/codicons/codicon/codicon.ttf")
                         ) {
                             BeforeUrlRequestCallback.Response.proceed()
                         } else {

--- a/shared/ui/package-lock.json
+++ b/shared/ui/package-lock.json
@@ -17,7 +17,6 @@
 				"code-prettify": "https://github.com/TeamCodeStream/code-prettify.git#62943684566f616b403ac354a1b5a094344c85bc",
 				"copy-to-clipboard": "3.3.1",
 				"csv": "6.3.6",
-				"diff": "github:dsellarsnr/jsdiff",
 				"emoji-mart": "2.11.1",
 				"ignore": "3.3.10",
 				"lint-staged": "13.2.3",
@@ -57,7 +56,6 @@
 				"@testing-library/react": "12.1.5",
 				"@testing-library/user-event": "14.4.3",
 				"@types/classnames": "2.2.9",
-				"@types/diff": "5.0.9",
 				"@types/emoji-mart": "2.8.4",
 				"@types/jest": "29.5.3",
 				"@types/lodash-es": "4.17.7",
@@ -3423,12 +3421,6 @@
 			"integrity": "sha512-MNl+rT5UmZeilaPxAVs6YaPC2m6aA8rofviZbhbxpPpl61uKodfdQVsBtgJGTqGizEf02oW3tsVe7FYB8kK14A==",
 			"dev": true
 		},
-		"node_modules/@types/diff": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.0.9.tgz",
-			"integrity": "sha512-RWVEhh/zGXpAVF/ZChwNnv7r4rvqzJ7lYNSmZSVTxjV0PBLf6Qu7RNg+SUtkpzxmiNkjCx0Xn2tPp7FIkshJwQ==",
-			"dev": true
-		},
 		"node_modules/@types/emoji-mart": {
 			"version": "2.8.4",
 			"resolved": "https://registry.npmjs.org/@types/emoji-mart/-/emoji-mart-2.8.4.tgz",
@@ -5754,14 +5746,6 @@
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.981744.tgz",
 			"integrity": "sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==",
 			"dev": true
-		},
-		"node_modules/diff": {
-			"version": "5.1.0",
-			"resolved": "git+ssh://git@github.com/dsellarsnr/jsdiff.git#de97a5ccdc8bc8218b71adfc101f1ebd85bd9a5a",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.3.1"
-			}
 		},
 		"node_modules/diff-sequences": {
 			"version": "29.4.3",
@@ -16667,12 +16651,6 @@
 			"integrity": "sha512-MNl+rT5UmZeilaPxAVs6YaPC2m6aA8rofviZbhbxpPpl61uKodfdQVsBtgJGTqGizEf02oW3tsVe7FYB8kK14A==",
 			"dev": true
 		},
-		"@types/diff": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.0.9.tgz",
-			"integrity": "sha512-RWVEhh/zGXpAVF/ZChwNnv7r4rvqzJ7lYNSmZSVTxjV0PBLf6Qu7RNg+SUtkpzxmiNkjCx0Xn2tPp7FIkshJwQ==",
-			"dev": true
-		},
 		"@types/emoji-mart": {
 			"version": "2.8.4",
 			"resolved": "https://registry.npmjs.org/@types/emoji-mart/-/emoji-mart-2.8.4.tgz",
@@ -18453,10 +18431,6 @@
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.981744.tgz",
 			"integrity": "sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==",
 			"dev": true
-		},
-		"diff": {
-			"version": "git+ssh://git@github.com/dsellarsnr/jsdiff.git#de97a5ccdc8bc8218b71adfc101f1ebd85bd9a5a",
-			"from": "diff@github:dsellarsnr/jsdiff"
 		},
 		"diff-sequences": {
 			"version": "29.4.3",


### PR DESCRIPTION
Problem was with loading actual monaco editor from cdn, react wrapper doesn't include monaco. Maybe I went too far with security? Whitelisted the minimum specific URLs needed but that makes it fragile.