### PR TITLE
NR-236213

### DIFF
--- a/shared/agent/src/providers/newrelic/logs/nrLogsProvider.ts
+++ b/shared/agent/src/providers/newrelic/logs/nrLogsProvider.ts
@@ -152,14 +152,13 @@ export class NrLogsProvider {
 
 			const logs = await this.graphqlClient.runNrql<LogResult>(accountId, query, 400);
 
-			const possibleSeverityAttributes: string[] = [
+			const possibleSeverityAttributes: Set<string> = new Set([
 				`log_severity`,
 				`level`,
 				`log.level`,
 				`loglevel`,
 				`log_level`,
-				`level_name`,
-			];
+			]);
 
 			logs.map(lr => {
 				const myKeys = Object.keys(lr);

--- a/shared/ui/Stream/APMLogging/APMLogRow.tsx
+++ b/shared/ui/Stream/APMLogging/APMLogRow.tsx
@@ -4,7 +4,7 @@ import Timestamp from "../Timestamp";
 import Icon from "@codestream/webview/Stream/Icon";
 import { isEmpty as _isEmpty } from "lodash-es";
 import { HostApi } from "@codestream/webview/webview-api";
-import { LogResult } from "@codestream/protocols/agent";
+import { LogResult, LogResultSpecialColumns } from "@codestream/protocols/agent";
 import copy from "copy-to-clipboard";
 import Tooltip from "../Tooltip";
 
@@ -122,7 +122,12 @@ const DetailViewTable = styled.div`
 	}
 `;
 
-const hiddenColumns = ["log_summary", "expandedContent"];
+const hiddenColumns = [
+	"expandedContent",
+	LogResultSpecialColumns.message,
+	LogResultSpecialColumns.severity,
+	LogResultSpecialColumns.summary,
+];
 
 export const APMLogRow = (props: {
 	timestamp: string;

--- a/shared/util/src/protocol/agent/agent.protocol.providers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.providers.ts
@@ -2571,10 +2571,14 @@ export interface LogResult {
 	[key: string]: string;
 }
 
+export const LogResultSpecialColumns = {
+	message: "__cs_message",
+	severity: "__cs_severity",
+	summary: "__cs_log_summary",
+};
+
 export interface GetLogsResponse {
 	logs?: LogResult[];
-	messageAttribute?: string;
-	severityAttribute?: string;
 	accountId: number;
 	error?: NRErrorResponse;
 }
@@ -2730,7 +2734,7 @@ export interface NRQLRecentQuery {
 	/**
 	 * Recent, runnable, query from the current user
 	 */
-	query: string;	
+	query: string;
 	accounts: Account[];
 	createdAt: number;
 	dayString?: string;


### PR DESCRIPTION
* Add `level_name` to possible severity attributes.

* Allow EACH ROW to have its own message and severity attributes. (Useful when logs are mixed for the same entity / service)