### PR TITLE
nrql updates

### DIFF
--- a/shared/agent/.vscode/launch.json
+++ b/shared/agent/.vscode/launch.json
@@ -48,16 +48,13 @@
 		{
 			"type": "node",
 			"request": "launch",
-			"runtimeExecutable": "node",
+			"runtimeExecutable": "npx",
 			"name": "Run UnitTests for File",
-			"program": "${workspaceFolder}/node_modules/.bin/mochapack",
+			"program": "jest",
 			"args": ["${file}"],
 			"cwd": "${workspaceFolder}/",
 			"console": "integratedTerminal",
-			"internalConsoleOptions": "neverOpen",
-			"env": {
-				"TS_NODE_COMPILER_OPTIONS": "{ \"module\": \"commonjs\", \"types\": [\"node\"] }"
-			}
+			"internalConsoleOptions": "neverOpen"
 		},
 		{
 			"type": "node",

--- a/shared/agent/src/providers/newrelic/nrql/nrqlProvider.ts
+++ b/shared/agent/src/providers/newrelic/nrql/nrqlProvider.ts
@@ -427,7 +427,7 @@ export class NrNRQLProvider {
 		const isTimeseries = metadata?.timeSeries || metadata?.contents?.timeSeries;
 		const isFacet = metadata?.facet;
 		if (isTimeseries && isFacet) {
-			// TODO stacked bar!
+			// TODO stacked bar and line and area
 			return { selected: "table", enabled: ["table", "json"] };
 		}
 

--- a/shared/agent/src/providers/newrelic/nrql/nrqlProvider.ts
+++ b/shared/agent/src/providers/newrelic/nrql/nrqlProvider.ts
@@ -69,11 +69,17 @@ export class NrNRQLProvider {
 
 			void this.saveRecentQuery(request);
 
+			const facet = response?.rawResponse?.metadata?.facet;
 			return {
 				accountId,
 				results: response.results,
-				eventType: response?.rawResponse?.metadata?.eventType,
-				since: response?.rawResponse?.metadata?.rawSince,
+
+				metadata: {
+					eventType: response?.rawResponse?.metadata?.eventType,
+					since: response?.rawResponse?.metadata?.rawSince,
+					// facet is an array or string, normalize to array
+					facet: facet ? (Array.isArray(facet) ? facet : [facet]) : undefined,
+				},
 				resultsTypeGuess: this.getResultsType(
 					response.results,
 					response?.rawResponse?.metadata

--- a/shared/agent/test/unit/providers/newrelic/nrqlDocumentParser.spec.ts
+++ b/shared/agent/test/unit/providers/newrelic/nrqlDocumentParser.spec.ts
@@ -115,4 +115,42 @@ SELECT foo from Log where appName = 'bar'
 			},
 		]);
 	});
+
+	it("should handle embedded comments", () => {
+		const content = `FROM Transaction
+SELECT name /* that's the bar
+on a new line */
+WHERE name is not null // baz is here`;
+		const results = new NrqlDocumentParser().parse(content);
+		expect(results.length).toStrictEqual(1);
+		expect(results).toStrictEqual([
+			{
+				invalid: false,
+				text: content,
+				range: {
+					start: 0,
+					end: 100,
+				},
+			},
+		]);
+	});
+
+	it("should handle embedded comments", () => {
+		const content = `/*
+FROM Transaction SELECT name WHERE name is not null 
+*/`;
+		const results = new NrqlDocumentParser().parse(content);
+		expect(results.length).toStrictEqual(1);
+		expect(results).toStrictEqual([
+			{
+				invalid: false,
+				text: `FROM Transaction SELECT name WHERE name is not null 
+`,
+				range: {
+					start: 3,
+					end: 55,
+				},
+			},
+		]);
+	});
 });

--- a/shared/agent/test/unit/providers/newrelic/nrqlProvider.spec.ts
+++ b/shared/agent/test/unit/providers/newrelic/nrqlProvider.spec.ts
@@ -2,9 +2,59 @@ import { NrNRQLProvider } from "../../../../src/providers/newrelic/nrql/nrqlProv
 import { describe, expect, it } from "@jest/globals";
 // import { NewRelicGraphqlClient } from "../../../../src/providers/newrelic/newRelicGraphqlClient";
 
-const provider = new NrNRQLProvider({} as any);
+describe("fetchRecentQueries", () => {
+	const graphqlClient = {
+		query: function () {
+			return new Promise(resolve => {
+				let now = new Date().getTime();
+				resolve({
+					actor: {
+						accounts: [
+							{ id: 1, name: "foo" },
+							{ id: 2, name: "bar" },
+							{ id: 1, name: "baz" },
+						],
+						queryHistory: {
+							nrql: [
+								{ query: "Select Foo from Bar limit 1", accountIds: [1, 2, 3], createdAt: now },
+								{ query: "Select Foo from Bar limit 1", accountIds: [1, 2, 3], createdAt: now },
+								{ query: "Select bar from Baz limit 10", accountIds: [2, 3], createdAt: now },
+							],
+						},
+					},
+				} as any);
+			});
+		},
+	};
+	const provider = new NrNRQLProvider(graphqlClient as any);
+	it("fetches recent queries and dedupes", async () => {
+		const result = await provider.fetchRecentQueries({});
+		expect(result.items.length).toBe(2);
+		expect(
+			result.items.map(_ => {
+				return { accounts: _.accounts, dayString: _.dayString, query: _.query };
+			})
+		).toStrictEqual([
+			{
+				accounts: [
+					{ id: 1, name: "foo" },
+					{ id: 2, name: "bar" },
+					{ id: 1, name: "baz" },
+				],
+				dayString: "Today",
+				query: "Select Foo from Bar limit 1",
+			},
+			{
+				accounts: [{ id: 2, name: "bar" }],
+				dayString: "Today",
+				query: "Select bar from Baz limit 10",
+			},
+		]);
+	});
+});
 
 describe("transformQuery", () => {
+	const provider = new NrNRQLProvider({} as any);
 	const cleaned = `FROM Collection   SELECT foo    WHERE queryTypes = 'bar'    AND status = 'baz'`;
 
 	it("removes all comments properly (with space)", () => {
@@ -49,5 +99,95 @@ WHERE queryTypes = 'bar'
 AND status = 'baz'
 */`);
 		expect(result).toBe("");
+	});
+});
+
+describe("getResultsType", () => {
+	const provider = new NrNRQLProvider({} as any);
+
+	it("is a table", () => {
+		const result = provider.getResultsType([], {} as any);
+		expect(result).toStrictEqual({ selected: "table", enabled: NrNRQLProvider.ALL_RESULT_TYPES });
+	});
+
+	it("is a billboard", () => {
+		const result = provider.getResultsType(
+			[
+				{
+					count: 1,
+				},
+			],
+			{} as any
+		);
+		expect(result).toStrictEqual({ selected: "billboard", enabled: ["billboard", "json"] });
+	});
+
+	it("is a table (timeseries & facet)", () => {
+		const result = provider.getResultsType(
+			[
+				// can be anything > 1 result
+				{
+					count: 1,
+				},
+				{
+					count: 1,
+				},
+			],
+			{ timeSeries: true, facet: "count" } as any
+		);
+		expect(result).toStrictEqual({ selected: "table", enabled: ["table", "json"] });
+	});
+
+	it("is json (timeseries)", () => {
+		const result = provider.getResultsType(
+			[
+				// can be anything > 1 result
+				{
+					count: 1,
+					foo: "bar",
+				},
+				{
+					count: 1,
+					foo: "bar",
+				},
+			],
+			{ timeSeries: true } as any
+		);
+		expect(result).toStrictEqual({
+			selected: "json",
+			enabled: ["json"],
+		});
+	});
+
+	it("is line (timeseries)", () => {
+		const result = provider.getResultsType(
+			[
+				// can be anything > 1 result
+				{
+					count: 1,
+				},
+				{
+					count: 1,
+				},
+			],
+			{ timeSeries: true } as any
+		);
+		expect(result).toStrictEqual({ selected: "line", enabled: ["table", "json", "line", "area"] });
+	});
+
+	it("is bar (facet)", () => {
+		const result = provider.getResultsType(
+			[
+				// can be anything > 1 result
+				{
+					count: 1,
+				},
+				{
+					count: 1,
+				},
+			],
+			{ facet: "name" } as any
+		);
+		expect(result).toStrictEqual({ selected: "bar", enabled: ["bar", "json", "pie", "table"] });
 	});
 });

--- a/shared/agent/test/unit/providers/newrelic/nrqlProvider.spec.ts
+++ b/shared/agent/test/unit/providers/newrelic/nrqlProvider.spec.ts
@@ -1,0 +1,53 @@
+import { NrNRQLProvider } from "../../../../src/providers/newrelic/nrql/nrqlProvider";
+import { describe, expect, it } from "@jest/globals";
+// import { NewRelicGraphqlClient } from "../../../../src/providers/newrelic/newRelicGraphqlClient";
+
+const provider = new NrNRQLProvider({} as any);
+
+describe("transformQuery", () => {
+	const cleaned = `FROM Collection   SELECT foo    WHERE queryTypes = 'bar'    AND status = 'baz'`;
+
+	it("removes all comments properly (with space)", () => {
+		const result = provider.transformQuery(`FROM Collection
+  SELECT foo -- that's the foo
+  WHERE queryTypes = 'bar' 
+  AND status = 'baz' // baz is here`);
+		expect(result).toBe(cleaned);
+	});
+
+	it("removes all comments properly (without space)", () => {
+		const result = provider.transformQuery(`FROM Collection
+  SELECT foo --that's the foo
+  WHERE queryTypes = 'bar' 
+  AND status = 'baz' //baz is here`);
+		expect(result).toBe(cleaned);
+	});
+
+	it("removes all comments properly (with multiline)", () => {
+		const result = provider.transformQuery(`FROM Collection
+  SELECT foo /* that's the foo
+  and it's on two lines */
+  WHERE queryTypes = 'bar' 
+  AND status = 'baz' //baz is here`);
+		expect(result).toBe(cleaned);
+	});
+
+	it("removes all whitespace at the end", () => {
+		const result = provider.transformQuery(`FROM Collection
+SELECT foo /* that's the foo
+and it's on two lines */
+WHERE queryTypes = 'bar' 
+AND status = 'baz' //baz is here
+       `);
+		expect(result).toBe(`FROM Collection SELECT foo  WHERE queryTypes = 'bar'  AND status = 'baz'`);
+	});
+
+	it("removes all whitespace at the end", () => {
+		const result = provider.transformQuery(`/* FROM Collection
+SELECT foo
+WHERE queryTypes = 'bar' 
+AND status = 'baz'
+*/`);
+		expect(result).toBe("");
+	});
+});

--- a/shared/ui/Stream/NRQL/CustomTooltip.tsx
+++ b/shared/ui/Stream/NRQL/CustomTooltip.tsx
@@ -5,6 +5,7 @@ type CustomTooltipProps = {
 	active?: boolean;
 	payload?: Array<any>;
 	label?: any;
+	facet: string[];
 };
 
 const StyledCustomTooltipWrapper = styled.div`
@@ -17,12 +18,19 @@ const StyledCustomTooltipWrapper = styled.div`
 	}
 `;
 
-const _customTooltip = ({ active, payload, label }: CustomTooltipProps) => {
+export const CustomTooltip = ({ active, payload, label, facet }: CustomTooltipProps) => {
 	if (active && payload && payload.length) {
+		let facetName;
+		if (facet.length === 1) {
+			facetName = payload[0].payload[facet[0]];
+		} else {
+			facetName = payload[0].payload["facet"].join(", ");
+		}
+
 		return (
 			<StyledCustomTooltipWrapper>
 				<div className="tooltip--custom">
-					<p>{payload[0].payload.facet}</p>
+					<p>{facetName}</p>
 					<p>Value: {payload[0].value}</p>
 				</div>
 			</StyledCustomTooltipWrapper>
@@ -31,5 +39,3 @@ const _customTooltip = ({ active, payload, label }: CustomTooltipProps) => {
 
 	return null;
 };
-
-export const CustomTooltip = styled(_customTooltip)``;

--- a/shared/ui/Stream/NRQL/NRQLEditor.tsx
+++ b/shared/ui/Stream/NRQL/NRQLEditor.tsx
@@ -10,6 +10,10 @@ import {
 } from "../../../util/src/protocol/agent/agent.protocol.providers";
 import { MonacoEditor } from "./MonacoEditor";
 
+export interface NRQLEditorApi {
+	setValue: (value: string) => void;
+}
+
 export const NRQLEditor = React.forwardRef(
 	(
 		props: {
@@ -29,15 +33,19 @@ export const NRQLEditor = React.forwardRef(
 		let editorRef = useRef<any>(null);
 		const [textAreaValue, setTextAreaValue] = useState<string>(props.defaultValue || "");
 		// Expose the ref and various functions to the parent component
-		React.useImperativeHandle(ref, () => ({
-			setValue: value => {
-				if (editorRef.current) {
-					editorRef.current.setValue(value);
-				} else {
-					setTextAreaValue(value);
-				}
-			},
-		}));
+		React.useImperativeHandle(
+			ref,
+			() =>
+				({
+					setValue: value => {
+						if (editorRef.current) {
+							editorRef.current.setValue(value);
+						} else {
+							setTextAreaValue(value);
+						}
+					},
+				}) as NRQLEditorApi
+		);
 
 		if (props.useEnhancedEditor === false) {
 			return (

--- a/shared/ui/Stream/NRQL/NRQLEditor.tsx
+++ b/shared/ui/Stream/NRQL/NRQLEditor.tsx
@@ -141,6 +141,10 @@ export const NRQLEditor = React.forwardRef(
 					{ open: "[", close: "]" },
 					{ open: "(", close: ")" },
 				],
+				comments: {
+					lineComment: "--",
+					blockComment: ["/*", "*/"],
+				},
 			});
 
 			monaco.languages.setMonarchTokensProvider("nrql", {

--- a/shared/ui/Stream/NRQL/NRQLEditor.tsx
+++ b/shared/ui/Stream/NRQL/NRQLEditor.tsx
@@ -24,8 +24,8 @@ export const NRQLEditor = React.forwardRef(
 			onSubmit?: (e: { value: string | undefined }) => void;
 			setValue?: (e: { value: string | undefined }) => void;
 			isReadonly?: boolean;
-			// if false, editor will fallback to a simple <textarea>, true & undefined are the same
-			useEnhancedEditor?: boolean;
+			// if true, editor will fallback to a simple <textarea>
+			useSimpleEditor?: boolean;
 		},
 		ref
 	) => {
@@ -47,7 +47,7 @@ export const NRQLEditor = React.forwardRef(
 				}) as NRQLEditorApi
 		);
 
-		if (props.useEnhancedEditor === false) {
+		if (props.useSimpleEditor) {
 			return (
 				<textarea
 					style={{ height: "120px", width: "100%" }}

--- a/shared/ui/Stream/NRQL/NRQLPanel.tsx
+++ b/shared/ui/Stream/NRQL/NRQLPanel.tsx
@@ -6,7 +6,11 @@ import {
 	ResultsTypeGuess,
 	isNRErrorResponse,
 } from "@codestream/protocols/agent";
-import { IdeNames, OpenEditorViewNotificationType } from "@codestream/protocols/webview";
+import {
+	BrowserEngines,
+	IdeNames,
+	OpenEditorViewNotificationType,
+} from "@codestream/protocols/webview";
 import { parseId } from "@codestream/webview/utilities/newRelic";
 import { Disposable } from "@codestream/webview/utils";
 import React, { useEffect, useMemo, useRef, useState } from "react";
@@ -127,9 +131,13 @@ export const NRQLPanel = (props: {
 	entryPoint: string;
 	entityGuid?: string;
 	query?: string;
-	ide?: { name?: IdeNames };
+	ide?: { name?: IdeNames; browserEngine?: BrowserEngines };
 }) => {
-	const supports = { export: props.ide?.name === "VSC" };
+	const supports = {
+		export: props.ide?.name === "VSC",
+		// default to true! currently JsBrowser works!
+		enhancedEditor: true, // !props.ide || props?.ide?.browserEngine !== "JxBrowser",
+	};
 
 	const initialAccountId = props.accountId
 		? props.accountId
@@ -406,6 +414,7 @@ export const NRQLPanel = (props: {
 									setUserQuery(e.value!);
 									executeNRQL(accountId, e.value!);
 								}}
+								useEnhancedEditor={supports.enhancedEditor}
 								ref={nrqlEditorRef}
 							/>
 						</ResizeEditorContainer>

--- a/shared/ui/Stream/NRQL/NRQLPanel.tsx
+++ b/shared/ui/Stream/NRQL/NRQLPanel.tsx
@@ -421,7 +421,7 @@ export const NRQLPanel = (props: {
 									setUserQuery(e.value!);
 									executeNRQL(accountId, e.value!);
 								}}
-								useEnhancedEditor={supports.enhancedEditor}
+								useSimpleEditor={!supports.enhancedEditor}
 								ref={nrqlEditorRef}
 							/>
 						</ResizeEditorContainer>

--- a/shared/ui/Stream/NRQL/NRQLPanel.tsx
+++ b/shared/ui/Stream/NRQL/NRQLPanel.tsx
@@ -254,7 +254,7 @@ export const NRQLPanel = (props: {
 
 			const response = await HostApi.instance.send(GetNRQLRequestType, {
 				accountId,
-				query: nrqlQuery.replace(/[\n\r]/g, " "),
+				query: nrqlQuery,
 			});
 
 			if (!response) {

--- a/shared/ui/Stream/NRQL/NRQLResultsArea.tsx
+++ b/shared/ui/Stream/NRQL/NRQLResultsArea.tsx
@@ -15,7 +15,11 @@ const formatXAxisTime = time => {
 	return new Date(time).toLocaleTimeString();
 };
 
-export const NRQLResultsArea = (props: { results: NRQLResult[] }) => {
+interface Props {
+	results: NRQLResult[];
+}
+
+export const NRQLResultsArea = (props: Props) => {
 	const result = props.results ? props.results[0] : undefined;
 	const dataKeys = Object.keys(result || {}).filter(
 		_ => _ !== "beginTimeSeconds" && _ !== "endTimeSeconds"

--- a/shared/ui/Stream/NRQL/NRQLResultsBar.tsx
+++ b/shared/ui/Stream/NRQL/NRQLResultsBar.tsx
@@ -4,7 +4,16 @@ import { CartesianGrid, ResponsiveContainer, YAxis, BarChart, Bar, Cell, Tooltip
 import { Colors } from "./utils";
 import { CustomTooltip } from "./CustomTooltip";
 
-export const NRQLResultsBar = (props: { results: NRQLResult[] }) => {
+interface Props {
+	results: NRQLResult[];
+	/**
+	 * the name of the facet (aka name, path, foo, bar). Not the property facet returned from the results,
+	 * but the facet in the metadata that points to the name of the faceted property/ies
+	 */
+	facet: string[];
+}
+
+export const NRQLResultsBar = (props: Props) => {
 	const results = props.results;
 	// find the first key that has a value that's a number, fallback to count
 	const keyName =
@@ -31,10 +40,17 @@ export const NRQLResultsBar = (props: { results: NRQLResult[] }) => {
 					>
 						<CartesianGrid strokeDasharray="3 3" horizontal={true} vertical={false} />
 						<YAxis tick={{ fontSize: 11 }} />
-						<Tooltip content={<CustomTooltip />} />
+						<Tooltip content={<CustomTooltip facet={props.facet} />} />
 						<Bar dataKey={keyName} fill="#8884d8">
 							{results.map((entry, index) => (
-								<Cell key={entry.facet} fill={Colors[index % Colors.length]} />
+								<Cell
+									key={
+										entry[
+											props.facet ? (props.facet.length === 1 ? props.facet[0] : "facet") : "facet"
+										]
+									}
+									fill={Colors[index % Colors.length]}
+								/>
 							))}
 						</Bar>
 					</BarChart>

--- a/shared/ui/Stream/NRQL/NRQLResultsBillboard.tsx
+++ b/shared/ui/Stream/NRQL/NRQLResultsBillboard.tsx
@@ -13,7 +13,15 @@ const BillboardValue = styled.div`
 	line-height: 1;
 `;
 
-export const NRQLResultsBillboard = (props: { results: NRQLResult[]; eventType?: string }) => {
+interface Props {
+	results: NRQLResult[];
+	/**
+	 * Name of the collection
+	 */
+	eventType?: string;
+}
+
+export const NRQLResultsBillboard = (props: Props) => {
 	let firstResult = props.results[0];
 	let onlyKey = Object.keys(firstResult)[0];
 	const value = firstResult[onlyKey];

--- a/shared/ui/Stream/NRQL/NRQLResultsJSON.tsx
+++ b/shared/ui/Stream/NRQL/NRQLResultsJSON.tsx
@@ -4,7 +4,11 @@ import { MonacoEditor } from "./MonacoEditor";
 import { isDarkTheme } from "@codestream/webview/src/themes";
 import { ThemeContext } from "styled-components";
 
-export const NRQLResultsJSON = (props: { results: NRQLResult[] }) => {
+interface Props {
+	results: NRQLResult[];
+}
+
+export const NRQLResultsJSON = (props: Props) => {
 	const themeContext = useContext(ThemeContext);
 	const monacoRef = useRef<any>(null);
 

--- a/shared/ui/Stream/NRQL/NRQLResultsLine.tsx
+++ b/shared/ui/Stream/NRQL/NRQLResultsLine.tsx
@@ -15,7 +15,16 @@ const formatXAxisTime = time => {
 	return new Date(time).toLocaleTimeString();
 };
 
-export const NRQLResultsLine = (props: { results: NRQLResult[] }) => {
+interface Props {
+	results: NRQLResult[];
+	/**
+	 * the name of the facets (aka name, path, foo, bar). Not the property facet returned from the results,
+	 * but the facet in the metadata that points to the name of the faceted property/ies
+	 */
+	facet?: string[];
+}
+
+export const NRQLResultsLine = (props: Props) => {
 	const result = props.results ? props.results[0] : undefined;
 	const dataKeys = Object.keys(result || {}).filter(
 		_ => _ !== "beginTimeSeconds" && _ !== "endTimeSeconds"

--- a/shared/ui/Stream/NRQL/NRQLResultsTable.tsx
+++ b/shared/ui/Stream/NRQL/NRQLResultsTable.tsx
@@ -14,11 +14,13 @@ const cellStyle = {
 	fontFamily: "'Courier New', Courier, monospace",
 };
 
-export const NRQLResultsTable = (props: {
+interface Props {
 	results: NRQLResult[];
 	width: number | string;
 	height: number | string;
-}) => {
+}
+
+export const NRQLResultsTable = (props: Props) => {
 	const hasKey = (obj, key) => {
 		return obj.hasOwnProperty(key);
 	};

--- a/shared/ui/ipc/host.protocol.ts
+++ b/shared/ui/ipc/host.protocol.ts
@@ -29,6 +29,7 @@ export interface Collaborator {
 }
 
 export type IdeNames = "VSC" | "VS" | "JETBRAINS";
+export type BrowserEngines = "JCEF" | "JxBrowser" | "DotNetBrowser";
 
 export interface BootstrapInHostResponse {
 	capabilities: Capabilities;
@@ -330,10 +331,11 @@ export interface OpenEditorViewNotification {
 		| "nrql_file"
 		// other
 		| "notification"
+		| "golden_metrics"
 		| "profile";
 	ide: {
-		name?: "VSC" | "VS" | "JETBRAINS";
-		browserEngine?: "JCEF" | "JxBrowser" | "DotNetBrowser" | undefined;
+		name?: IdeNames;
+		browserEngine?: BrowserEngines;
 	};
 
 	accountId?: number;

--- a/shared/ui/src/__tests__/Stream/NRQL/NRQLPanel.test.tsx
+++ b/shared/ui/src/__tests__/Stream/NRQL/NRQLPanel.test.tsx
@@ -40,7 +40,13 @@ const mockHostApi = {
 	send: async (a: { method: string }, b, c) => {
 		if (a.method === "codestream/newrelic/nrql/queries/recent") {
 			return {
-				items: [{ query: "SELECT * FROM FOO", accountIds: [1], createdAt: new Date().getTime() }],
+				items: [
+					{
+						query: "SELECT * FROM FOO",
+						accounts: [{ id: 1, name: "foo" }],
+						createdAt: new Date().getTime(),
+					},
+				],
 			} as GetNRQLRecentQueriesResponse;
 		}
 		if (a.method === "codestream/newrelic/accounts/all") {

--- a/shared/util/src/protocol/agent/agent.protocol.providers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.providers.ts
@@ -2761,8 +2761,7 @@ export interface NRQLRecentQuery {
 	/**
 	 * Recent, runnable, query from the current user
 	 */
-	query: string;
-	accountIds: number[];
+	query: string;	
 	accounts: Account[];
 	createdAt: number;
 	dayString?: string;

--- a/shared/util/src/protocol/agent/agent.protocol.providers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.providers.ts
@@ -2675,8 +2675,11 @@ export interface NRQLResult {
 export interface GetNRQLResponse {
 	results?: NRQLResult[];
 	accountId: number;
-	eventType?: string;
-	since?: string;
+	metadata?: {
+		facet?: string[];
+		eventType?: string;
+		since?: string;
+	};
 	error?: NRErrorResponse;
 	resultsTypeGuess?: ResultsTypeGuess;
 }

--- a/shared/util/test/utils/system/strings.spec.ts
+++ b/shared/util/test/utils/system/strings.spec.ts
@@ -127,5 +127,5 @@ describe("strings.ts", () => {
 				"FROM ErrorTrace SELECT * WHERE error.class LIKE 'TypeError' AND error.message LIKE 'Cannot read properties of undefined (reading \\'find\\')' SINCE 1681396857577 until 1681397057577 ORDER BY timestamp DESC LIMIT 1"
 			);
 		});
-	});
+	}); 
 });

--- a/vscode/nrql.configuration.json
+++ b/vscode/nrql.configuration.json
@@ -1,6 +1,6 @@
 {
 	"comments": {
-		"lineComment": "//",
+		"lineComment": "--",
 		"blockComment": ["/*", "*/"]
 	},
 	"brackets": [


### PR DESCRIPTION
- Wrong accountId is used in certain cases - NR-230636
- NRQL queries with comments fails - NR-229045
-- additional grammar cleanup w/r/t comments
- Don't assume a "facet" property - NR-229519
-- adds support for multi-faceted bar + pie charts
- Fixes Agent "Run UnitTests for this File"
- Adds ability to convert monaco editor into a simple textarea.
