### PR TITLE
Support non-APM/OTel logs

### DIFF
--- a/shared/agent/src/main-vs-2019.ts
+++ b/shared/agent/src/main-vs-2019.ts
@@ -36,7 +36,7 @@ export * from "./providers/trunk";
 export * from "./providers/youtrack";
 
 export * from "./providers/newrelic/clm/clmProvider";
-export * from "./providers/newrelic/logs/nrLogsProvider";
+export * from "./providers/newrelic/logs/loggingProvider";
 export * from "./providers/newrelic/slo/sloProvider";
 export * from "./providers/newrelic/anomalies/anomaliesProvider";
 export * from "./providers/newrelic/errors/observabilityErrorsProvider";

--- a/shared/agent/src/main.ts
+++ b/shared/agent/src/main.ts
@@ -33,7 +33,7 @@ export * from "./providers/trunk";
 export * from "./providers/youtrack";
 
 export * from "./providers/newrelic/clm/clmProvider";
-export * from "./providers/newrelic/logs/nrLogsProvider";
+export * from "./providers/newrelic/logs/loggingProvider";
 export * from "./providers/newrelic/slo/sloProvider";
 export * from "./providers/newrelic/anomalies/anomaliesProvider";
 export * from "./providers/newrelic/errors/observabilityErrorsProvider";

--- a/shared/agent/src/providers/newrelic/entity/entityProvider.ts
+++ b/shared/agent/src/providers/newrelic/entity/entityProvider.ts
@@ -126,6 +126,7 @@ export class EntityProvider implements Disposable {
 					guid
 					name
 					entityType
+					type
 					tags {
 						key
 						values
@@ -141,6 +142,7 @@ export class EntityProvider implements Disposable {
 					guid: string;
 					name: string;
 					entityType: EntityType;
+					type: string;
 					tags: { key: string; values: string[] }[];
 				};
 			};
@@ -152,6 +154,7 @@ export class EntityProvider implements Disposable {
 				accountName: entity.account.name,
 				entityGuid: entity.guid,
 				entityName: entity.name,
+				type: entity.type,
 				entityType: entity.entityType,
 				entityTypeDescription: EntityTypeMap[entity.entityType],
 				tags: entity.tags,

--- a/shared/agent/src/providers/newrelic/logs/entityAttributeMapper.ts
+++ b/shared/agent/src/providers/newrelic/logs/entityAttributeMapper.ts
@@ -116,8 +116,8 @@ export class EntityAttributeMapper {
 	}
 
 	getWhereClauseForEntity(entity: EntityAccount): string {
-		const { entityType, entityGuid, entityName, tags } = entity;
-		const entityTypeInUpperCase: string | null = entityType ? entityType.toUpperCase() : null;
+		const { type, entityGuid, entityName, tags } = entity;
+		const entityTypeInUpperCase: string | null = type ? type.toUpperCase() : null;
 		const logAttributeValue = entityName;
 
 		let whereClause = this.constructWhereConditionsWithLogAttributes({

--- a/shared/agent/src/providers/newrelic/logs/entityAttributeMapper.ts
+++ b/shared/agent/src/providers/newrelic/logs/entityAttributeMapper.ts
@@ -1,0 +1,138 @@
+/**
+ * Copied from https://source.datanerd.us/logging/shared-component-logs/blob/master/shared-component/helpers/entityLogAttributesMapper.js
+ *
+ * Note that "entity type" referred to in this file is `entity.type` and NOT `entity.entityType`
+ **/
+import { EntityAccount } from "@codestream/protocols/agent";
+import {
+	Attribute,
+	ComparisonType,
+	EntityTag,
+	ENTITY_TYPE_AND_LOG_ATTRIBUTES_MAP,
+	AZURE_ENTITY_TYPE_AND_LOG_ATTRIBUTES,
+} from "./logging.types";
+
+export class EntityAttributeMapper {
+	private createAttributeCondition(attribute: Attribute, attributeValue?: string): string {
+		const value =
+			attributeValue && attribute.prepare ? attribute.prepare(attributeValue) : attributeValue;
+
+		switch (attribute.comparisonType) {
+			case ComparisonType.EQUAL:
+				return `\`${attribute.attributeName}\`='${value!}'`;
+			case ComparisonType.CONTAINS:
+				return `\`${attribute.attributeName}\` LIKE '%${value!}%'`;
+			case ComparisonType.STARTS_WITH:
+				return `\`${attribute.attributeName}\` LIKE '${value!}%'`;
+			case ComparisonType.ENDS_WITH:
+				return `\`${attribute.attributeName}\` LIKE '%${value!}'`;
+			case ComparisonType.NOT_HAS:
+				return `NOT \`${attribute.attributeName}\``;
+			default:
+				throw new Error(`Unhandled condition: '${attribute.comparisonType}'`);
+		}
+	}
+
+	private getLogAttributesForEntityType(entityTypeInUpperCase: string | null): Attribute[] {
+		if (entityTypeInUpperCase === null) {
+			return [];
+		}
+
+		if (ENTITY_TYPE_AND_LOG_ATTRIBUTES_MAP[entityTypeInUpperCase]) {
+			return ENTITY_TYPE_AND_LOG_ATTRIBUTES_MAP[entityTypeInUpperCase];
+		}
+		// As Azure has 37 different resource types (at the moment of writing this), we cheated a bit to don't need
+		// to add duplicated code on the ENTITY_TYPE_AND_LOG_ATTRIBUTES_MAP and also to don't need to modify this
+		// list if a new Azure resource type support is added to NewRelic.
+		if (entityTypeInUpperCase?.startsWith("AZURE")) {
+			return AZURE_ENTITY_TYPE_AND_LOG_ATTRIBUTES;
+		}
+		return [];
+	}
+
+	private createAwsAccountIdLambdaCondition(entityTags: EntityTag[] = []): string {
+		const AWS_ACCOUNT_ID_TAG = "aws.accountId";
+
+		const tag = entityTags.find(tag => tag?.key === AWS_ACCOUNT_ID_TAG);
+		const awsAccountId = tag?.values?.[0];
+		let condition = "";
+
+		// If there's an entity tag for aws.accountId add a condition that
+		// checks `owner`=[aws.accountId]. We also have a "NOT" condition because
+		// not all lambdas tagged with aws.accountId will have an `owner` attribute.
+		// But in the case where they do have an `owner` we'll get the one that
+		// matches aws.accountId.
+
+		if (awsAccountId) {
+			const NOT_HAS_OWNER: Attribute = {
+				attributeName: "owner",
+				comparisonType: ComparisonType.NOT_HAS,
+			};
+
+			const OWNER_EQUALS: Attribute = {
+				attributeName: "owner",
+				comparisonType: ComparisonType.EQUAL,
+			};
+
+			const notHasOwner = this.createAttributeCondition(NOT_HAS_OWNER);
+			const ownerEqualsAwsAccountId = this.createAttributeCondition(OWNER_EQUALS, awsAccountId);
+
+			condition = ` AND (${notHasOwner} OR ${ownerEqualsAwsAccountId}) `;
+		}
+		return condition;
+	}
+
+	private constructWhereConditionsWithLogAttributes({
+		entityTypeInUpperCase,
+		entityGuid,
+		logAttributeValue,
+	}: {
+		entityTypeInUpperCase: string | null;
+		entityGuid: string;
+		logAttributeValue: string;
+	}): string {
+		const logAttributes = this.getLogAttributesForEntityType(entityTypeInUpperCase);
+		const hasLogAttributes = logAttributes && logAttributes.length;
+		const hasAttributeValue = typeof logAttributeValue !== "undefined";
+
+		let conditions = [
+			this.createAttributeCondition(
+				{ attributeName: "entity.guid", comparisonType: ComparisonType.EQUAL },
+				entityGuid
+			),
+			this.createAttributeCondition(
+				{ attributeName: "entity.guids", comparisonType: ComparisonType.CONTAINS },
+				entityGuid
+			),
+		];
+
+		if (hasLogAttributes && hasAttributeValue) {
+			conditions = conditions.concat(
+				logAttributes.map(attribute => this.createAttributeCondition(attribute, logAttributeValue))
+			);
+		}
+
+		return conditions.join(" OR ");
+	}
+
+	getWhereClauseForEntity(entity: EntityAccount): string {
+		const { entityType, entityGuid, entityName, tags } = entity;
+		const entityTypeInUpperCase: string | null = entityType ? entityType.toUpperCase() : null;
+		const logAttributeValue = entityName;
+
+		let whereClause = this.constructWhereConditionsWithLogAttributes({
+			entityTypeInUpperCase,
+			entityGuid,
+			logAttributeValue,
+		});
+
+		// Add condition where owner=tags.aws.accountId to prevent case where other
+		// lambdas with the same name are shown in the wrong entity
+		// https://new-relic.atlassian.net/browse/NR-230233
+		if (entityTypeInUpperCase === "AWSLAMBDAFUNCTION") {
+			whereClause += this.createAwsAccountIdLambdaCondition(tags);
+		}
+
+		return whereClause;
+	}
+}

--- a/shared/agent/src/providers/newrelic/logs/logging.types.ts
+++ b/shared/agent/src/providers/newrelic/logs/logging.types.ts
@@ -1,0 +1,175 @@
+import { EntityType } from "@codestream/protocols/agent";
+
+export enum ComparisonType {
+	EQUAL = "EQUAL",
+	CONTAINS = "CONTAINS",
+	STARTS_WITH = "STARTS_WITH",
+	ENDS_WITH = "ENDS_WITH",
+	NOT_HAS = "NOT_HAS",
+}
+
+export interface EntityTag {
+	key: string;
+	values: string[];
+}
+
+export interface Attribute {
+	attributeName: string;
+	comparisonType: ComparisonType;
+	prepare?: (value: string) => string;
+}
+
+export interface EntityAttributeMappings {
+	[type: string]: Attribute[];
+}
+
+export const ENTITY_TYPE_AND_LOG_ATTRIBUTES_MAP: EntityAttributeMappings = {
+	APPLICATION: [
+		{
+			attributeName: "service_name",
+			comparisonType: ComparisonType.EQUAL,
+		},
+		{
+			attributeName: "serviceName",
+			comparisonType: ComparisonType.EQUAL,
+		},
+		{
+			attributeName: "service.name",
+			comparisonType: ComparisonType.EQUAL,
+		},
+		{
+			attributeName: "entity.name",
+			comparisonType: ComparisonType.EQUAL,
+		},
+	],
+	CONTAINER: [
+		{
+			attributeName: "container_name",
+			comparisonType: ComparisonType.EQUAL,
+		},
+		{
+			attributeName: "container.name",
+			comparisonType: ComparisonType.EQUAL,
+		},
+		{
+			attributeName: "containerName",
+			comparisonType: ComparisonType.EQUAL,
+		},
+		{
+			attributeName: "docker.name",
+			comparisonType: ComparisonType.EQUAL,
+		},
+	],
+	HOST: [
+		{
+			attributeName: "host.name",
+			comparisonType: ComparisonType.EQUAL,
+		},
+		{
+			attributeName: "hostname",
+			comparisonType: ComparisonType.EQUAL,
+		},
+		{
+			attributeName: "host",
+			comparisonType: ComparisonType.EQUAL,
+		},
+	],
+	SERVICE: [
+		{
+			attributeName: "service_name",
+			comparisonType: ComparisonType.EQUAL,
+		},
+		{
+			attributeName: "serviceName",
+			comparisonType: ComparisonType.EQUAL,
+		},
+		{
+			attributeName: "service.name",
+			comparisonType: ComparisonType.EQUAL,
+		},
+		{
+			attributeName: "entity.name",
+			comparisonType: ComparisonType.EQUAL,
+		},
+		{
+			attributeName: "container_name",
+			comparisonType: ComparisonType.EQUAL,
+		},
+	],
+	AWSLAMBDAFUNCTION: [
+		{
+			attributeName: "faas.name",
+			comparisonType: ComparisonType.EQUAL,
+		},
+		{
+			attributeName: "aws.logGroup",
+			comparisonType: ComparisonType.EQUAL,
+		},
+		{
+			attributeName: "aws.logGroup",
+			comparisonType: ComparisonType.ENDS_WITH,
+			prepare: (value: string) => `/${value}`,
+		},
+		{
+			attributeName: "logGroup",
+			comparisonType: ComparisonType.EQUAL,
+		},
+		{
+			attributeName: "logGroup",
+			comparisonType: ComparisonType.ENDS_WITH,
+			prepare: (value: string) => `/${value}`,
+		},
+	],
+	SWITCH: [{ attributeName: "device_name", comparisonType: ComparisonType.EQUAL }],
+	ROUTER: [{ attributeName: "device_name", comparisonType: ComparisonType.EQUAL }],
+	KUBERNETESCLUSTER: [
+		{
+			attributeName: "cluster_name",
+			comparisonType: ComparisonType.EQUAL,
+		},
+	],
+	KUBERNETES_POD: [
+		{
+			attributeName: "pod_name",
+			comparisonType: ComparisonType.EQUAL,
+		},
+	],
+};
+
+export const AZURE_ENTITY_TYPE_AND_LOG_ATTRIBUTES: Attribute[] = [
+	{ attributeName: "azure.resourceName", comparisonType: ComparisonType.EQUAL },
+	// Microsoft didn't guarantee the existence of azure.resourceName for all their resources at this moment, so we need
+	// to add a fallback to the last segment of the azure.resourceId which should be always the resource name (uppercase).
+	{
+		attributeName: "azure.resourceId",
+		comparisonType: ComparisonType.ENDS_WITH,
+		prepare: (value: string) => `/${value}`,
+	},
+];
+
+export interface LogEntityResult {
+	guid: string;
+	name: string;
+	entityType: EntityType;
+	type: string;
+	tags: {
+		key: string;
+		values: string[];
+	}[];
+	account: {
+		name: string;
+		id: number;
+	};
+}
+
+export interface LogEntitySearchResult {
+	actor: {
+		entitySearch: {
+			count: number;
+			results: {
+				nextCursor: string;
+				entities: LogEntityResult[];
+			};
+		};
+	};
+}

--- a/shared/agent/src/providers/newrelic/logs/loggingProvider.ts
+++ b/shared/agent/src/providers/newrelic/logs/loggingProvider.ts
@@ -174,7 +174,7 @@ export class LoggingProvider {
 
 			ContextLogger.log(`getLogs query: ${query}`);
 
-			const logs = await this.graphqlClient.runNrql<LogResult>(accountId, query, 100000);
+			const logs = await this.graphqlClient.runAsyncNrql<LogResult>(accountId, query);
 
 			logs.map(lr => {
 				const myKeys = Object.keys(lr);

--- a/shared/agent/src/providers/newrelic/logs/loggingProvider.ts
+++ b/shared/agent/src/providers/newrelic/logs/loggingProvider.ts
@@ -24,7 +24,6 @@ import { ContextLogger } from "../../contextLogger";
 import { mapNRErrorResponse } from "../utils";
 import { Strings } from "../../../system";
 import { LogEntityResult, LogEntitySearchResult } from "./logging.types";
-import { escapeNrql } from "@codestream/utils/system/string";
 import { EntityAttributeMapper } from "./entityAttributeMapper";
 
 @lsp
@@ -84,10 +83,8 @@ export class LoggingProvider {
 			  }
 			}`;
 
-			ContextLogger.log(`getLoggingEntities query: ${query}`);
-
 			const response: LogEntitySearchResult = await this.graphqlClient.query<LogEntitySearchResult>(
-				escapeNrql(query),
+				query,
 				{
 					cursor: request.nextCursor ?? null,
 				}
@@ -177,7 +174,7 @@ export class LoggingProvider {
 
 			ContextLogger.log(`getLogs query: ${query}`);
 
-			const logs = await this.graphqlClient.runNrql<LogResult>(accountId, query, 400);
+			const logs = await this.graphqlClient.runNrql<LogResult>(accountId, query, 100000);
 
 			logs.map(lr => {
 				const myKeys = Object.keys(lr);

--- a/shared/agent/src/providers/newrelic/newRelicGraphqlClient.ts
+++ b/shared/agent/src/providers/newrelic/newRelicGraphqlClient.ts
@@ -713,23 +713,23 @@ export class NewRelicGraphqlClient implements Disposable {
 		let results: T[] = [];
 
 		while (!completed) {
-			setTimeout(async () => {
-				const queryProgressResults = await this.query<{
-					actor: {
-						account: {
-							nrqlQueryProgress: {
-								results: T[];
-								queryProgress: {
-									completed: boolean;
-								};
+			const queryProgressResults = await this.query<{
+				actor: {
+					account: {
+						nrqlQueryProgress: {
+							results: T[];
+							queryProgress: {
+								completed: boolean;
 							};
 						};
 					};
-				}>(queryProgress, { accountId });
+				};
+			}>(queryProgress, { accountId });
 
-				completed = queryProgressResults.actor.account.nrqlQueryProgress.queryProgress.completed;
-				results = queryProgressResults.actor.account.nrqlQueryProgress.results;
-			}, 5000);
+			completed = queryProgressResults.actor.account.nrqlQueryProgress.queryProgress.completed;
+			results = queryProgressResults.actor.account.nrqlQueryProgress.results;
+
+			await Functions.wait(5000);
 		}
 
 		return results;

--- a/shared/agent/src/providers/newrelic/newRelicGraphqlClient.ts
+++ b/shared/agent/src/providers/newrelic/newRelicGraphqlClient.ts
@@ -661,10 +661,10 @@ export class NewRelicGraphqlClient implements Disposable {
 	}
 
 	async runAsyncNrql<T>(accountId: number, nrql: string): Promise<T[]> {
-		const query = `query Nrql($accountId:Int!) {
+		const query = `query Nrql($accountId:Int!, $nrql:Nrql!) {
 			actor {
 				account(id: $accountId) {
-					nrql(query: "${nrql}", timeout: 1, async: true) {
+					nrql(query: $nrql, timeout: 1, async: true) {
 						results
 						queryProgress {
 							completed
@@ -687,7 +687,7 @@ export class NewRelicGraphqlClient implements Disposable {
 					};
 				};
 			};
-		}>(query, { accountId });
+		}>(query, { accountId, nrql });
 
 		//bail out early if, for some reason, we got something back that quickly
 		if (queryResults.actor.account.nrql.queryProgress.completed) {
@@ -696,10 +696,10 @@ export class NewRelicGraphqlClient implements Disposable {
 
 		const queryId = queryResults.actor.account.nrql.queryProgress.queryId;
 
-		const queryProgress = `query Nrql($accountId:Int!) {
+		const queryProgress = `query Nrql($accountId:Int!, $queryId:Id!) {
 			actor {
 			  account(id: $accountId) {
-				nrqlQueryProgress( queryId: "${queryId}") {
+				nrqlQueryProgress( queryId: $queryId) {
 				  results
 				  queryProgress {
 					completed
@@ -724,7 +724,7 @@ export class NewRelicGraphqlClient implements Disposable {
 						};
 					};
 				};
-			}>(queryProgress, { accountId });
+			}>(queryProgress, { accountId, queryId });
 
 			completed = queryProgressResults.actor.account.nrqlQueryProgress.queryProgress.completed;
 			results = queryProgressResults.actor.account.nrqlQueryProgress.results;

--- a/shared/agent/src/providers/newrelic/nrContainer.ts
+++ b/shared/agent/src/providers/newrelic/nrContainer.ts
@@ -25,7 +25,7 @@ import { ReposProvider } from "./repos/reposProvider";
 import { SloProvider } from "./slo/sloProvider";
 import { SpansProvider } from "./spans/spansProvider";
 import { NraiProvider } from "./nrai/nraiProvider";
-import { NrLogsProvider } from "./logs/nrLogsProvider";
+import { LoggingProvider } from "./logs/loggingProvider";
 import { NrNRQLProvider } from "./nrql/nrqlProvider";
 import { NewRelicVulnerabilitiesProvider } from "./vuln/nrVulnerability";
 import { NrqlCompletionProvider } from "./nrql/nrqlCompletionProvider";
@@ -195,7 +195,7 @@ export async function injectNR(sessionServiceContainer: SessionServiceContainer)
 
 	disposables.push(newRelicVulnerabilitiesProvider);
 
-	const logsProvider = new NrLogsProvider(newRelicGraphqlClient);
+	const logsProvider = new LoggingProvider(newRelicGraphqlClient);
 	const nrqlProvider = new NrNRQLProvider(newRelicGraphqlClient);
 
 	nrDirectives = new NrDirectives(

--- a/shared/agent/src/providers/newrelic/repos/reposProvider.ts
+++ b/shared/agent/src/providers/newrelic/repos/reposProvider.ts
@@ -257,6 +257,7 @@ export class ReposProvider implements Disposable {
 							entityGuid: entity.guid,
 							entityName: entity.name,
 							entityType: entity.entityType,
+							type: entity.type,
 							entityTypeDescription: entity.entityType
 								? EntityTypeMap[entity.entityType]
 								: undefined,

--- a/shared/agent/src/system/fetchCore.ts
+++ b/shared/agent/src/system/fetchCore.ts
@@ -75,10 +75,6 @@ export async function fetchCore(
 	let timeout: NodeJS.Timeout | undefined = undefined;
 	// Make sure original init is not modified
 	const init = { ...initIn };
-
-	// TODO NR-248533: Configurable through initIn from Logs Provider?
-	init.timeout = 600000;
-
 	try {
 		handleLimit(origin);
 		const controller = new AbortController();

--- a/shared/agent/src/system/fetchCore.ts
+++ b/shared/agent/src/system/fetchCore.ts
@@ -75,6 +75,10 @@ export async function fetchCore(
 	let timeout: NodeJS.Timeout | undefined = undefined;
 	// Make sure original init is not modified
 	const init = { ...initIn };
+
+	// TODO NR-248533: Configurable through initIn from Logs Provider?
+	init.timeout = 600000;
+
 	try {
 		handleLimit(origin);
 		const controller = new AbortController();

--- a/shared/ui/Stream/APMLogging/APMLogSearchPanel.tsx
+++ b/shared/ui/Stream/APMLogging/APMLogSearchPanel.tsx
@@ -455,16 +455,22 @@ export const APMLogSearchPanel = (props: {
 				return;
 			}
 
-			const response = await HostApi.instance.send(GetLogsRequestType, {
-				entity: entityAccount,
-				filterText,
-				limit: "MAX",
-				since: selectedSinceOption?.value || "30 MINUTES AGO",
-				order: {
-					field: "timestamp",
-					direction: "DESC",
+			const response = await HostApi.instance.send(
+				GetLogsRequestType,
+				{
+					entity: entityAccount,
+					filterText,
+					limit: "MAX",
+					since: selectedSinceOption?.value || "30 MINUTES AGO",
+					order: {
+						field: "timestamp",
+						direction: "DESC",
+					},
 				},
-			});
+				{
+					timeoutMs: 660000, // 11 minutes. NR1/GraphQL should timeout at 10 minutes, but we'll give it a little extra
+				}
+			);
 
 			setQueriedWithNonEmptyString(!_isEmpty(filterText));
 

--- a/shared/ui/Stream/APMLogging/APMLogSearchPanel.tsx
+++ b/shared/ui/Stream/APMLogging/APMLogSearchPanel.tsx
@@ -486,6 +486,10 @@ export const APMLogSearchPanel = (props: {
 					handleError(
 						"Please check your syntax and try again. Note that you do not have to escape special characters. We'll do that for you!"
 					);
+				} else if (response?.error?.error?.message?.includes("NRDB:1101002")) {
+					handleError(
+						"Unfortunately, this query has timed out. Please try a shorter time range, more specific search criteria, or navigate to New Relic One to run this query."
+					);
 				} else {
 					handleError(response.error?.error?.message ?? response.error?.error?.type);
 				}

--- a/shared/ui/Stream/APMLogging/APMLogSearchPanel.tsx
+++ b/shared/ui/Stream/APMLogging/APMLogSearchPanel.tsx
@@ -138,12 +138,20 @@ const MessageHeader = styled.div`
 `;
 
 const Option = (props: OptionProps) => {
+	let subtleLabel = `${props.data?.entityTypeDescription} | `;
+	subtleLabel += props.data?.entityAccount.type ? `${props.data?.entityAccount.type} | ` : "";
+	subtleLabel += props.data?.entityAccount.entityGuid;
+	subtleLabel = ` (${subtleLabel})`;
+
 	const children = (
 		<>
 			<OptionName>
-				{props.data?.label} <OptionType>{props.data?.entityTypeDescription}</OptionType>
+				{props.data?.label}
+				<OptionType>{subtleLabel}</OptionType>
 			</OptionName>
-			<OptionAccount>{props.data?.accountName}</OptionAccount>
+			<OptionAccount>
+				{props.data?.accountName} ({props.data?.entityAccount.accountId})
+			</OptionAccount>
 		</>
 	);
 	return <components.Option {...props} children={children} />;
@@ -218,7 +226,7 @@ export const APMLogSearchPanel = (props: {
 		}
 
 		const finishHandlingEntityAccount = (entityAccount: EntityAccount) => {
-			handleSelectDropdownOption(entityAccount);
+			handleDefaultEntitySelection(entityAccount);
 
 			fetchFieldDefinitions(entityAccount);
 			fetchLogs(entityAccount, props.suppliedQuery);
@@ -269,16 +277,21 @@ export const APMLogSearchPanel = (props: {
 		};
 	});
 
-	const handleSelectDropdownOption = (entityAccount: EntityAccount) => {
+	const handleDefaultEntitySelection = (entityAccount: EntityAccount) => {
 		if (!entityAccount) {
 			setSelectedEntityAccount(null);
 			return;
 		}
 
+		let subtleLabel = `${entityAccount.entityTypeDescription} | `;
+		subtleLabel += entityAccount.type ? `${entityAccount.type} | ` : "";
+		subtleLabel += entityAccount.entityGuid;
+		subtleLabel = ` (${subtleLabel})`;
+
 		const customLabel = (
 			<>
 				<span>Service: {entityAccount.entityName}</span>
-				<span className="subtle"> ({entityAccount.entityTypeDescription})</span>
+				<span className="subtle">{subtleLabel}</span>
 			</>
 		);
 
@@ -288,6 +301,33 @@ export const APMLogSearchPanel = (props: {
 			accountName: entityAccount.accountName,
 			entityTypeDescription: entityAccount.entityTypeDescription,
 			entityAccount: entityAccount,
+		});
+	};
+
+	const handleSelectDropdownOption = (optionProps: OptionProps) => {
+		if (!optionProps) {
+			setSelectedEntityAccount(null);
+			return;
+		}
+
+		let subtleLabel = `${optionProps.entityTypeDescription} | `;
+		subtleLabel += optionProps.entityAccount.type ? `${optionProps.entityAccount.type} | ` : "";
+		subtleLabel += optionProps.entityAccount.entityGuid;
+		subtleLabel = ` (${subtleLabel})`;
+
+		const customLabel = (
+			<>
+				<span>Service: {optionProps.entityAccount.entityName}</span>
+				<span className="subtle">{subtleLabel}</span>
+			</>
+		);
+
+		setSelectedEntityAccount({
+			value: optionProps.entityGuid,
+			label: customLabel,
+			accountName: optionProps.accountName,
+			entityTypeDescription: optionProps.entityTypeDescription,
+			entityAccount: optionProps.entityAccount,
 		});
 	};
 

--- a/shared/ui/webview-api.ts
+++ b/shared/ui/webview-api.ts
@@ -40,7 +40,9 @@ type Listener<NT extends NotificationType<any, any> = NotificationType<any, any>
 
 const ALERT_THRESHOLD = 20;
 
-const STALE_THRESHOLD = 60; // 1 minute
+// TODO NR-248533: Configurable from Logs Provider or by message type?
+const STALE_THRESHOLD = 600; // 10 minutes
+// const STALE_THRESHOLD = 60; // 1 minute
 
 class StaleRequestGroup {
 	private _oldestDate: number | undefined = undefined;

--- a/shared/util/src/protocol/agent/agent.protocol.providers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.providers.ts
@@ -1534,6 +1534,7 @@ export interface EntityAccount {
 	entityGuid: string;
 	entityName: string;
 	entityType?: EntityType;
+	type?: string;
 	entityTypeDescription?: string;
 	domain?: string;
 	url?: string;
@@ -2665,16 +2666,22 @@ export const DidDetectObservabilityAnomaliesNotificationType = new NotificationT
 	void
 >("codestream/didDetectObservabilityAnomalies");
 
-// reusing request/response types - internally we're just omitting a filter
+export interface GetLoggingEntitiesResponse {
+	totalResults: number;
+	entities: EntityAccount[];
+	nextCursor?: string;
+}
+
+// reusing request type - internally we're just omitting a filter
 export const GetLoggingEntitiesRequestType = new RequestType<
 	GetObservabilityEntitiesRequest,
-	GetObservabilityEntitiesResponse,
+	GetLoggingEntitiesResponse,
 	void,
 	void
 >("codestream/newrelic/logs/entities");
 
 export interface GetLogsRequest {
-	entityGuid: string;
+	entity: EntityAccount;
 	filterText: string;
 	order: {
 		field: string;
@@ -2705,7 +2712,7 @@ export const GetLogsRequestType = new RequestType<GetLogsRequest, GetLogsRespons
 );
 
 export interface GetSurroundingLogsRequest {
-	entityGuid: string;
+	entity: EntityAccount;
 	messageId: string;
 	since: number;
 }
@@ -2724,7 +2731,7 @@ export const GetSurroundingLogsRequestType = new RequestType<
 >("codestream/newrelic/logs/surrounding");
 
 export interface GetLogFieldDefinitionsRequest {
-	entityGuid: string;
+	entity: EntityAccount;
 }
 
 export interface LogFieldDefinition {


### PR DESCRIPTION
- Allow many more entity "types" (not entityType)
- Map those types to get additional WHERE clause criteria for Logs
- Allow agent calls to specify a timeout that overrides the default for aborting long running / stale requests.