### PR TITLE
Global Nav not honoring the currently expanded entity

### DIFF
--- a/shared/ui/Stream/GlobalNav.tsx
+++ b/shared/ui/Stream/GlobalNav.tsx
@@ -5,7 +5,7 @@ import {
 } from "@codestream/protocols/webview";
 import { useAppDispatch, useAppSelector } from "@codestream/webview/utilities/hooks";
 import cx from "classnames";
-import React from "react";
+import React, { useCallback } from "react";
 import { WebviewPanels } from "@codestream/protocols/api";
 import { HeadshotName } from "../src/components/HeadshotName";
 import { CodeStreamState } from "../store";
@@ -29,7 +29,7 @@ const sum = (total, num) => total + Math.round(num);
 export function GlobalNav() {
 	const dispatch = useAppDispatch();
 	const derivedState = useAppSelector((state: CodeStreamState) => {
-		const { users, umis, preferences } = state;
+		const { users, umis } = state;
 		const user = users[state.session.userId!];
 		const eligibleJoinCompanies = user?.eligibleJoinCompanies;
 		let inviteCount: number = 0;
@@ -40,7 +40,6 @@ export function GlobalNav() {
 				}
 			});
 		}
-		const currentRepoId = user?.preferences?.currentO11yRepoId;
 
 		return {
 			currentUserId: state.session.userId,
@@ -54,10 +53,7 @@ export function GlobalNav() {
 			currentPullRequestId: state.context.currentPullRequest
 				? state.context.currentPullRequest.id
 				: undefined,
-			currentEntityGuid: currentRepoId
-				? (user?.preferences?.activeO11y?.[currentRepoId] as string)
-				: undefined,
-			entityAccounts: state.context.entityAccounts || [],
+			currentEntityGuid: state.context.currentEntityGuid,
 			eligibleJoinCompanies,
 			inviteCount,
 			isVsCode: state.ide.name === "VSC",
@@ -101,7 +97,7 @@ export function GlobalNav() {
 		setPlusMenuOpen(plusMenuOpen ? undefined : event.target.closest("label"));
 	};
 
-	const launchNrqlEditor = () => {
+	const launchNrqlEditor = useCallback(() => {
 		HostApi.instance.notify(OpenEditorViewNotificationType, {
 			panel: "nrql",
 			title: "NRQL",
@@ -112,9 +108,9 @@ export function GlobalNav() {
 				name: derivedState.ideName,
 			},
 		});
-	};
+	}, [derivedState.currentEntityGuid]);
 
-	const launchLogSearch = () => {
+	const launchLogSearch = useCallback(() => {
 		HostApi.instance.notify(OpenEditorViewNotificationType, {
 			panel: "logs",
 			title: "Logs",
@@ -124,7 +120,7 @@ export function GlobalNav() {
 				name: derivedState.ideName,
 			},
 		});
-	};
+	}, [derivedState.currentEntityGuid]);
 
 	const go = panel => {
 		close();
@@ -327,6 +323,7 @@ export function GlobalNav() {
 		totalUnread,
 		totalMentions,
 		derivedState.composeCodemarkActive,
+		derivedState.currentEntityGuid,
 		currentReviewId,
 		currentCodeErrorId,
 		currentPullRequestId,

--- a/shared/ui/Stream/Observability.tsx
+++ b/shared/ui/Stream/Observability.tsx
@@ -34,7 +34,11 @@ import {
 	ObservabilityLoadingServiceEntity,
 } from "@codestream/webview/Stream/ObservabilityLoading";
 import { CurrentMethodLevelTelemetry } from "@codestream/webview/store/context/types";
-import { setEntityAccounts, setRefreshAnomalies } from "../store/context/actions";
+import {
+	setCurrentEntityGuid,
+	setEntityAccounts,
+	setRefreshAnomalies,
+} from "../store/context/actions";
 
 import { HealthIcon } from "@codestream/webview/src/components/HealthIcon";
 import {
@@ -372,6 +376,7 @@ export const Observability = React.memo((props: Props) => {
 	};
 
 	function setExpandedEntityUserPref(repoId: string, entityGuid: string | undefined) {
+		dispatch(setCurrentEntityGuid(entityGuid!));
 		dispatch(setUserPreference({ prefPath: ["activeO11y", repoId], value: entityGuid }));
 	}
 

--- a/shared/ui/store/context/actions.ts
+++ b/shared/ui/store/context/actions.ts
@@ -146,6 +146,9 @@ export const setCurrentMethodLevelTelemetry = (data: any) =>
 export const setEntityAccounts = (entityAccounts: EntityAccount[]) =>
 	action(ContextActionsType.SetEntityAccounts, { entityAccounts });
 
+export const setCurrentEntityGuid = (entityGuid: string) =>
+	action(ContextActionsType.SetCurrentEntityGuid, { entityGuid });
+
 export const setCurrentObservabilityAnomaly = (
 	anomaly?: ObservabilityAnomaly,
 	entityGuid?: string,

--- a/shared/ui/store/context/reducer.ts
+++ b/shared/ui/store/context/reducer.ts
@@ -295,6 +295,13 @@ export function reduceContext(
 			};
 		}
 
+		case ContextActionsType.SetCurrentEntityGuid: {
+			return {
+				...state,
+				currentEntityGuid: action.payload.entityGuid,
+			};
+		}
+
 		case "RESET":
 			return {
 				...initialState,

--- a/shared/ui/store/context/types.ts
+++ b/shared/ui/store/context/types.ts
@@ -66,6 +66,7 @@ export enum ContextActionsType {
 	SetEntityAccounts = "@context/SetEntityAccounts",
 	SetCurrentTransactionSpan = "@context/SetCurrentTransactionSpan",
 	SetCurrentAPMLoggingSearchContext = "@context/SetCurrentObservabilityLogSearchContext",
+	SetCurrentEntityGuid = "@context/SetCurrentEntityGuid",
 }
 
 /**
@@ -147,6 +148,8 @@ export interface ContextState extends WebviewContext {
 	entityAccounts?: EntityAccount[];
 
 	selectedRegion?: string;
+
+	currentEntityGuid?: string;
 }
 
 export type ChatProviderAccess = "strict" | "permissive";


### PR DESCRIPTION
Adds "current entity guid" to redux (to get around two CodeStream instance issue), and then uses it for Global Nav into NRQL and Logs. Global Nav needed minor changes for ensuring we capture when the currentEntityGuid changed in state.