### PR TITLE
Fix event type

### DIFF
--- a/shared/ui/Stream/APMLogging/APMLogSearchPanel.tsx
+++ b/shared/ui/Stream/APMLogging/APMLogSearchPanel.tsx
@@ -481,7 +481,7 @@ export const APMLogSearchPanel = (props: {
 
 	const trackOpenTelemetry = (entryPoint: string, entityGuid?: string, accountId?: number) => {
 		const payload = {
-			event_type: "click",
+			event_type: "modal_display",
 			meta_data: `entry_point: ${entryPoint}`,
 		} as TelemetryData;
 

--- a/shared/ui/Stream/NRQL/NRQLPanel.tsx
+++ b/shared/ui/Stream/NRQL/NRQLPanel.tsx
@@ -195,7 +195,7 @@ export const NRQLPanel = (props: {
 
 	useEffect(() => {
 		HostApi.instance.track("codestream/nrql/webview displayed", {
-			event_type: "click",
+			event_type: "modal_display",
 			meta_data: `entry_point: ${props.entryPoint}`,
 		});
 

--- a/shared/ui/src/__tests__/Stream/APMLogging/APMLogSearchPanel.test.tsx
+++ b/shared/ui/src/__tests__/Stream/APMLogging/APMLogSearchPanel.test.tsx
@@ -130,7 +130,7 @@ describe("APM Logging Panel UI", () => {
 
 			expect(mockTrack).toHaveBeenCalledTimes(1);
 			expect(mockTrack).toHaveBeenCalledWith("codestream/logs/webview displayed", {
-				event_type: "click",
+				event_type: "modal_display",
 				meta_data: `entry_point: ${props.entryPoint}`,
 			});
 		});
@@ -154,7 +154,7 @@ describe("APM Logging Panel UI", () => {
 		await waitFor(() => {
 			expect(mockTrack).toHaveBeenCalledTimes(2);
 			expect(mockTrack).toHaveBeenCalledWith("codestream/logs/webview displayed", {
-				event_type: "click",
+				event_type: "modal_display",
 				entity_guid: ENTITY_GUID,
 				account_id: ACCOUNT_ID,
 				meta_data: `entry_point: ${ENTRY_POINT}`,

--- a/shared/ui/src/__tests__/Stream/NRQL/NRQLPanel.test.tsx
+++ b/shared/ui/src/__tests__/Stream/NRQL/NRQLPanel.test.tsx
@@ -95,7 +95,7 @@ describe("NRQL Panel UI", () => {
 
 			expect(mockTrack).toHaveBeenCalledTimes(2);
 			expect(mockTrack).toHaveBeenCalledWith("codestream/nrql/webview displayed", {
-				event_type: "click",
+				event_type: "modal_display",
 				meta_data: `entry_point: ${props.entryPoint}`,
 			});
 			expect(mockTrack).toHaveBeenCalledWith("codestream/nrql/query submitted", {


### PR DESCRIPTION
For "codestream/logs/webview displayed" and "codestream/nrql/webview displayed" change event type to modal_display