### PR TITLE
Stop the comment replacement regex from messing with things that have forward slashes when they have been single quoted

### DIFF
--- a/shared/agent/src/providers/newrelic/nrql/nrqlProvider.ts
+++ b/shared/agent/src/providers/newrelic/nrql/nrqlProvider.ts
@@ -117,7 +117,7 @@ export class NrNRQLProvider {
 	}
 
 	/**
- * Removes comments from the end of a string
+ * Removes comments from the end of a string, unless it has been single-quoted
  * 
  * FROM Collection
  * SELECT foo -- that's the foo
@@ -135,8 +135,12 @@ export class NrNRQLProvider {
  * @param nrql 
  * @returns 
  */
-	private removeNrqlComments(nrql: string) {
-		return nrql.replace(/(\-\-|\/\/|\/*\*[\s\S]*?\*\/).*$/gm, "");
+	private removeNrqlComments(nrql: string): string {
+		return nrql.replace(/'[^']*'|(\-\-|\/\/|\/*\*[\s\S]*?\*\/).*$/gm, (match, group1) => {
+			// If group1 is undefined, it means we matched a single-quoted string, so we return the match as is.
+			// Otherwise, we return an empty string to remove the comment.
+			return typeof group1 === "undefined" ? match : "";
+		});
 	}
 
 	transformQuery(nrql: string) {

--- a/shared/agent/test/unit/providers/newrelic/nrqlProvider.spec.ts
+++ b/shared/agent/test/unit/providers/newrelic/nrqlProvider.spec.ts
@@ -101,12 +101,10 @@ AND status = 'baz'
 		expect(result).toBe("");
 	});
 
-	it("escape forward slashes", () => {
+	it("treat single-quoted slashes as string literals and not remove them", () => {
 		const result = provider.transformQuery(`FROM Collection
 SELECT foo
 WHERE url = 'https://www.google.com/'`);
-
-		console.log(result);
 
 		expect(result).toBe(`FROM Collection SELECT foo WHERE url = 'https://www.google.com/'`);
 	});

--- a/shared/agent/test/unit/providers/newrelic/nrqlProvider.spec.ts
+++ b/shared/agent/test/unit/providers/newrelic/nrqlProvider.spec.ts
@@ -100,6 +100,16 @@ AND status = 'baz'
 */`);
 		expect(result).toBe("");
 	});
+
+	it("escape forward slashes", () => {
+		const result = provider.transformQuery(`FROM Collection
+SELECT foo
+WHERE url = 'https://www.google.com/'`);
+
+		console.log(result);
+
+		expect(result).toBe(`FROM Collection SELECT foo WHERE url = 'https://www.google.com/'`);
+	});
 });
 
 describe("getResultsType", () => {


### PR DESCRIPTION
This took longer than I had hoped...

While trying to figure out a way to escape the slashes, it finally clicked that the regex for handling comments was being too aggressive. Now we only remove "unquoted" comments, allowing things like URLs, etc., to be skipped as a string constant, not a comment.

One new test added, and _all_ tests are passing (so it hopefully didn't break existing comment replacement functionality)