### PR TITLE
VSC EOL CM

### DIFF
--- a/vscode/src/controllers/sidebarController.ts
+++ b/vscode/src/controllers/sidebarController.ts
@@ -1432,7 +1432,7 @@ export class SidebarController implements Disposable {
 					fileName: workspace.asRelativePath(uri),
 					languageId: e.document.languageId,
 					metrics: Editor.getMetrics(uri),
-					selections: Editor.toEditorSelections(e.selections),
+					selections: [],
 					visibleRanges: Editor.toSerializableRange(e.visibleRanges),
 					lineCount: e.document.lineCount
 				};


### PR DESCRIPTION
* Remove selections from active editor context changing, which is what triggered the compose icons on file change