### PR TITLE
NR-295070

### DIFF
--- a/shared/ui/Stream/CodeError/CodeError.tsx
+++ b/shared/ui/Stream/CodeError/CodeError.tsx
@@ -112,6 +112,8 @@ export const CodeError = (props: CodeErrorProps) => {
 		if (stackTraceHasUserLines && !selectedLineIndex) {
 			initializeStackTrace();
 			scrollToStackTrace();
+		} else {
+			dispatch(setFunctionToEditFailed(true));
 		}
 	}, [{ ...Object.values(stackTraceLines) }]);
 

--- a/shared/ui/Stream/CodeError/CodeError.tsx
+++ b/shared/ui/Stream/CodeError/CodeError.tsx
@@ -107,13 +107,11 @@ export const CodeError = (props: CodeErrorProps) => {
 	});
 
 	useEffect(() => {
-		const stackTraceHasUserLines = stackTraceLines?.some(_ => _.resolved);
+		const stackTraceHasBeenResolved = stackTraceLines.every(_ => _.resolved !== undefined);
 
-		if (stackTraceHasUserLines && !selectedLineIndex) {
+		if (stackTraceHasBeenResolved && !selectedLineIndex) {
 			initializeStackTrace();
 			scrollToStackTrace();
-		} else {
-			dispatch(setFunctionToEditFailed(true));
 		}
 	}, [{ ...Object.values(stackTraceLines) }]);
 


### PR DESCRIPTION
Ensure that every line receives a `resolved` value. Change check to ensure _ALL_ lines have the resolved value, whether its true or false, doesn't matter. This will allow the invocation of trying to find a stack trace line to navigate to, which will fail in some cases (when all lines are `false`) and the fallback to hit dispatching the functionToEditFailed=true so that NRAI will still get called.

I.e., if _some_ lines have resolved === undefined, then its not finished resolving.