### PR TITLE
NR-290993

### DIFF
--- a/shared/agent/src/providers/newrelic/discussions/discussions.provider.ts
+++ b/shared/agent/src/providers/newrelic/discussions/discussions.provider.ts
@@ -420,19 +420,7 @@ export class DiscussionsProvider {
 	@log()
 	async initializeNrAi(request: InitiateNrAiRequest): Promise<InitiateNrAiResponse> {
 		try {
-			const codeMarkId = await this.createCodeMark({
-				codeBlock: request.codeBlock,
-				fileUri: request.fileUri,
-				permalink: request.permalink,
-				repo: request.repo,
-				sha: request.sha,
-			});
-
-			const context = await this.generateContext(
-				request.entityGuid,
-				request.errorGroupGuid,
-				codeMarkId
-			);
+			const context = await this.generateContext(request.entityGuid, request.errorGroupGuid);
 
 			const initiateNrAiQuery = `
 				mutation($threadId: ID!, $prompt:String!, $context: GrokRawContextMetadata!) {

--- a/shared/ui/Stream/CodeError/CodeError.tsx
+++ b/shared/ui/Stream/CodeError/CodeError.tsx
@@ -266,21 +266,8 @@ export const CodeError = (props: CodeErrorProps) => {
 			return;
 		}
 
-		// must have repo information to initialize NRAI
-		if (!repoInfo?.name || !repoInfo.url || !sha) {
-			return;
-		}
-
 		initializeNrAiAnalysis();
-	}, [
-		discussion,
-		derivedState.functionToEdit,
-		derivedState.functionToEditFailed,
-		showGrok,
-		repoInfo?.name,
-		repoInfo?.url,
-		sha,
-	]);
+	}, [discussion, derivedState.functionToEdit, derivedState.functionToEditFailed, showGrok]);
 
 	const initializeNrAiAnalysis = async () => {
 		setNRAILoading(true);
@@ -294,10 +281,6 @@ export const CodeError = (props: CodeErrorProps) => {
 			stackTrace: stackTraceLines.join("\n"),
 			errorText: `${props.codeError.title} ${props.codeError?.text}`,
 			language: derivedState!.functionToEdit!.language,
-			fileUri: derivedState!.functionToEdit!.uri,
-			permalink: `https://${repoInfo?.url!}`,
-			repo: `https://${repoInfo?.url!}`,
-			sha: sha!,
 		};
 
 		// send the payload to the agent

--- a/shared/util/src/protocol/agent/agent.protocol.providers.ts
+++ b/shared/util/src/protocol/agent/agent.protocol.providers.ts
@@ -1443,14 +1443,10 @@ export interface InitiateNrAiRequest {
 	entityGuid: string;
 	errorGroupGuid: string;
 
-	fileUri: string;
 	codeBlock: string;
 	stackTrace: string;
 	errorText: string;
 	language?: string;
-	permalink: string;
-	repo: string;
-	sha: string;
 
 	threadId: string;
 }


### PR DESCRIPTION
- Remove the need for all repo information before invoking NRAI. Do this by skipping the codemark generation and just allowing all the prompt data to handle it.