### PR TITLE
Don't change user readable values in front-end, so tack on "AGO" into the query and remove it from the fallback/default.

### DIFF
--- a/shared/agent/src/providers/newrelic/errors/errorQueries.ts
+++ b/shared/agent/src/providers/newrelic/errors/errorQueries.ts
@@ -194,7 +194,7 @@ const errorQueryGroups: ErrorQueryTemplate[] = [
 				"FROM ErrorTrace",
 				`WHERE fingerprint IS NOT NULL AND NOT error.expected AND entityGuid='<%= applicationGuid %>'`,
 				"FACET error.class, message", // group the results by identifiers
-				`SINCE <%= since %>`,
+				`SINCE <%= since %> AGO`,
 				"LIMIT MAX",
 			].join(" ")
 		),
@@ -218,7 +218,7 @@ const errorQueryGroups: ErrorQueryTemplate[] = [
 				"FROM JavaScriptError",
 				`WHERE stackHash IS NOT NULL AND entityGuid='<%= applicationGuid %>'`,
 				"FACET stackTrace", // group the results by fingerprint
-				`SINCE <%= since %>`,
+				`SINCE <%= since %> AGO`,
 				"LIMIT MAX",
 			].join(" ")
 		),
@@ -244,7 +244,7 @@ const errorQueryGroups: ErrorQueryTemplate[] = [
 				"FROM MobileCrash",
 				`WHERE entityGuid='<%= applicationGuid %>'`,
 				"FACET crashFingerprint", // group the results by fingerprint
-				`SINCE <%= since %>}`,
+				`SINCE <%= since %> AGO`,
 				"LIMIT MAX",
 			].join(" ")
 		),
@@ -268,7 +268,7 @@ const errorQueryGroups: ErrorQueryTemplate[] = [
 				"FROM MobileHandledException",
 				`WHERE entityGuid='<%= applicationGuid %>'`,
 				"FACET handledExceptionUuid", // group the results by fingerprint
-				`SINCE <%= since %>`,
+				`SINCE <%= since %> AGO`,
 				"LIMIT MAX",
 			].join(" ")
 		),

--- a/shared/agent/src/providers/newrelic/errors/observabilityErrorsProvider.ts
+++ b/shared/agent/src/providers/newrelic/errors/observabilityErrorsProvider.ts
@@ -162,7 +162,7 @@ export class ObservabilityErrorsProvider {
 
 							const entityType: EntityType =
 								application.source.entity.entityType ?? "APM_APPLICATION_ENTITY";
-							const timeWindow = request.timeWindow ?? "3 days ago";
+							const timeWindow = request.timeWindow ?? "3 days";
 							const errorTraceWrappers = await this.findFingerprintedErrorTraces(
 								application.source.entity.account.id,
 								application.source.entity.guid,


### PR DESCRIPTION
Keep in line with Prod, so users see "3 days", "7 days", but missing "AGO" when placed into template so just hard-code it there.