### PR TITLE
AD - PHP Scopes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dist/
 jb/.classpath
 jb/bin/main/
 jb/bin/test/
+
+shared/agent/newrelic_agent.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -106,44 +106,6 @@
 			"smartStep": true,
 			"sourceMaps": true
 		},
-		{
-			"name": "Debug/Watch Current File Jest Tests",
-			"type": "node",
-			"request": "launch",
-			"cwd": "${workspaceFolder}/shared/ui",
-			"program": "./node_modules/.bin/jest",
-			"args": [
-				"--runInBand",
-				"--watch",
-				"${file}"
-			],
-			"console": "integratedTerminal",
-			"internalConsoleOptions": "neverOpen"
-		},
-		{
-			"name": "Debug/Watch All Jest Tests",
-			"type": "node",
-			"request": "launch",
-			"cwd": "${workspaceFolder}/shared/ui",
-			"program": "./node_modules/.bin/jest",
-			"args": [
-				"--runInBand",
-				"--watch",
-			],
-			"console": "integratedTerminal",
-			"internalConsoleOptions": "neverOpen"
-		},
-		{
-			"name": "Debug UI Jest Tests",
-			"type": "node",
-			"request": "launch",
-			"cwd": "${workspaceFolder}/shared/ui",
-			"program": "./node_modules/.bin/jest",
-			"args": [
-				"--runInBand",
-			],
-			"console": "integratedTerminal",
-			"internalConsoleOptions": "neverOpen"
-		}
+
 	]
 }

--- a/shared/agent/.vscode/launch.json
+++ b/shared/agent/.vscode/launch.json
@@ -82,6 +82,19 @@
 			"env": {
 				"TS_NODE_COMPILER_OPTIONS": "{ \"module\": \"commonjs\", \"types\": [\"node\"] }"
 			}
+		},
+		{
+			"name": "Debug/Watch Current File Jest Tests",
+			"type": "node",
+			"request": "launch",
+			"cwd": "${workspaceFolder}",
+			"program": "./node_modules/.bin/jest",
+			"args": ["--runInBand", "--watch", "${file}"],
+			"env": {
+				"NEW_RELIC_ENABLED": false
+			},
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen"
 		}
 	]
 }

--- a/shared/agent/src/providers/newrelic/anomalyDetectionDrillDown.ts
+++ b/shared/agent/src/providers/newrelic/anomalyDetectionDrillDown.ts
@@ -581,12 +581,7 @@ export class AnomalyDetectorDrillDown {
 	}
 
 	private runNrql<T>(nrql: string): Promise<T[]> {
-		try {
-			return this.graphqlClient.runNrql(this._accountId, nrql, 400);
-		} catch (ex) {
-			Logger.error(ex);
-			return Promise.resolve([]);
-		}
+		return this.graphqlClient.runNrql(this._accountId, nrql, 400);
 	}
 
 	private durationComparisonToAnomaly(

--- a/shared/agent/src/providers/newrelic/anomalyDetectionDrillDown.ts
+++ b/shared/agent/src/providers/newrelic/anomalyDetectionDrillDown.ts
@@ -184,6 +184,7 @@ export class AnomalyDetectorDrillDown {
 			isSupported: true,
 		};
 	}
+
 	private async executeCore(
 		languageSupport: LanguageSupport,
 		benchmarkSpans: SpanWithCodeAttrs[],
@@ -275,7 +276,7 @@ export class AnomalyDetectorDrillDown {
 		minimumSampleRate: number,
 		minimumRatio: number
 	): Promise<{ comparisons: Comparison[]; metricTimesliceNames: string[] }> {
-		const metricFilter = this.getMetricFilter(languageSupport, scope);
+		const metricFilter = this.getMetricFilter(scope);
 		const data = await this.getDurationMetric(this._dataTimeFrame, metricFilter);
 		const dataFiltered = languageSupport.filterMetrics(data, benchmarkSpans);
 
@@ -313,7 +314,7 @@ export class AnomalyDetectorDrillDown {
 		comparisons: Comparison[];
 		metricTimesliceNames: string[];
 	}> {
-		const metricFilter = this.getMetricFilter(languageSupport, scope);
+		const metricFilter = this.getMetricFilter(scope);
 		const errorCountLookup = `metricTimesliceName LIKE 'Errors/%'`;
 		const dataErrorCount = await this.getErrorCountMetric(errorCountLookup, this._dataTimeFrame);
 		const dataErrorCountFiltered = languageSupport.filterMetrics(dataErrorCount, benchmarkSpans);
@@ -561,7 +562,7 @@ export class AnomalyDetectorDrillDown {
 		return this.runNrql<NameValue>(query);
 	}
 
-	private getMetricFilter(languageSupport: LanguageSupport, scope: string | undefined) {
+	getMetricFilter(scope: string | undefined) {
 		if (scope) {
 			return `scope = '${escapeNrql(scope)}'`;
 		} else {

--- a/shared/agent/test/unit/providers/newrelic/anomalyDetectionDrillDown.spec.ts
+++ b/shared/agent/test/unit/providers/newrelic/anomalyDetectionDrillDown.spec.ts
@@ -1,0 +1,38 @@
+"use strict";
+
+import { describe, expect, it } from "@jest/globals";
+
+import { AnomalyDetectorDrillDown } from "../../../../src/providers/newrelic/anomalyDetectionDrillDown";
+import { GetObservabilityAnomaliesRequest } from "../../../../../util/src/protocol/agent/agent.protocol.providers";
+
+describe("anomalyDetectorDrillDown", () => {
+	const anomalyDetector = new AnomalyDetectorDrillDown(
+		{
+			//irrelevant for the test case, but needed to pass ctor
+			entityGuid: "MTExODgxMzl8QVBNfEFQUExJQ0FUSU9OfDMzMjE0MjMy",
+		} as GetObservabilityAnomaliesRequest,
+		{} as any,
+		{} as any,
+		{} as any
+	);
+
+	it("properly escapes embeddded scopes with backslashes", async () => {
+		const result = anomalyDetector.getMetricFilter(
+			"WebTransaction/Custom/App\\Http\\Controllers\\Api\\ControllerName@MethodName"
+		);
+
+		expect(result).toEqual(
+			`scope = 'WebTransaction/Custom/App\\\\\\\\Http\\\\\\\\Controllers\\\\\\\\Api\\\\\\\\ControllerName@MethodName'`
+		);
+	});
+
+	it("leaves embeddded scopes with forward slashes alone", async () => {
+		const result = anomalyDetector.getMetricFilter(
+			"WebTransaction/Custom/App/Http/Controllers/Api/ControllerName@MethodName"
+		);
+
+		expect(result).toEqual(
+			`scope = 'WebTransaction/Custom/App/Http/Controllers/Api/ControllerName@MethodName'`
+		);
+	});
+});

--- a/shared/ui/.vscode/launch.json
+++ b/shared/ui/.vscode/launch.json
@@ -13,6 +13,36 @@
 			"internalConsoleOptions": "neverOpen",
 			"env": { "CI": "true" },
 			"disableOptimisticBPs": true
+		},
+		{
+			"name": "Debug/Watch Current File Jest Tests",
+			"type": "node",
+			"request": "launch",
+			"cwd": "${workspaceFolder}",
+			"program": "./node_modules/.bin/jest",
+			"args": ["--runInBand", "--watch", "${file}"],
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen"
+		},
+		{
+			"name": "Debug/Watch All Jest Tests",
+			"type": "node",
+			"request": "launch",
+			"cwd": "${workspaceFolder}",
+			"program": "./node_modules/.bin/jest",
+			"args": ["--runInBand", "--watch"],
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen"
+		},
+		{
+			"name": "Debug Jest Tests",
+			"type": "node",
+			"request": "launch",
+			"cwd": "${workspaceFolder}",
+			"program": "./node_modules/.bin/jest",
+			"args": ["--runInBand"],
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen"
 		}
 	]
 }


### PR DESCRIPTION
"scope" can have double slashes that need escaped. Catch any exceptions at the query level

Example:

```
scope = 'WebTransaction/Custom/App\\Http\\Controllers\\Api\\SomeController@SomeAction'
```