### PR TITLE
fix indenting whats new page

### DIFF
--- a/shared/ui/Stream/WhatsNew.tsx
+++ b/shared/ui/Stream/WhatsNew.tsx
@@ -48,7 +48,7 @@ const TimelineDate = styled.div`
 
 const Update = styled.div``;
 const UpdateTitle = styled.h3`
-	margin-bottom: 2px;
+	margin-bottom: 6px;
 `;
 const UpdateItem = styled.div`
 	margin-bottom: 4px;
@@ -83,46 +83,42 @@ export const WhatsNewPanel = () => {
 				<div className="tl-body">
 					<Update>
 						<UpdateTitle>Log Search</UpdateTitle>
-						<ListContainer>
-							<UpdateItem>
-								No need to slow down your investigation by context switching between your IDE and
-								your browser to search logs. CodeStream brings the New Relic log-search experience
-								right into your IDE!
-							</UpdateItem>
-							<UpdateItem>
-								<img src="https://images.codestream.com/misc/WN-log-search.png" />
-							</UpdateItem>
-							<UpdateItem>
-								Click on the "View Logs" entry for any service listed in the CodeStream pane, or on
-								the "View Logs" icon in CodeStream's global navigation. You can also right-click on
-								a log line in your code and select "Find in logs" to look for entries from that
-								specific log line.
-							</UpdateItem>
-							<UpdateItem>
-								CodeStream's log search is currently available for logs collected by a New Relic APM
-								agent or the OTel integration.
-							</UpdateItem>
-						</ListContainer>
+						<UpdateItem>
+							No need to slow down your investigation by context switching between your IDE and your
+							browser to search logs. CodeStream brings the New Relic log-search experience right
+							into your IDE!
+						</UpdateItem>
+						<UpdateItem>
+							<img src="https://images.codestream.com/misc/WN-log-search.png" />
+						</UpdateItem>
+						<UpdateItem>
+							Click on the "View Logs" entry for any service listed in the CodeStream pane, or on
+							the "View Logs" icon in CodeStream's global navigation. You can also right-click on a
+							log line in your code and select "Find in logs" to look for entries from that specific
+							log line.
+						</UpdateItem>
+						<UpdateItem>
+							CodeStream's log search is currently available for logs collected by a New Relic APM
+							agent or the OTel integration.
+						</UpdateItem>
 					</Update>
 					<Update>
 						<UpdateTitle>Query Builder</UpdateTitle>
-						<ListContainer>
-							<UpdateItem>
-								The ability to run NRQL queries right from your IDE gives you powerful access to all
-								of the performance data New Relic has about your services. Click on the "Query your
-								data" icon in CodeStream's global navigation to access the query builder.
-							</UpdateItem>
-							<UpdateItem>
-								<img src="https://images.codestream.com/misc/WN-query-builder.png" />
-							</UpdateItem>
-							<UpdateItem>
-								Add a file with a `.nrql` extension to your repository to save and share queries.
-								Just click the "Run" link in the CodeLense above each query to run the query.
-							</UpdateItem>
-							<UpdateItem>
-								<img src="https://images.codestream.com/misc/WN-nrql-file.png" />
-							</UpdateItem>
-						</ListContainer>
+						<UpdateItem>
+							The ability to run NRQL queries right from your IDE gives you powerful access to all
+							of the performance data New Relic has about your services. Click on the "Query your
+							data" icon in CodeStream's global navigation to access the query builder.
+						</UpdateItem>
+						<UpdateItem>
+							<img src="https://images.codestream.com/misc/WN-query-builder.png" />
+						</UpdateItem>
+						<UpdateItem>
+							Add a file with a `.nrql` extension to your repository to save and share queries. Just
+							click the "Run" link in the CodeLense above each query to run the query.
+						</UpdateItem>
+						<UpdateItem>
+							<img src="https://images.codestream.com/misc/WN-nrql-file.png" />
+						</UpdateItem>
 					</Update>
 				</div>
 			</TimelineContent>
@@ -135,13 +131,11 @@ export const WhatsNewPanel = () => {
 				<div className="tl-body">
 					<Update>
 						<UpdateTitle>NRAI Apply Fix</UpdateTitle>
-						<ListContainer>
-							<UpdateItem>
-								A new "Apply Fix" button allows you to easily accept a suggested code fix when NRAI
-								analyzes an error for you. Code fixes are also now presented in a diff view so that
-								you can easily identify the changes.
-							</UpdateItem>
-						</ListContainer>
+						<UpdateItem>
+							A new "Apply Fix" button allows you to easily accept a suggested code fix when NRAI
+							analyzes an error for you. Code fixes are also now presented in a diff view so that
+							you can easily identify the changes.
+						</UpdateItem>
 					</Update>
 				</div>
 			</TimelineContent>


### PR DESCRIPTION
@planteater The indent was because the paragraphs were wrapped in `<ListContainer>`, you only want to use that if you are going to make a bulleted list.

I removed them here, as well as increased the margin between a title like "Log Search" and the below paragraph.