### PR TITLE
Moar Token Shtuff

### DIFF
--- a/jb/src/main/kotlin/agent/CodeStreamLanguageClient.kt
+++ b/jb/src/main/kotlin/agent/CodeStreamLanguageClient.kt
@@ -141,13 +141,6 @@ class CodeStreamLanguageClient(private val project: Project) : LanguageClient {
     @JsonNotification("codestream/didFailLogin")
     fun didFailLogin(json: JsonElement?) {}
 
-    @JsonNotification("codestream/didEncounterInvalidRefreshToken")
-    fun didEncounterInvalidRefreshToken(json: JsonElement?) {
-        appDispatcher.launch {
-            project.authenticationService?.onDidEncounterInvalidRefreshToken();
-        }
-    }
-
     @JsonNotification("codestream/didLogin")
     fun didLogin(json: JsonElement) {
         val notification = gson.fromJson<DidLoginNotification>(json)

--- a/jb/src/main/kotlin/authentication/AuthenticationService.kt
+++ b/jb/src/main/kotlin/authentication/AuthenticationService.kt
@@ -164,10 +164,6 @@ class AuthenticationService(val project: Project) {
         }
     }
 
-    suspend fun onDidEncounterInvalidRefreshToken() {
-        onDidLogout(DidLogoutNotification(LogoutReason.INVALID_REFRESH_TOKEN))
-    }
-
     suspend fun logout(reason: CSLogoutReason, newServerUrl: String? = null) {
         val agent = project.agentService ?: return
         val session = project.sessionService ?: return

--- a/shared/agent/src/api/codestream/codestreamApi.ts
+++ b/shared/agent/src/api/codestream/codestreamApi.ts
@@ -65,7 +65,6 @@ import {
 	DeleteUserRequest,
 	DeleteUserResponse,
 	DidChangeDataNotificationType,
-	DidEncounterInvalidRefreshTokenNotificationType,
 	ERROR_GENERIC_USE_ERROR_MESSAGE,
 	EditPostRequest,
 	FetchCodeErrorsRequest,
@@ -2453,7 +2452,7 @@ export class CodeStreamApiProvider implements ApiProvider {
 		this._refreshNRTokenPromise = new Promise((resolve, reject) => {
 			const url = "/no-auth/provider-refresh/newrelic";
 			this.put<{ refreshToken: string }, CSNewRelicProviderInfo>(url, {
-				refreshToken,
+				refreshToken: refreshToken, //+ "x", // uncomment to test roadblock
 			})
 				.then(response => {
 					if (response.accessToken) {
@@ -2476,15 +2475,6 @@ export class CodeStreamApiProvider implements ApiProvider {
 				})
 				.catch(ex => {
 					Logger.error(ex, cc);
-					if (ex.statusCode === 403) {
-						Logger.warn(
-							"New Relic access token refresh failed, sending DidEncounterInvalidRefreshTokenNotification..."
-						);
-						Container.instance().agent.sendNotification(
-							DidEncounterInvalidRefreshTokenNotificationType,
-							undefined
-						);
-					}
 					delete this._refreshNRTokenPromise;
 					reject(ex);
 				});

--- a/vscode/src/agent/agentConnection.ts
+++ b/vscode/src/agent/agentConnection.ts
@@ -148,7 +148,6 @@ import {
 	UpdateUserRequestType,
 	UserDidCommitNotification,
 	UserDidCommitNotificationType,
-	DidEncounterInvalidRefreshTokenNotificationType,
 	TelemetryEventName,
 	TelemetryData,
 	WhatsNewNotificationType,
@@ -202,11 +201,6 @@ export class CodeStreamAgentConnection implements Disposable {
 	private _onDidFailLogin = new EventEmitter<void>();
 	get onDidFailLogin(): Event<void> {
 		return this._onDidFailLogin.event;
-	}
-
-	private _onDidEncounterInvalidRefreshToken = new EventEmitter<void>();
-	get onDidEncounterInvalidRefreshToken(): Event<void> {
-		return this._onDidEncounterInvalidRefreshToken.event;
 	}
 
 	private _onDidRequireRestart = new EventEmitter<void>();
@@ -1347,9 +1341,6 @@ export class CodeStreamAgentConnection implements Disposable {
 		this._client.onNotification(DidLoginNotificationType, e => this._onDidLogin.fire(e));
 		this._client.onNotification(DidStartLoginNotificationType, () => this._onDidStartLogin.fire());
 		this._client.onNotification(DidFailLoginNotificationType, () => this._onDidFailLogin.fire());
-		this._client.onNotification(DidEncounterInvalidRefreshTokenNotificationType, () =>
-			this._onDidEncounterInvalidRefreshToken.fire()
-		);
 		this._client.onNotification(DidLogoutNotificationType, this.onLogout.bind(this));
 		this._client.onNotification(RestartRequiredNotificationType, () => {
 			this._onDidRequireRestart.fire();

--- a/vscode/src/api/session.ts
+++ b/vscode/src/api/session.ts
@@ -214,10 +214,6 @@ export class CodeStreamSession implements Disposable {
 		this._disposableUnauthenticated = Disposable.from(
 			Container.agent.onDidStartLogin(() => this.setStatus(SessionStatus.SigningIn)),
 			Container.agent.onDidFailLogin(() => this.setStatus(SessionStatus.SignedOut)),
-			Container.agent.onDidEncounterInvalidRefreshToken(() => {
-				Logger.log("Encountered invalid refresh token, logging out...");
-				this.setStatus(SessionStatus.SignedOut);
-			}),
 			Container.agent.onDidLogin(params => {
 				this.completeLogin(
 					SaveTokenReason.LOGIN_SUCCESS,


### PR DESCRIPTION
The two various notifications were battling against each other in all out gorilla warfare. Remove the (albeit, Original) notification and utilize the one that triggers the UX mechanism for logging out and navigating to the login screen